### PR TITLE
Keep MissionControlActor alive without WM sender

### DIFF
--- a/src/actor/mission_control.rs
+++ b/src/actor/mission_control.rs
@@ -66,6 +66,9 @@ impl MissionControlActor {
                 let _guard = span.enter();
                 self.handle_event(event);
             }
+        } else {
+            // Keep the receiver alive so the supervisor doesn't treat this actor as exited.
+            while let Some((_span, _event)) = self.rx.recv().await {}
         }
     }
 


### PR DESCRIPTION
## Summary\n- keep MissionControlActor receiver alive when wm_sender is missing to prevent supervisor panic\n\n## Testing\n- not run\n