### PR TITLE
perf: skip application with non regular activation policy

### DIFF
--- a/src/sys/app.rs
+++ b/src/sys/app.rs
@@ -2,9 +2,7 @@ use std::path::PathBuf;
 
 pub use nix::libc::pid_t;
 use objc2::rc::Retained;
-use objc2::{class, msg_send};
 use objc2_app_kit::{NSApplicationActivationPolicy, NSRunningApplication, NSWorkspace};
-use objc2_app_kit::{NSRunningApplication, NSWorkspace};
 use objc2_core_foundation::CGRect;
 use objc2_foundation::NSString;
 use serde::{Deserialize, Serialize};
@@ -27,7 +25,8 @@ pub fn running_apps(bundle: Option<String>) -> impl Iterator<Item = (pid_t, AppI
                 }
             }
             if app.activationPolicy() != NSApplicationActivationPolicy::Regular
-                && bundle_id != "com.apple.loginwindow" {
+                && bundle_id != "com.apple.loginwindow"
+            {
                 return None;
             }
             Some((app.pid(), AppInfo::from(&*app)))


### PR DESCRIPTION
## What?
Rift makes thread for each application, but most of applications - helper, menubar applications and system apps without windows. These apps have different activation policies.

## How
Skip applications with non-regular activation policy, which significantly reduces the thread count for running apps and makes Rift faster.

Maybe need to add a workaround for `com.apple.loginwindow`, because it is used in [`src/actor/wm_controller.rs`](https://github.com/acsandmann/rift/blob/307589034125e4737e5a01a0dbaa9d6b4699c449/src/actor/wm_controller.rs#L388).
I want to discuss it with you.

P.S. Thanks for creating Rift. I discovered it a month ago when trying to find the best tiling WM for macOS.
I have many ideas and changes for future PR.