### PR TITLE
feat: implement bringing windows to workspaces

### DIFF
--- a/rift.default.toml
+++ b/rift.default.toml
@@ -356,6 +356,7 @@ comb1 = "Alt + Shift"
 # - prev_workspace = true|false (optional skip-empty override)
 # - switch_to_workspace = N
 # - move_window_to_workspace = N / move_window_to_workspace = { workspace = N, window_id = 123 } (optional window id)
+# - bring_window_to_workspace = N (moves window and switches workspace at the same time)
 # - create_workspace
 # - switch_to_last_workspace
 # - set_workspace_layout = { mode = "traditional"|"bsp"|"master_stack"|"scrolling" } (active workspace)

--- a/src/actor/reactor/events/command.rs
+++ b/src/actor/reactor/events/command.rs
@@ -98,6 +98,16 @@ impl CommandEventHandler {
                     EventResponse::default()
                 }
             }
+            LayoutCommand::BringWindowToWorkspace { .. } => {
+                if let Some(space) = command_space {
+                    reactor
+                        .layout_manager
+                        .layout_engine
+                        .handle_virtual_workspace_command(space, &cmd)
+                } else {
+                    EventResponse::default()
+                }
+            }
             _ => {
                 let (visible_spaces, visible_space_centers) =
                     reactor.visible_spaces_for_layout(false);


### PR DESCRIPTION
At present there isn't a way (afaik) to send a window to workspace x, and bring your focus to that same workspace with one keybind, like a lot of other WMs have. I implemented a separate bring_window_to_workspace command, so the user can choose between just moving a window to a workspace with move_window_to_workspace, moving a window + switching to a workspace, or having keybinds for both if they so desire. The wiki should also be updated to mention the new command.

![demo](https://github.com/user-attachments/assets/19680bdf-ce6d-4375-b112-92137d51cb0f)
