### PR TITLE
fix: make rift-cli pipeable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1340,6 +1340,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "shell-escape",
+ "sigpipe",
  "slotmap",
  "static_assertions",
  "tempfile",
@@ -1553,6 +1554,15 @@ name = "signal-hook-registry"
 version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "sigpipe"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5584bfb3e0d348139d8210285e39f6d2f8a1902ac06de343e06357d1d763d8e6"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,6 +144,7 @@ num_enum = "0.7.4"
 notify = "8.2.0"
 notify-debouncer-mini = "0.7.0"
 dashmap = "6.1.0"
+sigpipe = "0.1.3"
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/src/bin/rift-cli.rs
+++ b/src/bin/rift-cli.rs
@@ -256,6 +256,7 @@ enum SubscribeCommands {
 }
 
 fn main() {
+    sigpipe::reset();
     let cli = Cli::parse();
 
     if let Commands::Service { service } = &cli.command {


### PR DESCRIPTION
## What?
Panic during piping `rift-cli`, because [this](https://github.com/rust-lang/rust/issues/62569).

## How 
Add `sigpipe` crate and use it to handle SIGPIPE for `rift-cli`
Any CLI must be pipeable.

P.S. I finally unloaded changes, which I made in my local branch.
Of course, there are still changes regarding IPC, which I made for integration with my SketchyBar config.
I think discuss IPC design in issue.