### PR TITLE
feat: per workspace layouts

### DIFF
--- a/rift.default.toml
+++ b/rift.default.toml
@@ -111,6 +111,9 @@ alignment = "center"
 # 			(disrespects alignment setting above)
 # - "anchored": always align focused column according to `alignment`
 focus_navigation_style = "niri"
+# the scrolling layout tends to function better without animations,
+# so you can disable them if you like
+# animate = false
 
 [settings.layout.scrolling.gestures]
 # Enable horizontal scroll gestures to switch columns

--- a/rift.default.toml
+++ b/rift.default.toml
@@ -80,6 +80,10 @@ hot_reload = true
 #	- "bsp" (binary space partitioning),
 #   - "master_stack" (master area + stack area)
 # defaults to "traditional" if omitted
+#
+# This is the default layout mode if there is nothing else configured
+# in the `workspace_rules` section below.
+# You can set different layouts per workspace using `workspace_rules`.
 mode = "traditional"
 
 # these settings only apply when layout mode == "master_stack"
@@ -115,6 +119,8 @@ enabled = false
 invert_horizontal = false
 # Number of fingers required for gesture
 fingers = 3
+# If true, scrolling past the end of the strip will trigger a workspace switch
+propagate_to_workspace_swipe = false
 
 [settings.layout.stack]
 # How much of each stacked window sticks out (in pixels)
@@ -237,6 +243,15 @@ preserve_focus_per_workspace = true
 workspace_auto_back_and_forth = false
 reapply_app_rules_on_title_change = false
 
+# Workspace-specific rules
+# - workspace: target workspace by index (integer) or name (string)
+# - layout: layout mode to use ("traditional", "bsp", "master_stack", "scrolling")
+# workspace_rules = [
+#   { workspace = 1, layout = "bsp" },
+#   { workspace = "second", layout = "scrolling" }
+# ]
+workspace_rules = []
+
 
 # Default workspace to activate on startup (0-based index).
 # If omitted, defaults to 0 (first workspace). Must be less than default_workspace_count.
@@ -340,6 +355,8 @@ comb1 = "Alt + Shift"
 # - move_window_to_workspace = N / move_window_to_workspace = { workspace = N, window_id = 123 } (optional window id)
 # - create_workspace
 # - switch_to_last_workspace
+# - next_window / prev_window
+# - ascend / descend
 # - move_focus = "left"|"right"|"up"|"down"
 # - move_node = "left"|"right"|"up"|"down"
 # - join_window = "left"|"right"|"up"|"down"
@@ -353,9 +370,14 @@ comb1 = "Alt + Shift"
 # - close_window = { window_server_id = 123 }
 # - focus_window = { window_id = 123, window_server_id = 456 }
 # - show_mission_control_all / show_mission_control_current / dismiss_mission_control (this is rift's own mission control, not macOS's)
+
 # the following commands *only* work when the master stack layout is active
 # - adjust_master_ratio = 0.05 / adjust_master_count = 1
 # - promote_to_master / swap_master_stack
+
+# the following commands *only* work when the scrolling layout is active
+# - scroll_strip = { delta = 0.5 }
+# - snap_strip / center_selection
 
 "Alt + Z" = "toggle_space_activated"
 

--- a/rift.default.toml
+++ b/rift.default.toml
@@ -358,6 +358,8 @@ comb1 = "Alt + Shift"
 # - move_window_to_workspace = N / move_window_to_workspace = { workspace = N, window_id = 123 } (optional window id)
 # - create_workspace
 # - switch_to_last_workspace
+# - set_workspace_layout = { mode = "traditional"|"bsp"|"master_stack"|"scrolling" } (active workspace)
+# - set_workspace_layout = { workspace = N, mode = "traditional"|"bsp"|"master_stack"|"scrolling" }
 # - next_window / prev_window
 # - ascend / descend
 # - move_focus = "left"|"right"|"up"|"down"
@@ -405,6 +407,12 @@ comb1 = "Alt + Shift"
 "comb1 + 3" = { move_window_to_workspace = 3 }
 
 "Alt + Tab" = "switch_to_last_workspace"
+
+# commands to change the layout engine of the active workspace
+# "Alt + Ctrl + 1" = { set_workspace_layout = { mode = "traditional" } }
+# "Alt + Ctrl + 2" = { set_workspace_layout = { mode = "bsp" } }
+# "Alt + Ctrl + 3" = { set_workspace_layout = { mode = "master_stack" } }
+# "Alt + Ctrl + 4" = { set_workspace_layout = { mode = "scrolling" } }
 
 "Alt + Shift + Left" = { join_window = "left" }
 "Alt + Shift + Right" = { join_window = "right" }

--- a/src/actor/event_tap.rs
+++ b/src/actor/event_tap.rs
@@ -423,8 +423,10 @@ impl EventTap {
             if let Some(nsevent) = NSEvent::eventWithCGEvent(event)
                 && nsevent.r#type() == NSEventType::Gesture
             {
-                let is_scrolling_mode =
-                    matches!(state.active_layout_mode, crate::common::config::LayoutMode::Scrolling);
+                let is_scrolling_mode = matches!(
+                    state.active_layout_mode,
+                    crate::common::config::LayoutMode::Scrolling
+                );
                 let scroll_handler = self.scroll.borrow();
                 if is_scrolling_mode && let Some(handler) = scroll_handler.as_ref() {
                     self.handle_scroll_gesture_event(handler, &nsevent);

--- a/src/actor/event_tap.rs
+++ b/src/actor/event_tap.rs
@@ -44,6 +44,7 @@ pub enum Request {
     Warp(CGPoint),
     EnforceHidden,
     ScreenParametersChanged(Vec<(CGRect, Option<SpaceId>)>, CoordinateConverter),
+    SpaceChanged(Vec<Option<SpaceId>>),
     SetEventProcessing(bool),
     SetFocusFollowsMouseEnabled(bool),
     SetHotkeys(Vec<(Hotkey, WmCommand)>),
@@ -381,6 +382,15 @@ impl EventTap {
                     .collect();
                 state.converter = converter;
                 state.window_level_cache.clear();
+            }
+            Request::SpaceChanged(spaces) => {
+                state.screen_spaces = state
+                    .screens
+                    .iter()
+                    .copied()
+                    .zip(spaces.into_iter())
+                    .filter_map(|(frame, maybe_space)| maybe_space.map(|space| (frame, space)))
+                    .collect();
             }
             Request::SetEventProcessing(enabled) => {
                 state.event_processing_enabled = enabled;

--- a/src/actor/event_tap.rs
+++ b/src/actor/event_tap.rs
@@ -8,7 +8,8 @@ use objc2_app_kit::{
 };
 use objc2_core_foundation::{CGPoint, CGRect};
 use objc2_core_graphics::{
-    CGEvent, CGEventFlags, CGEventMask, CGEventTapOptions as CGTapOpt, CGEventTapProxy, CGEventType,
+    CGEvent, CGEventField, CGEventFlags, CGEventMask, CGEventTapOptions as CGTapOpt,
+    CGEventTapProxy, CGEventType,
 };
 use tracing::{debug, error, trace, warn};
 
@@ -22,13 +23,21 @@ use crate::common::log::trace_misc;
 use crate::layout_engine::LayoutCommand as LC;
 use crate::sys::event::{self, Hotkey, KeyCode, MouseState, set_mouse_state};
 use crate::sys::geometry::CGRectExt;
-use crate::sys::haptics;
 use crate::sys::hotkey::{
     Modifiers, is_modifier_key, key_code_from_event, modifier_flag_for_key,
     modifiers_from_flags_with_keys,
 };
 use crate::sys::screen::{CoordinateConverter, SpaceId};
 use crate::sys::window_server::{self, WindowServerId, window_level};
+use crate::sys::{haptics, power};
+
+// Window levels can change for transient UI windows; cache briefly to reduce
+// query overhead without pinning stale values for long.
+const WINDOW_LEVEL_CACHE_TTL_NS: u64 = 300_000_000; // 300ms
+const MOUSE_MOVE_MIN_INTERVAL_NS_NORMAL: u64 = 8_000_000; // 8ms ~= 125 Hz
+const MOUSE_MOVE_MIN_DISTANCE_PX_SQ_NORMAL: f64 = 4.0; // 2px^2
+const MOUSE_MOVE_MIN_INTERVAL_NS_LOW_POWER: u64 = 16_000_000; // 16ms ~= 62 Hz
+const MOUSE_MOVE_MIN_DISTANCE_PX_SQ_LOW_POWER: f64 = 9.0; // 3px^2
 
 #[derive(Debug)]
 pub enum Request {
@@ -40,6 +49,7 @@ pub enum Request {
     SetHotkeys(Vec<(Hotkey, WmCommand)>),
     ConfigUpdated(Config),
     LayoutModesChanged(Vec<(SpaceId, crate::common::config::LayoutMode)>),
+    SetLowPowerMode(bool),
 }
 
 pub struct EventTap {
@@ -65,10 +75,20 @@ struct State {
     event_processing_enabled: bool,
     focus_follows_mouse_enabled: bool,
     disable_hotkey_active: bool,
+    low_power_mode: bool,
     pressed_keys: HashSet<KeyCode>,
     current_flags: CGEventFlags,
     screen_spaces: Vec<(CGRect, SpaceId)>,
     layout_mode_by_space: HashMap<SpaceId, crate::common::config::LayoutMode>,
+    last_mouse_move_loc: Option<CGPoint>,
+    last_mouse_move_timestamp: u64,
+    window_level_cache: HashMap<WindowServerId, CachedWindowLevel>,
+}
+
+#[derive(Debug, Copy, Clone)]
+struct CachedWindowLevel {
+    level: NSWindowLevel,
+    observed_at: u64,
 }
 
 impl Default for State {
@@ -82,10 +102,14 @@ impl Default for State {
             event_processing_enabled: false,
             focus_follows_mouse_enabled: true,
             disable_hotkey_active: false,
+            low_power_mode: power::is_low_power_mode_enabled(),
             pressed_keys: HashSet::default(),
             current_flags: CGEventFlags::empty(),
             screen_spaces: Vec::new(),
             layout_mode_by_space: HashMap::default(),
+            last_mouse_move_loc: None,
+            last_mouse_move_timestamp: 0,
+            window_level_cache: HashMap::default(),
         }
     }
 }
@@ -356,6 +380,7 @@ impl EventTap {
                     .filter_map(|(frame, maybe_space)| maybe_space.map(|space| (frame, space)))
                     .collect();
                 state.converter = converter;
+                state.window_level_cache.clear();
             }
             Request::SetEventProcessing(enabled) => {
                 state.event_processing_enabled = enabled;
@@ -425,6 +450,14 @@ impl EventTap {
                     state.layout_mode_by_space.len()
                 );
             }
+            Request::SetLowPowerMode(enabled) => {
+                if state.low_power_mode != enabled {
+                    debug!("low_power_mode changed in event tap: {}", enabled);
+                    state.low_power_mode = enabled;
+                    state.last_mouse_move_loc = None;
+                    state.last_mouse_move_timestamp = 0;
+                }
+            }
         }
     }
 
@@ -491,6 +524,11 @@ impl EventTap {
             }
             CGEventType::MouseMoved => {
                 let loc = CGEvent::location(Some(event));
+                let ts = CGEvent::timestamp(Some(event));
+                let sampling = mouse_move_sampling_profile(state.low_power_mode);
+                if !state.should_sample_mouse_move(loc, ts, sampling) {
+                    return true;
+                }
 
                 // stack line hover feedback
                 if let Some(tx) = &self.stack_line_tx {
@@ -502,7 +540,9 @@ impl EventTap {
                     && state.focus_follows_mouse_enabled
                     && !state.disable_hotkey_active
                 {
-                    if let Some(wsid) = state.track_mouse_move(loc) {
+                    if let Some(wsid) =
+                        state.track_mouse_move(loc, window_from_mouse_event(event), ts)
+                    {
                         _ = self.events_tx.send(Event::MouseMovedOverWindow(wsid));
                     }
                 }
@@ -857,6 +897,33 @@ unsafe extern "C-unwind" fn mouse_callback(
 }
 
 impl State {
+    #[inline]
+    fn should_sample_mouse_move(
+        &mut self,
+        loc: CGPoint,
+        timestamp: u64,
+        sampling: (u64, f64),
+    ) -> bool {
+        let Some(last_loc) = self.last_mouse_move_loc else {
+            self.last_mouse_move_loc = Some(loc);
+            self.last_mouse_move_timestamp = timestamp;
+            return true;
+        };
+
+        let dx = loc.x - last_loc.x;
+        let dy = loc.y - last_loc.y;
+        let dist_sq = dx * dx + dy * dy;
+        let elapsed = timestamp.saturating_sub(self.last_mouse_move_timestamp);
+
+        if dist_sq < sampling.1 && elapsed < sampling.0 {
+            return false;
+        }
+
+        self.last_mouse_move_loc = Some(loc);
+        self.last_mouse_move_timestamp = timestamp;
+        true
+    }
+
     fn layout_mode_at_point(&self, loc: CGPoint) -> Option<crate::common::config::LayoutMode> {
         self.screen_spaces
             .iter()
@@ -916,8 +983,13 @@ impl State {
         }
     }
 
-    fn track_mouse_move(&mut self, loc: CGPoint) -> Option<WindowServerId> {
-        let new_window = window_server::get_window_at_point(loc);
+    fn track_mouse_move(
+        &mut self,
+        loc: CGPoint,
+        hinted_window: Option<WindowServerId>,
+        event_timestamp: u64,
+    ) -> Option<WindowServerId> {
+        let new_window = hinted_window.or_else(|| window_server::get_window_at_point(loc));
         if self.above_window == new_window {
             return None;
         }
@@ -945,7 +1017,7 @@ impl State {
         let old_window = replace(&mut self.above_window, new_window);
 
         let new_window_level = new_window
-            .and_then(|id| trace_misc("window_level", || window_level(id.into())))
+            .map(|id| self.cached_window_level(id, event_timestamp))
             .unwrap_or(NSWindowLevel::MIN);
         let old_window_level = replace(&mut self.above_window_level, new_window_level);
         debug!(?old_window, ?old_window_level, ?new_window, ?new_window_level);
@@ -967,7 +1039,50 @@ impl State {
         if enabled {
             self.above_window = None;
             self.above_window_level = NSWindowLevel::MIN;
+            self.last_mouse_move_loc = None;
+            self.last_mouse_move_timestamp = 0;
+            self.window_level_cache.clear();
         }
+    }
+
+    #[inline]
+    fn cached_window_level(&mut self, id: WindowServerId, event_timestamp: u64) -> NSWindowLevel {
+        if let Some(cached) = self.window_level_cache.get(&id) {
+            if event_timestamp.saturating_sub(cached.observed_at) <= WINDOW_LEVEL_CACHE_TTL_NS {
+                return cached.level;
+            }
+        }
+
+        let level =
+            trace_misc("window_level", || window_level(id.into())).unwrap_or(NSWindowLevel::MIN);
+        self.window_level_cache.insert(id, CachedWindowLevel {
+            level,
+            observed_at: event_timestamp,
+        });
+        level
+    }
+}
+
+#[inline]
+fn window_from_mouse_event(event: &CGEvent) -> Option<WindowServerId> {
+    let field_value =
+        CGEvent::integer_value_field(Some(event), CGEventField::MouseEventWindowUnderMousePointer);
+    let id = u32::try_from(field_value).ok()?;
+    (id != 0).then(|| WindowServerId::new(id))
+}
+
+#[inline]
+fn mouse_move_sampling_profile(low_power_mode: bool) -> (u64, f64) {
+    if low_power_mode {
+        (
+            MOUSE_MOVE_MIN_INTERVAL_NS_LOW_POWER,
+            MOUSE_MOVE_MIN_DISTANCE_PX_SQ_LOW_POWER,
+        )
+    } else {
+        (
+            MOUSE_MOVE_MIN_INTERVAL_NS_NORMAL,
+            MOUSE_MOVE_MIN_DISTANCE_PX_SQ_NORMAL,
+        )
     }
 }
 

--- a/src/actor/reactor.rs
+++ b/src/actor/reactor.rs
@@ -2021,8 +2021,8 @@ impl Reactor {
         {
             let skip_empty = self.config.settings.gestures.skip_empty;
             let cmd = match dir {
-                Direction::Left => Some(layout::LayoutCommand::PrevWorkspace(Some(skip_empty))),
-                Direction::Right => Some(layout::LayoutCommand::NextWorkspace(Some(skip_empty))),
+                Direction::Left => Some(layout::LayoutCommand::NextWorkspace(Some(skip_empty))),
+                Direction::Right => Some(layout::LayoutCommand::PrevWorkspace(Some(skip_empty))),
                 _ => None,
             };
             if let Some(cmd) = cmd {

--- a/src/actor/reactor/animation.rs
+++ b/src/actor/reactor/animation.rs
@@ -238,7 +238,13 @@ impl AnimationManager {
 
         if animated_count > 0 {
             let low_power = power::is_low_power_mode_enabled();
-            if is_resize || !reactor.config.settings.animate || low_power {
+            let layout_animate = reactor
+                .layout_manager
+                .layout_engine
+                .layout_specific_animate_settings(space)
+                .unwrap_or(reactor.config.settings.animate);
+
+            if is_resize || !layout_animate || low_power {
                 anim.skip_to_end();
             } else {
                 anim.run();

--- a/src/actor/reactor/events/command.rs
+++ b/src/actor/reactor/events/command.rs
@@ -104,6 +104,9 @@ impl CommandEventHandler {
         };
 
         reactor.handle_layout_response(response, workspace_space);
+        if requires_workspace_space {
+            reactor.update_event_tap_layout_mode();
+        }
     }
 
     pub fn handle_command_metrics(_reactor: &mut Reactor, cmd: MetricsCommand) {

--- a/src/actor/reactor/events/command.rs
+++ b/src/actor/reactor/events/command.rs
@@ -35,8 +35,17 @@ impl CommandEventHandler {
                 | LayoutCommand::SwitchToWorkspace(_)
                 | LayoutCommand::SwitchToLastWorkspace
         );
+        let requires_workspace_space = matches!(
+            cmd,
+            LayoutCommand::NextWorkspace(_)
+                | LayoutCommand::PrevWorkspace(_)
+                | LayoutCommand::SwitchToWorkspace(_)
+                | LayoutCommand::SetWorkspaceLayout { .. }
+                | LayoutCommand::CreateWorkspace
+                | LayoutCommand::SwitchToLastWorkspace
+        );
         let command_space = reactor.workspace_command_space();
-        let workspace_space = if is_workspace_switch {
+        let workspace_space = if requires_workspace_space {
             if let Some(space) = command_space {
                 reactor.store_current_floating_positions(space);
             }
@@ -56,6 +65,7 @@ impl CommandEventHandler {
             LayoutCommand::NextWorkspace(_)
             | LayoutCommand::PrevWorkspace(_)
             | LayoutCommand::SwitchToWorkspace(_)
+            | LayoutCommand::SetWorkspaceLayout { .. }
             | LayoutCommand::CreateWorkspace
             | LayoutCommand::SwitchToLastWorkspace => {
                 if let Some(space) = workspace_space {

--- a/src/actor/reactor/events/system.rs
+++ b/src/actor/reactor/events/system.rs
@@ -13,7 +13,10 @@ impl SystemEventHandler {
         reactor.menu_manager.menu_state = match reactor.menu_manager.menu_state {
             MenuState::Closed => MenuState::Open(1),
             MenuState::Open(depth) => {
-                debug!(depth, "menu already open; ignoring duplicate menu-open notification");
+                debug!(
+                    depth,
+                    "menu already open; ignoring duplicate menu-open notification"
+                );
                 MenuState::Open(depth)
             }
         };

--- a/src/actor/reactor/managers.rs
+++ b/src/actor/reactor/managers.rs
@@ -120,6 +120,7 @@ impl DragManager {
 /// Manages window notifications
 pub struct NotificationManager {
     pub last_sls_notification_ids: Vec<u32>,
+    pub last_layout_modes_by_space: HashMap<SpaceId, crate::common::config::LayoutMode>,
     pub _window_notify_tx: Option<window_notify::Sender>,
 }
 

--- a/src/actor/reactor/query.rs
+++ b/src/actor/reactor/query.rs
@@ -355,7 +355,7 @@ impl Reactor {
 
         Some(LayoutStateData {
             space_id: space_id_u64,
-            mode: self.layout_manager.layout_engine.layout_mode().to_string(),
+            mode: self.layout_manager.layout_engine.layout_mode_at(space_id).to_string(),
             floating_windows,
             tiled_windows,
             focused_window,

--- a/src/actor/reactor/query.rs
+++ b/src/actor/reactor/query.rs
@@ -8,7 +8,7 @@ use crate::actor::menu_bar;
 use crate::actor::reactor::Reactor;
 use crate::common::collections::HashSet;
 use crate::model::server::{
-    ApplicationData, DisplayData, LayoutStateData, WindowData, WorkspaceData,
+    ApplicationData, DisplayData, LayoutStateData, WindowData, WorkspaceData, WorkspaceLayoutData,
 };
 use crate::model::virtual_workspace::VirtualWorkspaceId;
 use crate::sys::screen::{ScreenInfo, SpaceId, get_active_space_number, managed_display_space_ids};
@@ -39,6 +39,15 @@ impl ReactorQueryHandle {
     pub fn query_displays(&self) -> Vec<DisplayData> {
         let mut reactor = self.inner.write();
         reactor.query_displays()
+    }
+
+    pub fn query_workspace_layouts(
+        &self,
+        space_id: Option<SpaceId>,
+        workspace_id: Option<usize>,
+    ) -> Vec<WorkspaceLayoutData> {
+        let mut reactor = self.inner.write();
+        reactor.query_workspace_layouts(space_id, workspace_id)
     }
 
     pub fn query_window_info(&self, window_id: WindowId) -> Option<WindowData> {
@@ -85,6 +94,14 @@ impl Reactor {
     }
 
     pub fn query_displays(&mut self) -> Vec<DisplayData> { self.handle_displays_query() }
+
+    pub fn query_workspace_layouts(
+        &mut self,
+        space_id: Option<SpaceId>,
+        workspace_id: Option<usize>,
+    ) -> Vec<WorkspaceLayoutData> {
+        self.handle_workspace_layouts_query(space_id, workspace_id)
+    }
 
     pub fn query_window_info(&mut self, window_id: WindowId) -> Option<WindowData> {
         self.handle_window_info_query(window_id)
@@ -211,9 +228,20 @@ impl Reactor {
                 }
             }
 
+            let layout_mode = space_id
+                .and_then(|space| {
+                    self.layout_manager
+                        .layout_engine
+                        .virtual_workspace_manager()
+                        .workspace_info(space, *workspace_id)
+                        .map(|ws| ws.layout_mode().to_string())
+                })
+                .unwrap_or_else(|| "unknown".to_string());
+
             workspaces.push(WorkspaceData {
                 id: format!("{:?}", workspace_id),
                 name: workspace_name.to_string(),
+                layout_mode,
                 is_active,
                 window_count: windows.len(),
                 windows,
@@ -222,6 +250,45 @@ impl Reactor {
         }
 
         workspaces
+    }
+
+    fn handle_workspace_layouts_query(
+        &mut self,
+        space_id_param: Option<SpaceId>,
+        workspace_id: Option<usize>,
+    ) -> Vec<WorkspaceLayoutData> {
+        let Some(space) = space_id_param.or_else(|| self.default_query_space()) else {
+            return Vec::new();
+        };
+
+        let workspace_list = self
+            .layout_manager
+            .layout_engine
+            .virtual_workspace_manager_mut()
+            .list_workspaces(space);
+        let active_workspace = self.layout_manager.layout_engine.active_workspace(space);
+
+        workspace_list
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| workspace_id.map(|target| target == *index).unwrap_or(true))
+            .filter_map(|(index, (id, name))| {
+                let layout_mode = self
+                    .layout_manager
+                    .layout_engine
+                    .virtual_workspace_manager()
+                    .workspace_info(space, *id)
+                    .map(|ws| ws.layout_mode().to_string())?;
+
+                Some(WorkspaceLayoutData {
+                    id: format!("{:?}", id),
+                    index,
+                    name: name.clone(),
+                    layout_mode,
+                    is_active: active_workspace == Some(*id),
+                })
+            })
+            .collect()
     }
 
     fn handle_active_workspace_query(

--- a/src/actor/reactor/tests.rs
+++ b/src/actor/reactor/tests.rs
@@ -266,6 +266,7 @@ fn handle_layout_response_groups_windows_by_app_and_screen() {
                 WindowId::new(2, 2),
             ],
             focus_window: None,
+            boundary_hit: None,
         },
         None,
     );
@@ -309,6 +310,7 @@ fn handle_layout_response_includes_handles_for_raise_and_focus_windows() {
         layout::EventResponse {
             raise_windows: vec![WindowId::new(1, 1)],
             focus_window: Some(WindowId::new(2, 1)),
+            boundary_hit: None,
         },
         None,
     );

--- a/src/actor/wm_controller.rs
+++ b/src/actor/wm_controller.rs
@@ -291,6 +291,7 @@ impl WmController {
             }
             PowerStateChanged(is_low_power_mode) => {
                 info!("Power state changed: low power mode = {}", is_low_power_mode);
+                _ = self.event_tap_tx.send(event_tap::Request::SetLowPowerMode(is_low_power_mode));
             }
             Command(Wm(crate::actor::wm_controller::WmCmd::ToggleSpaceActivated)) => {
                 self.events_tx.send(reactor::Event::Command(reactor::Command::Reactor(

--- a/src/actor/wm_controller.rs
+++ b/src/actor/wm_controller.rs
@@ -288,6 +288,9 @@ impl WmController {
                     spaces.clone(),
                     self.get_windows_for_spaces(&spaces),
                 ));
+                _ = self
+                    .event_tap_tx
+                    .send(event_tap::Request::SpaceChanged(spaces));
             }
             PowerStateChanged(is_low_power_mode) => {
                 info!("Power state changed: low power mode = {}", is_low_power_mode);

--- a/src/actor/wm_controller.rs
+++ b/src/actor/wm_controller.rs
@@ -288,9 +288,7 @@ impl WmController {
                     spaces.clone(),
                     self.get_windows_for_spaces(&spaces),
                 ));
-                _ = self
-                    .event_tap_tx
-                    .send(event_tap::Request::SpaceChanged(spaces));
+                _ = self.event_tap_tx.send(event_tap::Request::SpaceChanged(spaces));
             }
             PowerStateChanged(is_low_power_mode) => {
                 info!("Power state changed: low power mode = {}", is_low_power_mode);

--- a/src/actor/wm_controller.rs
+++ b/src/actor/wm_controller.rs
@@ -264,7 +264,8 @@ impl WmController {
                 }
             }
             ScreenParametersChanged(screens, converter) => {
-                let frames: Vec<CGRect> = screens.iter().map(|s| s.frame).collect();
+                let frames_with_spaces: Vec<(CGRect, Option<SpaceId>)> =
+                    screens.iter().map(|s| (s.frame, s.space)).collect();
                 let spaces: Vec<Option<SpaceId>> = screens.iter().map(|s| s.space).collect();
 
                 self.events_tx.send(Event::ScreenParametersChanged(
@@ -272,9 +273,10 @@ impl WmController {
                     self.get_windows_for_spaces(&spaces),
                 ));
 
-                _ = self
-                    .event_tap_tx
-                    .send(event_tap::Request::ScreenParametersChanged(frames, converter));
+                _ = self.event_tap_tx.send(event_tap::Request::ScreenParametersChanged(
+                    frames_with_spaces,
+                    converter,
+                ));
                 if let Some(tx) = &self.stack_line_tx {
                     _ = tx.try_send(crate::actor::stack_line::Event::ScreenParametersChanged(
                         converter,

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -83,6 +83,17 @@ pub struct VirtualWorkspaceSettings {
     pub reapply_app_rules_on_title_change: bool,
     #[serde(default)]
     pub app_rules: Vec<AppWorkspaceRule>,
+    #[serde(default)]
+    pub workspace_rules: Vec<WorkspaceLayoutRule>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct WorkspaceLayoutRule {
+    /// Target workspace by index or name
+    pub workspace: WorkspaceSelector,
+    /// Layout mode to use for this workspace
+    pub layout: LayoutMode,
 }
 
 // Allow specifying a workspace by numeric index or by name in the config.
@@ -145,6 +156,7 @@ impl Default for VirtualWorkspaceSettings {
             default_workspace: 0,
             reapply_app_rules_on_title_change: false,
             app_rules: Vec::new(),
+            workspace_rules: Vec::new(),
         }
     }
 }
@@ -557,7 +569,7 @@ pub struct LayoutSettings {
 }
 
 /// Layout mode enum
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum LayoutMode {
     /// Traditional container-based tiling (i3/sway style)

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -583,7 +583,7 @@ pub enum LayoutMode {
     Scrolling,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct ScrollingLayoutSettings {
     /// Default width of the active column, as a fraction of the screen width.
@@ -606,6 +606,19 @@ pub struct ScrollingLayoutSettings {
     /// Trackpad gestures for scrolling layout
     #[serde(default)]
     pub gestures: ScrollingGestureSettings,
+}
+
+impl Default for ScrollingLayoutSettings {
+    fn default() -> Self {
+        Self {
+            column_width_ratio: default_scrolling_column_width_ratio(),
+            min_column_width_ratio: default_scrolling_min_column_width_ratio(),
+            max_column_width_ratio: default_scrolling_max_column_width_ratio(),
+            alignment: ScrollingAlignment::default(),
+            focus_navigation_style: ScrollingFocusNavigationStyle::default(),
+            gestures: ScrollingGestureSettings::default(),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy, Default)]

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -1084,7 +1084,7 @@ fn default_workspace_names() -> Vec<String> {
 fn default_swipe_vertical_tolerance() -> f64 { 0.4 }
 fn default_swipe_fingers() -> usize { 3 }
 fn default_distance_pct() -> f64 { 0.08 }
-fn default_overscroll_threshold() -> f64 { 0.75 }
+fn default_overscroll_threshold() -> f64 { 0.625 }
 
 fn default_stack_line_spacing() -> f64 { 0.0 }
 

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -583,6 +583,17 @@ pub enum LayoutMode {
     Scrolling,
 }
 
+impl ToString for LayoutMode {
+    fn to_string(&self) -> String {
+        match self {
+            LayoutMode::Traditional => "traditional".to_string(),
+            LayoutMode::Bsp => "bsp".to_string(),
+            LayoutMode::MasterStack => "master_stack".to_string(),
+            LayoutMode::Scrolling => "scrolling".to_string(),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct ScrollingLayoutSettings {

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -691,6 +691,12 @@ pub struct ScrollingGestureSettings {
     /// Normalized horizontal distance (0..1) required to fire a scroll step
     #[serde(default = "default_distance_pct")]
     pub distance_pct: f64,
+    /// If true, scrolling past the end of the strip will trigger a workspace switch
+    #[serde(default = "no")]
+    pub propagate_to_workspace_swipe: bool,
+    /// Amount of overscroll (in steps) required to trigger a workspace switch
+    #[serde(default = "default_overscroll_threshold")]
+    pub workspace_switch_threshold: f64,
 }
 
 impl Default for ScrollingGestureSettings {
@@ -701,6 +707,8 @@ impl Default for ScrollingGestureSettings {
             vertical_tolerance: default_swipe_vertical_tolerance(),
             fingers: default_swipe_fingers(),
             distance_pct: default_distance_pct(),
+            propagate_to_workspace_swipe: false,
+            workspace_switch_threshold: default_overscroll_threshold(),
         }
     }
 }
@@ -1076,6 +1084,7 @@ fn default_workspace_names() -> Vec<String> {
 fn default_swipe_vertical_tolerance() -> f64 { 0.4 }
 fn default_swipe_fingers() -> usize { 3 }
 fn default_distance_pct() -> f64 { 0.08 }
+fn default_overscroll_threshold() -> f64 { 0.75 }
 
 fn default_stack_line_spacing() -> f64 { 0.0 }
 

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -586,6 +586,9 @@ pub enum LayoutMode {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct ScrollingLayoutSettings {
+    /// Whether to animate window transitions in this layout.
+    #[serde(default)]
+    pub animate: Option<bool>,
     /// Default width of the active column, as a fraction of the screen width.
     #[serde(default = "default_scrolling_column_width_ratio")]
     pub column_width_ratio: f64,
@@ -611,6 +614,7 @@ pub struct ScrollingLayoutSettings {
 impl Default for ScrollingLayoutSettings {
     fn default() -> Self {
         Self {
+            animate: None,
             column_width_ratio: default_scrolling_column_width_ratio(),
             min_column_width_ratio: default_scrolling_min_column_width_ratio(),
             max_column_width_ratio: default_scrolling_max_column_width_ratio(),

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -240,6 +240,15 @@ impl MachHandler {
                     },
                 }
             }
+            RiftRequest::GetWorkspaceLayouts { space_id, workspace_id } => {
+                let workspace_layouts = self.reactor.query_workspace_layouts(
+                    space_id.map(crate::sys::screen::SpaceId::new),
+                    workspace_id,
+                );
+                RiftResponse::Success {
+                    data: serde_json::to_value(workspace_layouts).unwrap(),
+                }
+            }
 
             RiftRequest::GetApplications => {
                 let applications = self.reactor.query_applications();

--- a/src/ipc/protocol.rs
+++ b/src/ipc/protocol.rs
@@ -18,6 +18,10 @@ pub enum RiftRequest {
     GetLayoutState {
         space_id: u64,
     },
+    GetWorkspaceLayouts {
+        space_id: Option<u64>,
+        workspace_id: Option<usize>,
+    },
     GetApplications,
     GetMetrics,
     GetConfig,

--- a/src/layout_engine/engine.rs
+++ b/src/layout_engine/engine.rs
@@ -196,10 +196,8 @@ impl LayoutEngine {
                 .map(|layout| workspace.layout_system.visible_windows_in_layout(layout))
                 .unwrap_or_default();
             // Keep windows hidden by stack/group selection when rebuilding into a new mode.
-            let mut hidden_windows: Vec<_> = workspace
-                .windows()
-                .filter(|wid| !ordered.contains(wid))
-                .collect();
+            let mut hidden_windows: Vec<_> =
+                workspace.windows().filter(|wid| !ordered.contains(wid)).collect();
             hidden_windows.sort();
             ordered.extend(hidden_windows);
             (workspace.layout_mode, selected, ordered)

--- a/src/layout_engine/engine.rs
+++ b/src/layout_engine/engine.rs
@@ -667,8 +667,11 @@ impl LayoutEngine {
     fn remove_window_internal(&mut self, wid: WindowId, preserve_floating: bool) {
         let affected_space: Option<SpaceId> = self.space_with_window(wid);
 
-        if let Some(ws_id) = self.virtual_workspace_manager.workspace_for_window_any(wid) {
-            self.workspace_tree_mut(ws_id).remove_window(wid);
+        let ws_ids = self.virtual_workspace_manager.workspaces_for_window(wid);
+        if !ws_ids.is_empty() {
+            for ws_id in ws_ids {
+                self.workspace_tree_mut(ws_id).remove_window(wid);
+            }
         } else {
             // Fallback: search all workspaces
             let ws_ids: Vec<_> = self.virtual_workspace_manager.workspaces.keys().collect();

--- a/src/layout_engine/engine.rs
+++ b/src/layout_engine/engine.rs
@@ -261,9 +261,8 @@ impl LayoutEngine {
         for space in spaces {
             let workspaces = self.virtual_workspace_manager.list_workspaces(space).to_vec();
             for (index, (workspace_id, name)) in workspaces.iter().enumerate() {
-                let desired_mode = self
-                    .virtual_workspace_manager
-                    .desired_layout_mode_for_workspace(index, name);
+                let desired_mode =
+                    self.virtual_workspace_manager.desired_layout_mode_for_workspace(index, name);
                 let current_mode = self
                     .virtual_workspace_manager
                     .workspace_info(space, *workspace_id)
@@ -2336,7 +2335,8 @@ mod tests {
     use super::*;
     use crate::common::collections::HashMap;
     use crate::common::config::{
-        LayoutMode, LayoutSettings, VirtualWorkspaceSettings, WorkspaceLayoutRule, WorkspaceSelector,
+        LayoutMode, LayoutSettings, VirtualWorkspaceSettings, WorkspaceLayoutRule,
+        WorkspaceSelector,
     };
 
     fn test_engine() -> LayoutEngine {
@@ -2445,17 +2445,13 @@ mod tests {
         let window_id = WindowId::new(999, 1);
 
         let _ = engine.virtual_workspace_manager_mut().list_workspaces(space);
-        let _ = engine
-            .virtual_workspace_manager_mut()
-            .auto_assign_window(window_id, space);
+        let _ = engine.virtual_workspace_manager_mut().auto_assign_window(window_id, space);
 
-        let response = engine.handle_virtual_workspace_command(
-            space,
-            &LayoutCommand::SetWorkspaceLayout {
+        let response =
+            engine.handle_virtual_workspace_command(space, &LayoutCommand::SetWorkspaceLayout {
                 workspace: Some(1),
                 mode: LayoutMode::Bsp,
-            },
-        );
+            });
 
         assert!(response.raise_windows.is_empty());
         assert_eq!(response.focus_window, None);

--- a/src/layout_engine/engine.rs
+++ b/src/layout_engine/engine.rs
@@ -211,6 +211,17 @@ impl LayoutEngine {
         }
     }
 
+    pub fn layout_specific_animate_settings(&self, space: SpaceId) -> Option<bool> {
+        if let Some(ws_id) = self.virtual_workspace_manager.active_workspace(space) {
+            match self.workspace_tree(ws_id) {
+                LayoutSystemKind::Scrolling(_) => self.layout_settings.scrolling.animate,
+                _ => None,
+            }
+        } else {
+            None
+        }
+    }
+
     fn active_floating_windows_in_workspace(&self, space: SpaceId) -> Vec<WindowId> {
         self.floating
             .active_flat(space)

--- a/src/layout_engine/systems.rs
+++ b/src/layout_engine/systems.rs
@@ -97,6 +97,7 @@ pub use scrolling::ScrollingLayoutSystem;
 
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
+#[derive(Debug)]
 #[enum_dispatch(LayoutSystem)]
 pub enum LayoutSystemKind {
     Traditional(TraditionalLayoutSystem),

--- a/src/layout_engine/systems/bsp.rs
+++ b/src/layout_engine/systems/bsp.rs
@@ -9,7 +9,7 @@ use crate::layout_engine::{Direction, LayoutId, LayoutKind, Orientation};
 use crate::model::selection::*;
 use crate::model::tree::{NodeId, NodeMap, Tree};
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 enum NodeKind {
     Split {
         orientation: Orientation,
@@ -23,12 +23,12 @@ enum NodeKind {
     },
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy)]
+#[derive(Serialize, Deserialize, Clone, Copy, Debug)]
 struct LayoutState {
     root: NodeId,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct BspLayoutSystem {
     layouts: slotmap::SlotMap<crate::layout_engine::LayoutId, LayoutState>,
     tree: Tree<Components>,
@@ -506,7 +506,7 @@ impl BspLayoutSystem {
     }
 }
 
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Default, Serialize, Deserialize, Debug)]
 struct Components {
     selection: Selection,
 }

--- a/src/layout_engine/systems/master_stack.rs
+++ b/src/layout_engine/systems/master_stack.rs
@@ -12,7 +12,7 @@ use crate::layout_engine::{
 };
 use crate::model::tree::NodeId;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct MasterStackLayoutSystem {
     inner: TraditionalLayoutSystem,
     settings: MasterStackSettings,

--- a/src/layout_engine/systems/scrolling.rs
+++ b/src/layout_engine/systems/scrolling.rs
@@ -38,6 +38,8 @@ struct LayoutState {
     last_step_px: AtomicU64,
     #[serde(skip, default = "default_atomic")]
     last_center_offset_delta_px: AtomicU64,
+    #[serde(skip, default = "default_atomic")]
+    overscroll_accumulation: AtomicU64,
     fullscreen: HashSet<WindowId>,
     fullscreen_within_gaps: HashSet<WindowId>,
 }
@@ -57,6 +59,7 @@ impl LayoutState {
             last_gap_x: AtomicU64::new(0.0f64.to_bits()),
             last_step_px: AtomicU64::new(0.0f64.to_bits()),
             last_center_offset_delta_px: AtomicU64::new(0.0f64.to_bits()),
+            overscroll_accumulation: AtomicU64::new(0.0f64.to_bits()),
             fullscreen: HashSet::default(),
             fullscreen_within_gaps: HashSet::default(),
         }
@@ -258,6 +261,9 @@ impl Clone for LayoutState {
             last_center_offset_delta_px: AtomicU64::new(
                 self.last_center_offset_delta_px.load(Ordering::Relaxed),
             ),
+            overscroll_accumulation: AtomicU64::new(
+                self.overscroll_accumulation.load(Ordering::Relaxed),
+            ),
             fullscreen: self.fullscreen.clone(),
             fullscreen_within_gaps: self.fullscreen_within_gaps.clone(),
         }
@@ -335,26 +341,27 @@ impl ScrollingLayoutSystem {
         (widths, starts)
     }
 
-    pub fn scroll_by_delta(&mut self, layout: LayoutId, delta: f64) {
+    pub fn scroll_by_delta(&mut self, layout: LayoutId, delta: f64) -> Option<Direction> {
         let min_ratio = self.settings.min_column_width_ratio;
         let max_ratio = self.settings.max_column_width_ratio;
+        let threshold = self.settings.gestures.workspace_switch_threshold;
         let Some(state) = self.layout_state_mut(layout) else {
-            return;
+            return None;
         };
         let screen_width = f64::from_bits(state.last_screen_width.load(Ordering::Relaxed));
         let gap_x = f64::from_bits(state.last_gap_x.load(Ordering::Relaxed));
         if screen_width <= 0.0 {
-            return;
+            return None;
         }
         let (widths, starts) =
             Self::column_widths_and_starts(state, screen_width, gap_x, min_ratio, max_ratio);
         if starts.is_empty() {
-            return;
+            return None;
         }
         let selected_idx = state.selected_location().map(|(idx, _)| idx).unwrap_or(0);
         let step = widths.get(selected_idx).copied().unwrap_or(1.0) + gap_x;
         if step <= 0.0 {
-            return;
+            return None;
         }
         let base_max_offset = starts.last().copied().unwrap_or(0.0);
         let center_offset_delta =
@@ -365,8 +372,36 @@ impl ScrollingLayoutSystem {
             (0.0, base_max_offset)
         };
         let current = f64::from_bits(state.scroll_offset_px.load(Ordering::Relaxed));
-        let next = (current + delta * step).clamp(min_offset, max_offset);
+        let next_raw = current + delta * step;
+        let next = next_raw.clamp(min_offset, max_offset);
         state.scroll_offset_px.store(next.to_bits(), Ordering::Relaxed);
+
+        if next_raw < min_offset && delta < 0.0 {
+            let overscroll = (min_offset - next_raw) / step;
+            let accum =
+                f64::from_bits(state.overscroll_accumulation.load(Ordering::Relaxed)) + overscroll;
+            if accum >= threshold {
+                state.overscroll_accumulation.store(0.0f64.to_bits(), Ordering::Relaxed);
+                Some(Direction::Left)
+            } else {
+                state.overscroll_accumulation.store(accum.to_bits(), Ordering::Relaxed);
+                None
+            }
+        } else if next_raw > max_offset && delta > 0.0 {
+            let overscroll = (next_raw - max_offset) / step;
+            let accum =
+                f64::from_bits(state.overscroll_accumulation.load(Ordering::Relaxed)) + overscroll;
+            if accum >= threshold {
+                state.overscroll_accumulation.store(0.0f64.to_bits(), Ordering::Relaxed);
+                Some(Direction::Right)
+            } else {
+                state.overscroll_accumulation.store(accum.to_bits(), Ordering::Relaxed);
+                None
+            }
+        } else {
+            state.overscroll_accumulation.store(0.0f64.to_bits(), Ordering::Relaxed);
+            None
+        }
     }
 
     pub fn snap_to_nearest_column(&mut self, layout: LayoutId) {

--- a/src/layout_engine/systems/scrolling.rs
+++ b/src/layout_engine/systems/scrolling.rs
@@ -268,7 +268,7 @@ fn default_atomic_bool() -> AtomicBool { AtomicBool::new(false) }
 fn default_atomic_i8() -> AtomicI8 { AtomicI8::new(0) }
 fn default_atomic() -> AtomicU64 { AtomicU64::new(0.0f64.to_bits()) }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct ScrollingLayoutSystem {
     layouts: slotmap::SlotMap<LayoutId, LayoutState>,
     #[serde(skip, default = "default_scrolling_settings")]

--- a/src/layout_engine/systems/traditional.rs
+++ b/src/layout_engine/systems/traditional.rs
@@ -10,7 +10,7 @@ use crate::model::selection::*;
 use crate::model::tree::{self, NodeId, NodeMap, OwnedNode, Tree};
 use crate::sys::geometry::Round;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct TraditionalLayoutSystem {
     pub(crate) tree: Tree<Components>,
     pub(crate) layout_roots: slotmap::SlotMap<LayoutId, OwnedNode>,
@@ -1913,7 +1913,7 @@ impl TraditionalLayoutSystem {
     }
 }
 
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Default, Serialize, Deserialize, Debug)]
 pub(crate) struct Components {
     selection: Selection,
     pub(crate) layout: Layout,
@@ -1954,19 +1954,19 @@ impl tree::Observer for Components {
     }
 }
 
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Default, Serialize, Deserialize, Debug)]
 pub(crate) struct WindowIndex {
     windows: slotmap::SecondaryMap<NodeId, WindowId>,
     window_nodes: crate::common::collections::BTreeMap<WindowId, WindowNodeInfoVec>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 struct WindowNodeInfo {
     layout: LayoutId,
     node: NodeId,
 }
 
-#[derive(Serialize, Deserialize, Default)]
+#[derive(Serialize, Deserialize, Default, Debug)]
 struct WindowNodeInfoVec(Vec<WindowNodeInfo>);
 
 impl WindowIndex {
@@ -2152,7 +2152,7 @@ impl StackLayoutResult {
     }
 }
 
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Default, Serialize, Deserialize, Debug)]
 pub(crate) struct Layout {
     pub(crate) info: slotmap::SecondaryMap<NodeId, LayoutInfo>,
 }

--- a/src/layout_engine/workspaces.rs
+++ b/src/layout_engine/workspaces.rs
@@ -161,11 +161,34 @@ impl WorkspaceLayouts {
             .collect()
     }
 
-    pub(crate) fn for_each_active(&self, mut f: impl FnMut(LayoutId)) {
-        for info in self.map.values() {
-            if let Some(l) = info.active() {
-                f(l);
-            }
+    pub(crate) fn active_layouts_with_workspace(
+        &self,
+    ) -> Vec<(crate::model::VirtualWorkspaceId, LayoutId)> {
+        self.map
+            .iter()
+            .filter_map(|(&(_, ws_id), info)| info.active().map(|l| (ws_id, l)))
+            .collect()
+    }
+
+    pub(crate) fn ensure_active_for_workspace(
+        &mut self,
+        space: SpaceId,
+        size: CGSize,
+        workspace_id: crate::model::VirtualWorkspaceId,
+        tree: &mut impl LayoutSystem,
+    ) {
+        self.ensure_active_for_space(space, size, std::iter::once(workspace_id), tree);
+    }
+
+    pub(crate) fn replace_layout(
+        &mut self,
+        space: SpaceId,
+        workspace_id: crate::model::VirtualWorkspaceId,
+        new_layout: LayoutId,
+    ) {
+        if let Some(info) = self.map.get_mut(&(space, workspace_id)) {
+            info.configurations.insert(info.active_size, new_layout);
+            info.last_saved = Some(new_layout);
         }
     }
 

--- a/src/layout_engine/workspaces.rs
+++ b/src/layout_engine/workspaces.rs
@@ -195,14 +195,11 @@ impl WorkspaceLayouts {
         let mut configurations = crate::common::collections::HashMap::default();
         configurations.insert(active_size, new_layout);
 
-        self.map.insert(
-            (space, workspace_id),
-            SpaceLayoutInfo {
-                configurations,
-                active_size,
-                last_saved: Some(new_layout),
-            },
-        );
+        self.map.insert((space, workspace_id), SpaceLayoutInfo {
+            configurations,
+            active_size,
+            last_saved: Some(new_layout),
+        });
     }
 
     pub(crate) fn spaces(&self) -> crate::common::collections::BTreeSet<SpaceId> {

--- a/src/layout_engine/workspaces.rs
+++ b/src/layout_engine/workspaces.rs
@@ -180,16 +180,29 @@ impl WorkspaceLayouts {
         self.ensure_active_for_space(space, size, std::iter::once(workspace_id), tree);
     }
 
-    pub(crate) fn replace_layout(
+    pub(crate) fn replace_layouts_for_workspace(
         &mut self,
         space: SpaceId,
         workspace_id: crate::model::VirtualWorkspaceId,
         new_layout: LayoutId,
     ) {
-        if let Some(info) = self.map.get_mut(&(space, workspace_id)) {
-            info.configurations.insert(info.active_size, new_layout);
-            info.last_saved = Some(new_layout);
-        }
+        let active_size = self
+            .map
+            .get(&(space, workspace_id))
+            .map(|info| info.active_size)
+            .unwrap_or_else(|| Size::from(CGSize::new(1000.0, 1000.0)));
+
+        let mut configurations = crate::common::collections::HashMap::default();
+        configurations.insert(active_size, new_layout);
+
+        self.map.insert(
+            (space, workspace_id),
+            SpaceLayoutInfo {
+                configurations,
+                active_size,
+                last_saved: Some(new_layout),
+            },
+        );
     }
 
     pub(crate) fn spaces(&self) -> crate::common::collections::BTreeSet<SpaceId> {

--- a/src/model/selection.rs
+++ b/src/model/selection.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::layout_engine::LayoutId;
 use crate::model::tree::{NodeId, NodeMap};
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub enum TreeEvent {
     AddedToForest(NodeId),
     AddedToParent(NodeId),
@@ -16,12 +16,12 @@ pub enum TreeEvent {
     RemovedFromForest(NodeId),
 }
 
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct Selection {
     nodes: slotmap::SecondaryMap<NodeId, SelectionInfo>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct SelectionInfo {
     selected_child: NodeId,
     stop_here: bool,

--- a/src/model/server.rs
+++ b/src/model/server.rs
@@ -14,9 +14,19 @@ pub struct WorkspaceData {
     pub id: String,
     pub index: usize,
     pub name: String,
+    pub layout_mode: String,
     pub is_active: bool,
     pub window_count: usize,
     pub windows: Vec<WindowData>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkspaceLayoutData {
+    pub id: String,
+    pub index: usize,
+    pub name: String,
+    pub layout_mode: String,
+    pub is_active: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/src/model/tree.rs
+++ b/src/model/tree.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use slotmap::SlotMap;
 
 /// N-ary tree.
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Tree<O> {
     pub map: NodeMap,
     pub data: O,
@@ -28,7 +28,7 @@ impl<O: Observer> Tree<O> {
 ///
 /// Multiple trees can be contained within a map. This also makes it easier
 /// to move branches between trees.
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct NodeMap {
     map: SlotMap<NodeId, Node>,
 }

--- a/src/model/virtual_workspace.rs
+++ b/src/model/virtual_workspace.rs
@@ -10,8 +10,8 @@ use crate::common::config::{
     AppWorkspaceRule, LayoutMode, LayoutSettings, VirtualWorkspaceSettings, WorkspaceSelector,
 };
 use crate::common::log::trace_misc;
-use crate::layout_engine::systems::LayoutSystemKind;
 use crate::layout_engine::Direction;
+use crate::layout_engine::systems::LayoutSystemKind;
 use crate::sys::app::pid_t;
 use crate::sys::geometry::CGRectDef;
 use crate::sys::screen::SpaceId;
@@ -87,9 +87,9 @@ impl VirtualWorkspace {
 
     pub fn create_layout_system(mode: LayoutMode, settings: &LayoutSettings) -> LayoutSystemKind {
         match mode {
-            LayoutMode::Traditional => {
-                LayoutSystemKind::Traditional(crate::layout_engine::systems::TraditionalLayoutSystem::default())
-            }
+            LayoutMode::Traditional => LayoutSystemKind::Traditional(
+                crate::layout_engine::systems::TraditionalLayoutSystem::default(),
+            ),
             LayoutMode::Bsp => {
                 LayoutSystemKind::Bsp(crate::layout_engine::systems::BspLayoutSystem::default())
             }
@@ -180,7 +180,10 @@ impl VirtualWorkspaceManager {
         Self::new_with_config(&VirtualWorkspaceSettings::default(), &LayoutSettings::default())
     }
 
-    pub fn new_with_rules(app_rules: Vec<AppWorkspaceRule>, layout_settings: LayoutSettings) -> Self {
+    pub fn new_with_rules(
+        app_rules: Vec<AppWorkspaceRule>,
+        layout_settings: LayoutSettings,
+    ) -> Self {
         let mut cfg = VirtualWorkspaceSettings::default();
         cfg.app_rules = app_rules;
         Self::new_with_config(&cfg, &layout_settings)
@@ -398,7 +401,11 @@ impl VirtualWorkspaceManager {
         name: Option<String>,
     ) -> Result<VirtualWorkspaceId, WorkspaceError> {
         self.ensure_space_initialized(space);
-        let count = self.workspaces_by_space.get(&space).map(|v: &Vec<VirtualWorkspaceId>| v.len()).unwrap_or(0);
+        let count = self
+            .workspaces_by_space
+            .get(&space)
+            .map(|v: &Vec<VirtualWorkspaceId>| v.len())
+            .unwrap_or(0);
         if count >= self.max_workspaces {
             return Err(WorkspaceError::InconsistentState(format!(
                 "Maximum workspace limit ({}) reached for space {:?}",
@@ -412,7 +419,11 @@ impl VirtualWorkspaceManager {
             name
         });
 
-        let idx = self.workspaces_by_space.get(&space).map(|v: &Vec<VirtualWorkspaceId>| v.len()).unwrap_or(0);
+        let idx = self
+            .workspaces_by_space
+            .get(&space)
+            .map(|v: &Vec<VirtualWorkspaceId>| v.len())
+            .unwrap_or(0);
         let mode = self.resolve_layout_mode_for_workspace(idx, &name);
 
         let workspace = VirtualWorkspace::new(name, space, mode, &self.layout_settings);
@@ -619,7 +630,11 @@ impl VirtualWorkspaceManager {
 
     pub fn workspace_for_window_any(&self, window_id: WindowId) -> Option<VirtualWorkspaceId> {
         self.window_to_workspace.iter().find_map(|((_, wid), ws_id)| {
-            if *wid == window_id { Some(*ws_id) } else { None }
+            if *wid == window_id {
+                Some(*ws_id)
+            } else {
+                None
+            }
         })
     }
 
@@ -987,7 +1002,12 @@ impl VirtualWorkspaceManager {
             self.last_rule_decision.get(&(space, window_id)).copied().unwrap_or(false);
 
         self.ensure_space_initialized(space);
-        if self.workspaces_by_space.get(&space).map(|v: &Vec<VirtualWorkspaceId>| v.is_empty()).unwrap_or(true) {
+        if self
+            .workspaces_by_space
+            .get(&space)
+            .map(|v: &Vec<VirtualWorkspaceId>| v.is_empty())
+            .unwrap_or(true)
+        {
             return Err(WorkspaceError::NoWorkspacesAvailable);
         }
 
@@ -1023,7 +1043,11 @@ impl VirtualWorkspaceManager {
                 };
 
                 if let Some(workspace_idx) = maybe_idx {
-                    let len = self.workspaces_by_space.get(&space).map(|v: &Vec<VirtualWorkspaceId>| v.len()).unwrap_or(0);
+                    let len = self
+                        .workspaces_by_space
+                        .get(&space)
+                        .map(|v: &Vec<VirtualWorkspaceId>| v.len())
+                        .unwrap_or(0);
                     if workspace_idx >= len {
                         tracing::warn!(
                             "App rule references non-existent workspace index {}, falling back to active workspace",
@@ -1501,7 +1525,8 @@ mod tests {
         settings.default_workspace_count = 5;
         settings.default_workspace = 3;
 
-        let mut manager = VirtualWorkspaceManager::new_with_config(&settings, &LayoutSettings::default());
+        let mut manager =
+            VirtualWorkspaceManager::new_with_config(&settings, &LayoutSettings::default());
 
         let space = SpaceId::new(42);
         let workspaces = manager.list_workspaces(space);
@@ -1685,7 +1710,8 @@ mod tests {
             },
         ];
 
-        let mut manager = VirtualWorkspaceManager::new_with_config(&settings, &LayoutSettings::default());
+        let mut manager =
+            VirtualWorkspaceManager::new_with_config(&settings, &LayoutSettings::default());
 
         // 1. Floating persistence via app_id (case-insensitive)
         let w_float = WindowId::new(10, 1);

--- a/src/model/virtual_workspace.rs
+++ b/src/model/virtual_workspace.rs
@@ -6,8 +6,11 @@ use tracing::{error, warn};
 
 use crate::actor::app::WindowId;
 use crate::common::collections::{HashMap, HashSet};
-use crate::common::config::{AppWorkspaceRule, VirtualWorkspaceSettings, WorkspaceSelector};
+use crate::common::config::{
+    AppWorkspaceRule, LayoutMode, LayoutSettings, VirtualWorkspaceSettings, WorkspaceSelector,
+};
 use crate::common::log::trace_misc;
+use crate::layout_engine::systems::LayoutSystemKind;
 use crate::layout_engine::Direction;
 use crate::sys::app::pid_t;
 use crate::sys::geometry::CGRectDef;
@@ -53,21 +56,51 @@ pub enum AppRuleResult {
     Unmanaged,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct VirtualWorkspace {
     pub name: String,
     pub space: SpaceId,
     windows: HashSet<WindowId>,
     last_focused: Option<WindowId>,
+    pub layout_system: LayoutSystemKind,
+    pub layout_mode: LayoutMode,
 }
 
 impl VirtualWorkspace {
-    fn new(name: String, space: SpaceId) -> Self {
+    fn new(name: String, space: SpaceId, mode: LayoutMode, settings: &LayoutSettings) -> Self {
+        let layout_system = Self::create_layout_system(mode, settings);
         Self {
             name,
             space,
             windows: HashSet::default(),
             last_focused: None,
+            layout_system,
+            layout_mode: mode,
+        }
+    }
+
+    pub fn tree(&self) -> &LayoutSystemKind { &self.layout_system }
+
+    pub fn tree_mut(&mut self) -> &mut LayoutSystemKind { &mut self.layout_system }
+
+    pub fn layout_mode(&self) -> LayoutMode { self.layout_mode }
+
+    pub fn create_layout_system(mode: LayoutMode, settings: &LayoutSettings) -> LayoutSystemKind {
+        match mode {
+            LayoutMode::Traditional => {
+                LayoutSystemKind::Traditional(crate::layout_engine::systems::TraditionalLayoutSystem::default())
+            }
+            LayoutMode::Bsp => {
+                LayoutSystemKind::Bsp(crate::layout_engine::systems::BspLayoutSystem::default())
+            }
+            LayoutMode::MasterStack => LayoutSystemKind::MasterStack(
+                crate::layout_engine::systems::MasterStackLayoutSystem::new(
+                    settings.master_stack.clone(),
+                ),
+            ),
+            LayoutMode::Scrolling => LayoutSystemKind::Scrolling(
+                crate::layout_engine::systems::ScrollingLayoutSystem::new(&settings.scrolling),
+            ),
         }
     }
 
@@ -105,7 +138,7 @@ impl Default for HideCorner {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct VirtualWorkspaceManager {
-    workspaces: SlotMap<VirtualWorkspaceId, VirtualWorkspace>,
+    pub(crate) workspaces: SlotMap<VirtualWorkspaceId, VirtualWorkspace>,
     workspaces_by_space: HashMap<SpaceId, Vec<VirtualWorkspaceId>>,
     pub active_workspace_per_space:
         HashMap<SpaceId, (Option<VirtualWorkspaceId>, VirtualWorkspaceId)>,
@@ -129,7 +162,13 @@ pub struct VirtualWorkspaceManager {
     #[serde(skip)]
     default_workspace: usize,
     #[serde(skip)]
-    workspace_auto_back_and_forth: bool,
+    pub workspace_auto_back_and_forth: bool,
+    #[serde(skip)]
+    pub workspace_rules: Vec<crate::common::config::WorkspaceLayoutRule>,
+    #[serde(skip)]
+    pub default_layout_mode: LayoutMode,
+    #[serde(skip)]
+    pub layout_settings: LayoutSettings,
 }
 
 impl Default for VirtualWorkspaceManager {
@@ -137,15 +176,20 @@ impl Default for VirtualWorkspaceManager {
 }
 
 impl VirtualWorkspaceManager {
-    pub fn new() -> Self { Self::new_with_config(&VirtualWorkspaceSettings::default()) }
-
-    pub fn new_with_rules(app_rules: Vec<AppWorkspaceRule>) -> Self {
-        let mut cfg = VirtualWorkspaceSettings::default();
-        cfg.app_rules = app_rules;
-        Self::new_with_config(&cfg)
+    pub fn new() -> Self {
+        Self::new_with_config(&VirtualWorkspaceSettings::default(), &LayoutSettings::default())
     }
 
-    pub fn new_with_config(config: &VirtualWorkspaceSettings) -> Self {
+    pub fn new_with_rules(app_rules: Vec<AppWorkspaceRule>, layout_settings: LayoutSettings) -> Self {
+        let mut cfg = VirtualWorkspaceSettings::default();
+        cfg.app_rules = app_rules;
+        Self::new_with_config(&cfg, &layout_settings)
+    }
+
+    pub fn new_with_config(
+        config: &VirtualWorkspaceSettings,
+        layout_settings: &LayoutSettings,
+    ) -> Self {
         let max_workspaces = 32;
         let target_count = config.default_workspace_count.max(1).min(max_workspaces);
         let default_workspace = config.default_workspace.min(target_count - 1);
@@ -166,14 +210,24 @@ impl VirtualWorkspaceManager {
             default_workspace_names: config.workspace_names.clone(),
             default_workspace,
             workspace_auto_back_and_forth: config.workspace_auto_back_and_forth,
+            workspace_rules: config.workspace_rules.clone(),
+            default_layout_mode: layout_settings.mode,
+            layout_settings: layout_settings.clone(),
         };
 
         manager.rebuild_app_rule_regex_cache();
         manager
     }
 
-    pub fn update_settings(&mut self, config: &VirtualWorkspaceSettings) {
+    pub fn update_settings(
+        &mut self,
+        config: &VirtualWorkspaceSettings,
+        layout_settings: &LayoutSettings,
+    ) {
         self.app_rules = config.app_rules.clone();
+        self.workspace_rules = config.workspace_rules.clone();
+        self.default_layout_mode = layout_settings.mode;
+        self.layout_settings = layout_settings.clone();
         self.default_workspace_count = config.default_workspace_count;
         self.default_workspace_names = config.workspace_names.clone();
         self.workspace_auto_back_and_forth = config.workspace_auto_back_and_forth;
@@ -182,9 +236,10 @@ impl VirtualWorkspaceManager {
         let target_count = self.default_workspace_count.max(1).min(self.max_workspaces);
         self.default_workspace = config.default_workspace.min(target_count - 1);
 
-        for (space, ids) in self.workspaces_by_space.iter_mut() {
-            while ids.len() < target_count {
-                let idx = ids.len();
+        let spaces: Vec<SpaceId> = self.workspaces_by_space.keys().copied().collect();
+        for space in spaces {
+            while self.workspaces_by_space.get(&space).unwrap().len() < target_count {
+                let idx = self.workspaces_by_space.get(&space).unwrap().len();
                 let name = if let Some(n) = self.default_workspace_names.get(idx) {
                     n.clone()
                 } else {
@@ -192,9 +247,11 @@ impl VirtualWorkspaceManager {
                     self.workspace_counter += 1;
                     name
                 };
-                let ws = VirtualWorkspace::new(name, *space);
+
+                let mode = self.resolve_layout_mode_for_workspace(idx, &name);
+                let ws = VirtualWorkspace::new(name, space, mode, &self.layout_settings);
                 let id = self.workspaces.insert(ws);
-                ids.push(id);
+                self.workspaces_by_space.get_mut(&space).unwrap().push(id);
             }
         }
     }
@@ -233,7 +290,9 @@ impl VirtualWorkspaceManager {
                 .get(i)
                 .cloned()
                 .unwrap_or_else(|| format!("Workspace {}", i + 1));
-            let ws = VirtualWorkspace::new(name, space);
+
+            let mode = self.resolve_layout_mode_for_workspace(i, &name);
+            let ws = VirtualWorkspace::new(name, space, mode, &self.layout_settings);
             let id = self.workspaces.insert(ws);
             ids.push(id);
         }
@@ -243,6 +302,19 @@ impl VirtualWorkspaceManager {
         if let Some(&default_id) = ids.get(default_idx) {
             self.active_workspace_per_space.insert(space, (None, default_id));
         }
+    }
+
+    fn resolve_layout_mode_for_workspace(&self, index: usize, name: &str) -> LayoutMode {
+        // Check workspace_rules (last matching rule wins, like app_rules)
+        for rule in self.workspace_rules.iter().rev() {
+            match &rule.workspace {
+                WorkspaceSelector::Index(idx) if *idx == index => return rule.layout,
+                WorkspaceSelector::Name(n) if n == name => return rule.layout,
+                _ => continue,
+            }
+        }
+        // Fall back to global default
+        self.default_layout_mode
     }
 
     pub fn remap_space(&mut self, old_space: SpaceId, new_space: SpaceId) {
@@ -326,7 +398,7 @@ impl VirtualWorkspaceManager {
         name: Option<String>,
     ) -> Result<VirtualWorkspaceId, WorkspaceError> {
         self.ensure_space_initialized(space);
-        let count = self.workspaces_by_space.get(&space).map(|v| v.len()).unwrap_or(0);
+        let count = self.workspaces_by_space.get(&space).map(|v: &Vec<VirtualWorkspaceId>| v.len()).unwrap_or(0);
         if count >= self.max_workspaces {
             return Err(WorkspaceError::InconsistentState(format!(
                 "Maximum workspace limit ({}) reached for space {:?}",
@@ -340,7 +412,10 @@ impl VirtualWorkspaceManager {
             name
         });
 
-        let workspace = VirtualWorkspace::new(name, space);
+        let idx = self.workspaces_by_space.get(&space).map(|v: &Vec<VirtualWorkspaceId>| v.len()).unwrap_or(0);
+        let mode = self.resolve_layout_mode_for_workspace(idx, &name);
+
+        let workspace = VirtualWorkspace::new(name, space, mode, &self.layout_settings);
         let workspace_id = self.workspaces.insert(workspace);
         self.workspaces_by_space.entry(space).or_default().push(workspace_id);
 
@@ -540,6 +615,12 @@ impl VirtualWorkspaceManager {
         window_id: WindowId,
     ) -> Option<VirtualWorkspaceId> {
         self.window_to_workspace.get(&(space, window_id)).copied()
+    }
+
+    pub fn workspace_for_window_any(&self, window_id: WindowId) -> Option<VirtualWorkspaceId> {
+        self.window_to_workspace.iter().find_map(|((_, wid), ws_id)| {
+            if *wid == window_id { Some(*ws_id) } else { None }
+        })
     }
 
     pub fn set_last_rule_decision(&mut self, space: SpaceId, window_id: WindowId, value: bool) {
@@ -906,7 +987,7 @@ impl VirtualWorkspaceManager {
             self.last_rule_decision.get(&(space, window_id)).copied().unwrap_or(false);
 
         self.ensure_space_initialized(space);
-        if self.workspaces_by_space.get(&space).map(|v| v.is_empty()).unwrap_or(true) {
+        if self.workspaces_by_space.get(&space).map(|v: &Vec<VirtualWorkspaceId>| v.is_empty()).unwrap_or(true) {
             return Err(WorkspaceError::NoWorkspacesAvailable);
         }
 
@@ -942,7 +1023,7 @@ impl VirtualWorkspaceManager {
                 };
 
                 if let Some(workspace_idx) = maybe_idx {
-                    let len = self.workspaces_by_space.get(&space).map(|v| v.len()).unwrap_or(0);
+                    let len = self.workspaces_by_space.get(&space).map(|v: &Vec<VirtualWorkspaceId>| v.len()).unwrap_or(0);
                     if workspace_idx >= len {
                         tracing::warn!(
                             "App rule references non-existent workspace index {}, falling back to active workspace",
@@ -1043,7 +1124,7 @@ impl VirtualWorkspaceManager {
         let first_id = self
             .workspaces_by_space
             .get(&space)
-            .and_then(|v| v.first().copied())
+            .and_then(|v: &Vec<VirtualWorkspaceId>| v.first().copied())
             .ok_or_else(|| {
                 WorkspaceError::InconsistentState("No workspaces for space".to_string())
             })?;
@@ -1420,7 +1501,7 @@ mod tests {
         settings.default_workspace_count = 5;
         settings.default_workspace = 3;
 
-        let mut manager = VirtualWorkspaceManager::new_with_config(&settings);
+        let mut manager = VirtualWorkspaceManager::new_with_config(&settings, &LayoutSettings::default());
 
         let space = SpaceId::new(42);
         let workspaces = manager.list_workspaces(space);
@@ -1604,7 +1685,7 @@ mod tests {
             },
         ];
 
-        let mut manager = VirtualWorkspaceManager::new_with_config(&settings);
+        let mut manager = VirtualWorkspaceManager::new_with_config(&settings, &LayoutSettings::default());
 
         // 1. Floating persistence via app_id (case-insensitive)
         let w_float = WindowId::new(10, 1);

--- a/src/model/virtual_workspace.rs
+++ b/src/model/virtual_workspace.rs
@@ -652,6 +652,16 @@ impl VirtualWorkspaceManager {
         })
     }
 
+    pub fn workspaces_for_window(&self, window_id: WindowId) -> Vec<VirtualWorkspaceId> {
+        let mut ids = HashSet::default();
+        for ((_, wid), ws_id) in self.window_to_workspace.iter() {
+            if *wid == window_id {
+                ids.insert(*ws_id);
+            }
+        }
+        ids.into_iter().collect()
+    }
+
     pub fn set_last_rule_decision(&mut self, space: SpaceId, window_id: WindowId, value: bool) {
         self.last_rule_decision.insert((space, window_id), value);
     }

--- a/src/model/virtual_workspace.rs
+++ b/src/model/virtual_workspace.rs
@@ -62,8 +62,14 @@ pub struct VirtualWorkspace {
     pub space: SpaceId,
     windows: HashSet<WindowId>,
     last_focused: Option<WindowId>,
+    #[serde(default = "default_layout_system_kind")]
     pub layout_system: LayoutSystemKind,
+    #[serde(default)]
     pub layout_mode: LayoutMode,
+}
+
+fn default_layout_system_kind() -> LayoutSystemKind {
+    VirtualWorkspace::create_layout_system(LayoutMode::default(), &LayoutSettings::default())
 }
 
 impl VirtualWorkspace {
@@ -318,6 +324,14 @@ impl VirtualWorkspaceManager {
         }
         // Fall back to global default
         self.default_layout_mode
+    }
+
+    pub fn desired_layout_mode_for_workspace(&self, index: usize, name: &str) -> LayoutMode {
+        self.resolve_layout_mode_for_workspace(index, name)
+    }
+
+    pub fn initialized_spaces(&self) -> Vec<SpaceId> {
+        self.workspaces_by_space.keys().copied().collect()
     }
 
     pub fn remap_space(&mut self, old_space: SpaceId, new_space: SpaceId) {


### PR DESCRIPTION
now that the scrolling layout has been merged i am feeling pretty good about the variety of layout engines offered. the next step is to make things be configurable per workspace.

some negotiation will have to be done regarding breaking changes as this will result in significant and likely breaking changes. 

- [x] establish a workspace_rules system like app_rules
- [x] right now workspace switch gestures and scrolling layout gestures are exclusive, only one can run at once. now that we can have one workspace be scrolling and others be traditional src/actor/event_tap needs to be aware of the layout type that the current workspace is: how we want to establish this, i am not sure...
- [ ] maybe some kind of indicator?
- [x] commands to switch layout, load a saved layout, etc
- [ ] swap layout between two workspaces (maybe windows too)
- [ ] specify workspace layout per display/etc 
- [ ] allow * in workspace_rules to match all displays