### PR TITLE
feat: smart alignment of first and last windows for scrolling layout + center + anchored

### DIFF
--- a/src/layout_engine/systems/scrolling.rs
+++ b/src/layout_engine/systems/scrolling.rs
@@ -604,7 +604,16 @@ impl LayoutSystem for ScrollingLayoutSystem {
             match self.settings.alignment {
                 crate::common::config::ScrollingAlignment::Left => tiling.origin.x,
                 crate::common::config::ScrollingAlignment::Center => {
-                    tiling.origin.x + (tiling.size.width - selected_width) / 2.0
+                    let is_first = selected_col_idx == 0;
+                    let is_last = selected_col_idx == state.columns.len().saturating_sub(1);
+
+                    if is_first {
+                        tiling.origin.x
+                    } else if is_last {
+                        tiling.origin.x + tiling.size.width - selected_width
+                    } else {
+                        tiling.origin.x + (tiling.size.width - selected_width) / 2.0 // Center others
+                    }
                 }
                 crate::common::config::ScrollingAlignment::Right => {
                     tiling.origin.x + tiling.size.width - selected_width


### PR DESCRIPTION
Small PR to improve the behaviour of the scrolling layout when mode = "scrolling", alignment = "center" and focus_navigation_style = "anchored" .

This change left aligns the first window and right aligns the last window to prevent wasted space.