### PR TITLE
fix: selection descends to stack immediately, for navigation to work

### DIFF
--- a/src/layout_engine/systems/traditional.rs
+++ b/src/layout_engine/systems/traditional.rs
@@ -665,8 +665,6 @@ impl LayoutSystem for TraditionalLayoutSystem {
             if let Some(nl) = new_layout {
                 self.set_layout(container, nl);
 
-                // After converting to stack, ensure selection descends into the stack
-                // so that navigation within the stack works immediately
                 if nl.is_stacked() {
                     if let Some(first_child) = container.first_child(self.map()) {
                         self.select(first_child);


### PR DESCRIPTION
When you convert a regular layout (like Horizontal/Vertical) to a stack layout (HorizontalStack/VerticalStack), you couldn't immediately navigate between windows in the stack. You had to focus  away from the stack and back again before navigation would work. 

This is apparent, working with 3 windows, and stack the first 2 and trying to navigating up/down. You cannot until you focus away and refocus back.

After converting to stack layout, the selection was still sitting on the container itself instead of descending into one of the stacked children. So when you tried to navigate up/down within the stack, the system was trying to move the entire container rather than navigate between the children inside it.