### PR TITLE
feat: native tabs support

### DIFF
--- a/src/actor/reactor/managers.rs
+++ b/src/actor/reactor/managers.rs
@@ -336,4 +336,5 @@ pub struct WindowServerInfoManager {
 pub struct PendingSpaceChangeManager {
     pub pending_space_change: Option<PendingSpaceChange>,
     pub topology_relayout_pending: bool,
+    pub last_space_change_signature: Option<(Vec<Option<SpaceId>>, Vec<WindowServerId>)>,
 }


### PR DESCRIPTION
An initial attempt to support native macOS tabs (addressing #36).

Introduces a tab-group identity as one logical Rift window. Uses AX tab-groups, with fallback on window server IDs.

Still a bit rough around the edges, but keen to see if we can progress towards a solution for this.