### PR TITLE
Default fibonacci spiral layout for BSP mode

### DIFF
--- a/src/actor/reactor/managers/space_activation.rs
+++ b/src/actor/reactor/managers/space_activation.rs
@@ -64,14 +64,10 @@ impl SpaceActivationPolicy {
     pub fn set_login_window_active(&mut self, active: bool) { self.login_window_active = active; }
 
     #[allow(dead_code)]
-    pub fn on_space_created(&mut self, space: SpaceId) {
-        self.known_user_spaces.insert(space);
-    }
+    pub fn on_space_created(&mut self, space: SpaceId) { self.known_user_spaces.insert(space); }
 
     #[allow(dead_code)]
-    pub fn on_space_destroyed(&mut self, space: SpaceId) {
-        self.known_user_spaces.remove(&space);
-    }
+    pub fn on_space_destroyed(&mut self, space: SpaceId) { self.known_user_spaces.remove(&space); }
 
     /// Note: this emits no events; Reactor should call this and then recompute active spaces.
     pub fn on_spaces_updated(

--- a/src/layout_engine/systems/bsp.rs
+++ b/src/layout_engine/systems/bsp.rs
@@ -367,10 +367,7 @@ impl BspLayoutSystem {
                     // Use alternating orientations based on depth for fibonacci spiral
                     let depth = self.node_depth(sel);
                     let orientation = self.orientation_for_depth(depth);
-                    self.kind.insert(sel, NodeKind::Split {
-                        orientation,
-                        ratio: 0.5,
-                    });
+                    self.kind.insert(sel, NodeKind::Split { orientation, ratio: 0.5 });
                     left.detach(&mut self.tree).push_back(sel);
                     right.detach(&mut self.tree).push_back(sel);
                     self.tree.data.selection.select(&self.tree.map, right);
@@ -559,15 +556,18 @@ mod tests {
     fn fibonacci_spiral_alternates_split_orientation() {
         let mut system = BspLayoutSystem::default();
         let layout = system.create_layout();
-        
+
         // Add first window - it takes the full layout
         system.add_window_after_selection(layout, w(1));
-        
+
         // Add second window - should split horizontally (depth 0)
         system.add_window_after_selection(layout, w(2));
         let tree = system.draw_tree(layout);
-        assert!(tree.contains("Horizontal"), "Second window should create horizontal split at depth 0");
-        
+        assert!(
+            tree.contains("Horizontal"),
+            "Second window should create horizontal split at depth 0"
+        );
+
         // Add third window - should split vertically (depth 1)
         system.add_window_after_selection(layout, w(3));
         let tree = system.draw_tree(layout);
@@ -575,7 +575,7 @@ mod tests {
         let vertical_count = tree.matches("Vertical").count();
         assert_eq!(horizontal_count, 1, "Should have 1 horizontal split");
         assert_eq!(vertical_count, 1, "Should have 1 vertical split");
-        
+
         // Add fourth window - should split horizontally (depth 2)
         system.add_window_after_selection(layout, w(4));
         let tree = system.draw_tree(layout);
@@ -583,7 +583,7 @@ mod tests {
         let vertical_count = tree.matches("Vertical").count();
         assert_eq!(horizontal_count, 2, "Should have 2 horizontal splits");
         assert_eq!(vertical_count, 1, "Should have 1 vertical split");
-        
+
         // Add fifth window - should split vertically (depth 3)
         system.add_window_after_selection(layout, w(5));
         let tree = system.draw_tree(layout);


### PR DESCRIPTION
Currently, BSP mode always splits horizontally when inserting windows. I was surprised by the note in the README calling BSP mode "bspwm-like". I expected the classic fibonacci spiral where split direction alternates based on tree depth.
Ref: https://github.com/baskerville/bspwm/blob/master/README.md#longest-side-scheme

## Changes

- **Added `node_depth()` method** - Calculates node depth by traversing parents (root = 0)
- **Added `orientation_for_depth()` method** - Returns orientation based on depth:
  - Even depth (0, 2, 4...) → Horizontal
  - Odd depth (1, 3, 5...) → Vertical
- **Updated `insert_window_at_selection()`** - Uses `orientation_for_depth()` instead of hardcoded `Orientation::Horizontal`

## Result

Window splits now alternate to create a fibonacci spiral:

```
1st window: full screen
2nd window: horizontal split (side-by-side)
3rd window: vertical split (stacked)
4th window: horizontal split
...
```

Test added to verify orientation alternates correctly through 5 window insertions.

<!-- START COPILOT ORIGINAL PROMPT -->



<details>

<summary>Original prompt</summary>

> ## Problem
> 
> The current BSP mode in rift always splits windows horizontally when inserting new windows. Users familiar with bspwm expect the classic fibonacci spiral behavior where the split direction alternates between horizontal and vertical as new windows are added.
> 
> ## Expected Behavior (bspwm-style)
> 
> When opening new windows, the split direction should alternate to create a fibonacci spiral pattern:
> 1. First window takes full screen
> 2. Second window splits **horizontally** (side-by-side with first)
> 3. Third window splits **vertically** (stacked with second window's area)
> 4. Fourth window splits **horizontally** (side-by-side within that area)
> 5. And so on, alternating directions...
> 
> This creates a spiral pattern where each new window takes half of the previous window's space, with the direction flipping each time.
> 
> ## Current Behavior
> 
> In `src/layout_engine/systems/bsp.rs`, the `insert_window_at_selection` function (around line 343-346) always uses `Orientation::Horizontal`:
> 
> ```rust
> self.kind.insert(sel, NodeKind::Split {
>     orientation: Orientation::Horizontal,
>     ratio: 0.5,
> });
> ```
> 
> ## Proposed Solution
> 
> 1. Add a helper method to calculate the depth of a node in the BSP tree
> 2. Modify `insert_window_at_selection` to determine the split orientation based on the node's depth:
>    - Even depth (0, 2, 4, ...) → Horizontal split
>    - Odd depth (1, 3, 5, ...) → Vertical split
> 
> This will make BSP mode behave like bspwm by default, creating the fibonacci spiral layout pattern.
> 
> ## Files to Modify
> 
> - `src/layout_engine/systems/bsp.rs`: 
>   - Add a `node_depth(&self, node: NodeId) -> usize` helper method to `BspLayoutSystem`
>   - Update `insert_window_at_selection` to use alternating orientations based on depth


</details>



<!-- START COPILOT CODING AGENT SUFFIX -->

*This pull request was created from Copilot chat.*
>