### PR TITLE
feat(config): add menu bar display mode configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ dev
 target
 rift.toml
 src/bin/dev.rs
+# Jetbrains IDE files
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ objc2-app-kit = { version = "0.3.1", default-features = false, features = [
 	"NSColor",
 	"NSControl",
 	"NSEvent",
+	"NSFont",
+	"NSFontDescriptor",
 	"NSGraphics",
 	"NSImage",
 	"NSResponder",
@@ -88,10 +90,13 @@ objc2-core-graphics = { version = "0.3.1", default-features = false, features = 
 ]}
 objc2-foundation = { version = "0.3.1", default-features = false, features = [
 	"NSArray",
+	"NSAttributedString",
+	"NSDictionary",
 	"NSEnumerator",
 	"NSKeyValueCoding",
 	"NSNotification",
 	"NSProcessInfo",
+	"NSString",
 	"NSValue"
 ]}
 objc2-quartz-core = { version = "0.3.0", default-features = false, features = [

--- a/rift.default.toml
+++ b/rift.default.toml
@@ -125,6 +125,13 @@ enabled = false
 # if enabled, it will show all workspaces including empty ones. disabled because this
 # tends to take up too much room in the menubar and then is auto hidden by macos
 show_empty = false
+# display mode for workspace indicators
+# - "layout": show window layout previews (default)
+# For workspace numbers without offset (defaults to 0):
+# display_mode = { workspace_numbers = {} }
+# For workspace numbers with offset:
+# display_mode = { workspace_numbers = { offset = 1 } }
+display_mode = "layout"
 
 [settings.ui.stack_line]
 # experimental stack line indicator (defaults to off)

--- a/src/actor/menu_bar.rs
+++ b/src/actor/menu_bar.rs
@@ -93,7 +93,15 @@ impl Menu {
         self.last_signature = Some(sig);
 
         let show_all = self.config.settings.ui.menu_bar.show_empty;
-        icon.update(active_space, workspaces, active_workspace, windows, show_all);
+        let display_mode = &self.config.settings.ui.menu_bar.display_mode;
+        icon.update(
+            active_space,
+            workspaces,
+            active_workspace,
+            windows,
+            show_all,
+            display_mode,
+        );
     }
 }
 

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -416,12 +416,26 @@ pub struct WindowSnappingSettings {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum MenuBarDisplayMode {
+    #[default]
+    Layout,
+    #[serde(rename_all = "snake_case")]
+    WorkspaceNumbers {
+        #[serde(default)]
+        offset: usize,
+    },
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
 #[serde(deny_unknown_fields)]
 pub struct MenuBarSettings {
     #[serde(default = "no")]
     pub enabled: bool,
     #[serde(default = "no")]
     pub show_empty: bool,
+    #[serde(default)]
+    pub display_mode: MenuBarDisplayMode,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]


### PR DESCRIPTION
Added display_mode option for menu bar workspace indicators with support for layout previews and workspace numbers.

Example configuration:
Show window layout previews (default)
> display_mode = "layout"

Show workspace numbers without offset
> display_mode = { workspace_numbers = {} }

Show workspace numbers with custom offset
> display_mode = { workspace_numbers = { offset = 1 } }

Sorry gitlab did not allow me to re-open the PR because I'm using the 'main' branch and force pushed to it. 
Relates to #127 

<img width="120" height="38" alt="image" src="https://github.com/user-attachments/assets/c9f6265d-1324-4c60-9669-b3f76ca78067" />

I appreciate feedback on this, as I have no experience in the obj2c api nor am I usually doing frontends. 
