### PR TITLE
Add aerospace layout mode

### DIFF
--- a/rift.default.toml
+++ b/rift.default.toml
@@ -76,7 +76,7 @@ hot_reload = true
 
 [settings.layout]
 # Layout system
-# - mode: "traditional" (i3/sway-like containers) or "bsp" (binary space partitioning)
+# - mode: "traditional" (i3/sway-like containers), "aerospace" (traditional + join-with semantics), or "bsp" (binary space partitioning)
 #   defaults to "traditional" if omitted
 mode = "traditional"
 

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -529,7 +529,7 @@ impl StackLineSettings {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
 #[serde(deny_unknown_fields)]
 pub struct LayoutSettings {
-    /// Layout mode: "traditional" (i3/sway style containers)
+    /// Layout mode: "traditional" (i3/sway style containers), "aerospace" (traditional + join-with semantics), or "bsp"
     #[serde(default)]
     pub mode: LayoutMode,
     /// Stack system configuration
@@ -549,6 +549,8 @@ pub enum LayoutMode {
     Traditional,
     /// Binary space partitioning tiling
     Bsp,
+    /// AeroSpace-inspired join behavior with traditional layout semantics
+    Aerospace,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]

--- a/src/layout_engine.rs
+++ b/src/layout_engine.rs
@@ -9,7 +9,9 @@ pub use engine::{EventResponse, LayoutCommand, LayoutEngine, LayoutEvent};
 pub(crate) use floating::FloatingManager;
 pub use graph::{Direction, LayoutKind, Orientation};
 pub(crate) use systems::LayoutId;
-pub use systems::{BspLayoutSystem, LayoutSystem, LayoutSystemKind, TraditionalLayoutSystem};
+pub use systems::{
+    AerospaceLayoutSystem, BspLayoutSystem, LayoutSystem, LayoutSystemKind, TraditionalLayoutSystem,
+};
 pub(crate) use workspaces::WorkspaceLayouts;
 
 pub use crate::model::virtual_workspace::{

--- a/src/layout_engine/engine.rs
+++ b/src/layout_engine/engine.rs
@@ -131,6 +131,7 @@ impl LayoutEngine {
         match &self.tree {
             LayoutSystemKind::Traditional(_) => "traditional",
             LayoutSystemKind::Bsp(_) => "bsp",
+            LayoutSystemKind::Aerospace(_) => "aerospace",
         }
     }
 
@@ -594,6 +595,9 @@ impl LayoutEngine {
             crate::common::config::LayoutMode::Bsp => {
                 LayoutSystemKind::Bsp(crate::layout_engine::BspLayoutSystem::default())
             }
+            crate::common::config::LayoutMode::Aerospace => LayoutSystemKind::Aerospace(
+                crate::layout_engine::AerospaceLayoutSystem::default(),
+            ),
         };
 
         LayoutEngine {
@@ -1111,6 +1115,25 @@ impl LayoutEngine {
                             EventResponse::default()
                         }
                     }
+                    LayoutSystemKind::Aerospace(s) => {
+                        if s.parent_of_selection_is_stacked(layout) {
+                            let default_orientation: crate::common::config::StackDefaultOrientation =
+                                self.layout_settings.stack.default_orientation;
+                            let toggled_windows = s
+                                .apply_stacking_to_parent_of_selection(layout, default_orientation);
+                            if !toggled_windows.is_empty() {
+                                EventResponse {
+                                    raise_windows: toggled_windows,
+                                    focus_window: None,
+                                }
+                            } else {
+                                EventResponse::default()
+                            }
+                        } else {
+                            s.toggle_tile_orientation(layout);
+                            EventResponse::default()
+                        }
+                    }
                     LayoutSystemKind::Bsp(s) => {
                         s.toggle_tile_orientation(layout);
                         EventResponse::default()
@@ -1343,6 +1366,15 @@ impl LayoutEngine {
         let layout_id = self.layout(space);
         match &self.tree {
             LayoutSystemKind::Traditional(s) => s.collect_group_containers_in_selection_path(
+                layout_id,
+                screen,
+                self.layout_settings.stack.stack_offset,
+                gaps,
+                stack_line_thickness,
+                stack_line_horiz,
+                stack_line_vert,
+            ),
+            LayoutSystemKind::Aerospace(s) => s.collect_group_containers_in_selection_path(
                 layout_id,
                 screen,
                 self.layout_settings.stack.stack_offset,

--- a/src/layout_engine/systems.rs
+++ b/src/layout_engine/systems.rs
@@ -86,7 +86,7 @@ pub trait LayoutSystem: Serialize + for<'de> Deserialize<'de> {
 }
 
 mod traditional;
-pub use traditional::TraditionalLayoutSystem;
+pub use traditional::{AerospaceLayoutSystem, TraditionalLayoutSystem};
 mod bsp;
 pub use bsp::BspLayoutSystem;
 
@@ -96,4 +96,5 @@ pub use bsp::BspLayoutSystem;
 pub enum LayoutSystemKind {
     Traditional(TraditionalLayoutSystem),
     Bsp(BspLayoutSystem),
+    Aerospace(AerospaceLayoutSystem),
 }


### PR DESCRIPTION
## Summary
- add aerospace layout mode (traditional layout + join-with semantics)
- implement AeroSpace-style join behavior in the aerospace wrapper
- wire layout mode through config/defaults/engine
- add aerospace join test to lock focused-window semantics

## Testing
- cargo test -p rift-wm layout_engine::systems::traditional::tests::aerospace_join_uses_focused_window_not_container
