### PR TITLE
fix #83: Respect stack default orientation when unstacking

### DIFF
--- a/src/layout_engine/engine.rs
+++ b/src/layout_engine/engine.rs
@@ -791,7 +791,10 @@ impl LayoutEngine {
             }
             LayoutCommand::UnstackWindows => {
                 self.workspace_layouts.mark_last_saved(space, workspace_id, layout);
-                let unstacked_windows = self.tree.unstack_parent_of_selection(layout);
+                let default_orientation: crate::common::config::StackDefaultOrientation =
+                    self.layout_settings.stack.default_orientation;
+                let unstacked_windows =
+                    self.tree.unstack_parent_of_selection(layout, default_orientation);
                 EventResponse {
                     raise_windows: unstacked_windows,
                     focus_window: None,

--- a/src/layout_engine/systems.rs
+++ b/src/layout_engine/systems.rs
@@ -72,7 +72,11 @@ pub trait LayoutSystem: Serialize + for<'de> Deserialize<'de> {
         layout: LayoutId,
         default_orientation: crate::common::config::StackDefaultOrientation,
     ) -> Vec<WindowId>;
-    fn unstack_parent_of_selection(&mut self, layout: LayoutId) -> Vec<WindowId>;
+    fn unstack_parent_of_selection(
+        &mut self,
+        layout: LayoutId,
+        default_orientation: crate::common::config::StackDefaultOrientation,
+    ) -> Vec<WindowId>;
     fn unjoin_selection(&mut self, _layout: LayoutId);
     fn resize_selection_by(&mut self, layout: LayoutId, amount: f64);
     fn rebalance(&mut self, layout: LayoutId);

--- a/src/layout_engine/systems/bsp.rs
+++ b/src/layout_engine/systems/bsp.rs
@@ -992,7 +992,13 @@ impl LayoutSystem for BspLayoutSystem {
         vec![]
     }
 
-    fn unstack_parent_of_selection(&mut self, _layout: LayoutId) -> Vec<WindowId> { vec![] }
+    fn unstack_parent_of_selection(
+        &mut self,
+        _layout: LayoutId,
+        _default_orientation: crate::common::config::StackDefaultOrientation,
+    ) -> Vec<WindowId> {
+        vec![]
+    }
 
     fn unjoin_selection(&mut self, _layout: LayoutId) {}
 


### PR DESCRIPTION
When unstacking windows with `default_orientation =
  "perpendicular"`, the system was incorrectly always
  switching from VerticalStackLayout to VerticalLayout
  instead of the expected HorizontalLayout. This change
  updates the `unstack_parent_of_selection` method to
  properly use the configured `StackDefaultOrientation`
  setting, ensuring:

  - HorizontalStack → VerticalLayout (when perpendicular)
  - VerticalStack → HorizontalLayout (when perpendicular)
  - Proper handling of "same", "horizontal", and
  "vertical" orientation modes