### PR TITLE
fix: retain window layout on external displays on wake from sleep

### DIFF
--- a/src/actor/reactor/events/system.rs
+++ b/src/actor/reactor/events/system.rs
@@ -1,4 +1,4 @@
-use tracing::debug;
+use tracing::{debug, info};
 
 use crate::actor::app::WindowId;
 use crate::actor::raise_manager;
@@ -35,10 +35,13 @@ impl SystemEventHandler {
     }
 
     pub fn handle_system_woke(reactor: &mut Reactor) {
+        info!("system woke from sleep");
         let ids: Vec<u32> =
             reactor.window_manager.window_ids.keys().map(|wsid| wsid.as_u32()).collect();
         crate::sys::window_notify::update_window_notifications(&ids);
         reactor.notification_manager.last_sls_notification_ids = ids;
+
+        reactor.space_manager.pending_wake_from_sleep = true;
     }
 
     pub fn handle_raise_completed(reactor: &mut Reactor, window_id: WindowId, sequence_id: u64) {

--- a/src/actor/reactor/managers.rs
+++ b/src/actor/reactor/managers.rs
@@ -80,9 +80,11 @@ impl AppManager {
 /// Manages space and screen state
 pub struct SpaceManager {
     pub screens: Vec<Screen>,
+    pub screen_space_by_id: HashMap<ScreenId, SpaceId>,
     pub fullscreen_by_space: HashMap<u64, FullscreenTrack>,
     pub changing_screens: HashSet<WindowServerId>,
-    pub screen_space_by_id: HashMap<ScreenId, SpaceId>,
+    pub pending_wake_from_sleep: bool,
+    pub wake_completed_at: Option<std::time::Instant>,
 }
 
 impl SpaceManager {


### PR DESCRIPTION
On wake with external displays, macOS can send multiple ScreenParametersChanged and SpaceChanged events in interim states as external displays reconnect, including changing space IDs multiple times for displays.

This PR attempts to fix this by preventing layout updates while spaces are still updating following wake, with a 5 second grace period to pick up any display reconnections.

This mostly fixes #217 for my setup.