### PR TITLE
fix: use correct coordinate for stack_line indicator

### DIFF
--- a/src/actor/stack_line.rs
+++ b/src/actor/stack_line.rs
@@ -311,7 +311,7 @@ mod tests {
             VerticalPlacement::Right,
         );
         assert_eq!(frame_top.origin.x, 100.0);
-        assert_eq!(frame_top.origin.y, 200.0 + 300.0 - thickness);
+        assert_eq!(frame_top.origin.y, 200.0);
         assert_eq!(frame_top.size.width, 400.0);
         assert_eq!(frame_top.size.height, thickness);
 
@@ -323,7 +323,7 @@ mod tests {
             VerticalPlacement::Right,
         );
         assert_eq!(frame_bottom.origin.x, 100.0);
-        assert_eq!(frame_bottom.origin.y, 200.0);
+        assert_eq!(frame_bottom.origin.y, 200.0 + 300.0 - thickness);
         assert_eq!(frame_bottom.size.width, 400.0);
         assert_eq!(frame_bottom.size.height, thickness);
 


### PR DESCRIPTION
## What? 
Fix flipping stack_line coordinates for rendering indicator

## How
Because after rewriting indicator from NSWindow to CoreGraphics in [b2a1c4a](https://github.com/acsandmann/rift/commit/b2a1c4affd650bda8f612e805a09634956b86f07), it still uses converted coordinate<br>(Quartz->Cocoa)

Now it is using original, not converted coordinates.
And swap coordinate calculation for Top and Bottom placements, now it is displaying correctly.

I think about removing `cocoa_group_frame` entirely, because cocoa frame coordinates are not used and not needed in the codebase.