### PR TITLE
fix rendering and hot reload issues with stackline

### DIFF
--- a/src/actor/reactor.rs
+++ b/src/actor/reactor.rs
@@ -1252,7 +1252,6 @@ impl Reactor {
                 self.layout_engine.set_layout_settings(&self.config.settings.layout);
                 let _ = self.drag_manager.update_config(self.config.settings.window_snapping);
 
-                // Send config update to stack line
                 if let Some(tx) = &self.stack_line_tx {
                     let _ = tx.try_send(crate::actor::stack_line::Event::ConfigUpdated(
                         self.config.clone(),

--- a/src/actor/stack_line.rs
+++ b/src/actor/stack_line.rs
@@ -140,7 +140,6 @@ impl StackLine {
         let new_enabled = self.is_enabled();
 
         if old_enabled && !new_enabled {
-            // Stack line was disabled, clear all indicators
             for indicator in self.indicators.values() {
                 if let Err(err) = indicator.clear() {
                     tracing::warn!(
@@ -152,7 +151,6 @@ impl StackLine {
             self.indicators.clear();
             self.group_sigs_by_space.clear();
         } else if new_enabled {
-            // Stack line is enabled, update all existing indicators with new config
             let new_config = self.indicator_config();
             for (node_id, indicator) in &self.indicators {
                 if let Some(group_data) = indicator.group_data() {

--- a/src/layout_engine/systems/traditional.rs
+++ b/src/layout_engine/systems/traditional.rs
@@ -791,8 +791,6 @@ impl TraditionalLayoutSystem {
                     self.tree.data.selection.local_selection(map, node).unwrap_or(children[0]);
                 let selected_index = children.iter().position(|&c| c == local_sel).unwrap_or(0);
 
-                // For vertical stacks, the UI uses bottom-up indexing while the layout engine uses top-down
-                // So we need to invert the index for vertical stacks
                 let ui_selected_index = if matches!(kind, VerticalStack) {
                     children.len().saturating_sub(1).saturating_sub(selected_index)
                 } else {
@@ -837,7 +835,6 @@ impl TraditionalLayoutSystem {
                 .local_selection(map, node)
                 .or_else(|| node.first_child(map))
             {
-                // Calculate the frame for the next node within the current container
                 rect = self.calculate_child_frame_in_container(node, next, rect, gaps);
                 node = next;
                 continue;
@@ -848,7 +845,6 @@ impl TraditionalLayoutSystem {
         out
     }
 
-    /// Calculate the frame for a specific child within an axis-based container
     fn calculate_child_frame_in_axis(
         &self,
         parent_rect: CGRect,
@@ -863,7 +859,6 @@ impl TraditionalLayoutSystem {
             return parent_rect;
         }
 
-        // Calculate sizes based on the layout logic similar to layout_axis
         let total: f32 = siblings.iter().map(|&child| self.tree.data.layout.info[child].size).sum();
         let inner_gap = if horizontal {
             gaps.inner.horizontal
@@ -884,7 +879,6 @@ impl TraditionalLayoutSystem {
             (axis_len - total_gap).max(0.0)
         };
 
-        // Calculate offset up to the target child
         let mut offset = if horizontal {
             parent_rect.origin.x
         } else {
@@ -900,7 +894,6 @@ impl TraditionalLayoutSystem {
             }
         }
 
-        // Calculate the target child's size
         let ratio =
             f64::from(self.tree.data.layout.info[siblings[child_index]].size) / f64::from(total);
         let seg_len = usable_axis * ratio;
@@ -918,7 +911,6 @@ impl TraditionalLayoutSystem {
         }
     }
 
-    /// Calculate the frame for a child node within its parent container
     fn calculate_child_frame_in_container(
         &self,
         parent_node: NodeId,
@@ -939,10 +931,7 @@ impl TraditionalLayoutSystem {
                 self.calculate_child_frame_in_axis(parent_rect, &siblings, child_index, false, gaps)
             }
             crate::layout_engine::LayoutKind::HorizontalStack
-            | crate::layout_engine::LayoutKind::VerticalStack => {
-                // For stacks, children occupy the full parent rect (they're stacked)
-                parent_rect
-            }
+            | crate::layout_engine::LayoutKind::VerticalStack => parent_rect,
         }
     }
 }


### PR DESCRIPTION
A video worth a thousand words.

* StackLine now matches closely with the screen, previously they always used to fully occupy the screen, regardless of partial stack layout.
* Fixed vertical stack selection inverted when rendering.
* Fix hot reloading of stack line thickness, before it allocated the width when config was changed on the fly, but it was still rendering the previous width.

https://github.com/user-attachments/assets/36ab028e-0bfb-4314-bfba-05f23a7eb72d

