### PR TITLE
fix: activation by user send tx too

### DIFF
--- a/src/actor/app.rs
+++ b/src/actor/app.rs
@@ -73,80 +73,49 @@ impl serde::ser::Serialize for WindowId {
 }
 
 impl<'de> serde::de::Deserialize<'de> for WindowId {
-
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-
-
     where D: serde::de::Deserializer<'de> {
         struct WindowIdVisitor;
-
         impl<'de> serde::de::Visitor<'de> for WindowIdVisitor {
-
             type Value = WindowId;
-
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-
-
                 formatter.write_str(
-
                     "a WindowId struct (with fields `pid` and `idx`), a tuple/seq (pid, idx), or a debug string like `WindowId { pid: 123, idx: 456 }`",
-
                 )
             }
-
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-
-
             where E: serde::de::Error {
                 WindowId::from_debug_string(v)
                     .ok_or_else(|| E::custom("invalid WindowId debug string"))
-
-
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<WindowId, A::Error>
-
-
             where A: serde::de::SeqAccess<'de> {
                 let pid: pid_t = seq
-
                     .next_element()?
                     .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
 
                 let idx_u32: u32 = seq
-
                     .next_element()?
                     .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?;
 
                 let idx = std::num::NonZeroU32::new(idx_u32)
-
                     .ok_or_else(|| serde::de::Error::custom("idx must be non-zero"))?;
-
-
                 Ok(WindowId { pid, idx })
 
             }
 
             fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
-
-
             where M: serde::de::MapAccess<'de> {
                 let mut pid: Option<pid_t> = None;
-
-
                 let mut idx: Option<u32> = None;
-
-
 
                 while let Some(key) = map.next_key::<String>()? {
                     match key.as_str() {
-
                         "pid" => {
-
                             pid = Some(map.next_value()?);
                         }
                         "idx" => {
-
                             idx = Some(map.next_value()?);
                         }
                         // ignore unknown fields to be forward compatible
@@ -1230,23 +1199,3 @@ fn trace<T>(
     }
     out
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
## What?
Slow applications can cause Rift panic, because Rift drops sender without sending, and it cause thread panic.

<details>

```
thread 'org.chromium.Chromium(521)' (12663770) panicked at /Users/alle_ox/.cargo/git/checkouts/continue-a1e2725023670563/df4d2f9/src/lib.rs:444:13:
Sender dropped without sending data
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/be0ade2b602bdfe37a3cc259fcc79e8624dcba94/library/std/src/panicking.rs:698:5
   1: core::panicking::panic_fmt
             at /rustc/be0ade2b602bdfe37a3cc259fcc79e8624dcba94/library/core/src/panicking.rs:80:14
   2: <continue::Sender<R> as core::ops::drop::Drop>::drop
             at /Users/alle_ox/.cargo/git/checkouts/continue-a1e2725023670563/df4d2f9/src/lib.rs:444:13
   3: core::ptr::drop_in_place<continue::Sender<()>>
             at /Users/alle_ox/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:804:1
   4: rift_wm::actor::app::State::on_activation_changed
             at ./src/actor/app.rs:920:14
   5: rift_wm::actor::app::State::handle_notification
             at ./src/actor/app.rs:652:26
   6: rift_wm::actor::app::State::handle_incoming::{{closure}}
             at ./src/actor/app.rs:333:26
   7: <tokio::future::maybe_done::MaybeDone<Fut> as core::future::future::Future>::poll
             at /Users/alle_ox/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/future/maybe_done.rs:65:63
   8: rift_wm::actor::app::State::run::{{closure}}::{{closure}}
             at /Users/alle_ox/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/macros/join.rs:179:28
   9: <core::future::poll_fn::PollFn<F> as core::future::future::Future>::poll
             at /Users/alle_ox/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/future/poll_fn.rs:151:9
  10: rift_wm::actor::app::State::run::{{closure}}
             at ./src/actor/app.rs:285:9
  11: rift_wm::sys::executor::State::process_tasks
             at ./src/sys/executor.rs:98:54
  12: rift_wm::sys::executor::Handle::new::{{closure}}::{{closure}}
             at ./src/sys/executor.rs:77:39
  13: rift_wm::sys::run_loop::WakeupHandle::for_current_thread::perform
             at ./src/sys/run_loop.rs:54:13
              ....
```
</details>

## How
Make case for `ts.elapsed() > Duration::from_millis(1000)` and call  `tx.send()`.
Maybe it's not good solution, and you can help me find another.