### PR TITLE
feature: display workspace number instead of layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ dev
 target
 rift.toml
 src/bin/dev.rs
+# Jetbrains IDE files
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,10 +243,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "libc",
+]
+
+[[package]]
+name = "core-text"
+version = "20.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9d2790b5c08465d49f8dc05c8bcae9fea467855947db39b0f8145c091aaced5"
+dependencies = [
+ "core-foundation",
+ "core-graphics",
+ "foreign-types",
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -492,6 +538,33 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "fsevent-sys"
@@ -1244,6 +1317,9 @@ dependencies = [
  "bitflags 2.10.0",
  "clap",
  "continue",
+ "core-foundation",
+ "core-graphics",
+ "core-text",
  "crossbeam-channel",
  "dashmap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ ascii_tree = "0.1.1"
 thiserror = { version = "2.0.17", default-features = false }
 bitflags = "2.4.1"
 clap = { version = "4.5.4", features = ["derive"] }
+core-foundation = "0.9"
+core-graphics = "0.23"
+core-text = "20.1"
 dirs = "6.0.0"
 dispatchr = { git = "https://github.com/drewcrawford/dispatchr" }
 nix = { version = "0.30.1", features = ["process", "user"] }

--- a/rift.default.toml
+++ b/rift.default.toml
@@ -125,6 +125,8 @@ enabled = false
 # if enabled, it will show all workspaces including empty ones. disabled because this
 # tends to take up too much room in the menubar and then is auto hidden by macos
 show_empty = false
+# if enabled, show workspace numbers instead of window layout previews
+show_workspace_numbers = false
 
 [settings.ui.stack_line]
 # experimental stack line indicator (defaults to off)

--- a/src/actor/menu_bar.rs
+++ b/src/actor/menu_bar.rs
@@ -134,6 +134,14 @@ impl Menu {
         self.last_signature = Some(sig);
 
         let show_all = self.config.settings.ui.menu_bar.show_empty;
-        icon.update(active_space, workspaces, active_workspace, windows, show_all);
+        let show_numbers = self.config.settings.ui.menu_bar.show_workspace_numbers;
+        icon.update(
+            active_space,
+            workspaces,
+            active_workspace,
+            windows,
+            show_all,
+            show_numbers,
+        );
     }
 }

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -422,6 +422,9 @@ pub struct MenuBarSettings {
     pub enabled: bool,
     #[serde(default = "no")]
     pub show_empty: bool,
+    /// If true, show workspace numbers instead of window layout previews
+    #[serde(default = "no")]
+    pub show_workspace_numbers: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]


### PR DESCRIPTION
# Overview
Added a new configuration option to display workspace numbers instead of window layout previews in the menu bar.

## Configuration

Add the following to your `~/.config/rift/config.toml`:

```toml
[settings.ui.menu_bar]
enabled = true
show_workspace_numbers = true
```

## Options

- `show_workspace_numbers = false` (default): Shows the traditional window layout preview
- `show_workspace_numbers = true`: Shows the workspace number (1-based) instead

This option can be combined with:
- `show_empty = false` (default): Only shows workspaces with windows
- `show_empty = true`: Shows all workspaces including empty ones

Example: 
<img width="85" height="42" alt="image" src="https://github.com/user-attachments/assets/0c8de334-7209-4c53-a9b5-545cbe933c3a" />


## Notes

In contrast to other WMs like i3, hyprland etc, this will only show the workspace if at least one window exists or show_empty is set. This means switching to an empty workspace does not show the number yet, which is okay from my point of view.