### PR TITLE
Update path for embedding Info.plist

### DIFF
--- a/src/bin/rift.rs
+++ b/src/bin/rift.rs
@@ -28,7 +28,7 @@ use rift_wm::sys::service::{ServiceCommands, handle_service_command};
 use rift_wm::sys::skylight::{CGSEventType, KnownCGSEvent};
 use tokio::join;
 
-embed_plist::embed_info_plist!("../../assets/Info.plist");
+embed_plist::embed_info_plist!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/Info.plist"));
 
 #[derive(Parser)]
 struct Cli {


### PR DESCRIPTION
This was causing my build to fail for nix. I think in general the consensus is to use CARGO_MANIFEST_DIR instead of working build directory path.