### PR TITLE
fix: stabilize cross-display drag snapback

### DIFF
--- a/src/actor/reactor.rs
+++ b/src/actor/reactor.rs
@@ -1524,14 +1524,19 @@ impl Reactor {
         frame: &CGRect,
         window_server_id: Option<WindowServerId>,
     ) -> Option<SpaceId> {
-        if let Some(space) = window_server_id.and_then(crate::sys::window_server::window_space)
-            && (self.space_manager.screen_by_space(space).is_some()
-                || crate::sys::window_server::space_is_user(space.get()))
-        {
+        if let Some(space) = self.best_space_for_frame(frame) {
             return Some(space);
         }
 
-        self.best_space_for_frame(frame)
+        if let Some(space) = window_server_id.and_then(crate::sys::window_server::window_space) {
+            if self.space_manager.screen_by_space(space).is_some()
+                || crate::sys::window_server::space_is_user(space.get())
+            {
+                return Some(space);
+            }
+        }
+
+        None
     }
 
     fn best_space_for_frame(&self, frame: &CGRect) -> Option<SpaceId> {

--- a/src/actor/reactor/animation.rs
+++ b/src/actor/reactor/animation.rs
@@ -182,8 +182,16 @@ impl AnimationManager {
                         if target_frame.same_as(current_frame) {
                             continue;
                         }
-                        any_frame_changed = true;
                         let wsid = window.info.sys_id.unwrap();
+                        if reactor
+                            .transaction_manager
+                            .get_target_frame(wsid)
+                            .is_some_and(|pending| pending.same_as(target_frame))
+                        {
+                            trace!(?wid, ?target_frame, "Skipping redundant layout request");
+                            continue;
+                        }
+                        any_frame_changed = true;
                         let txid = reactor.transaction_manager.generate_next_txid(wsid);
                         (current_frame, Some(wsid), txid)
                     }
@@ -277,6 +285,16 @@ impl AnimationManager {
             let current_frame = window.frame_monotonic;
             if target_frame.same_as(current_frame) {
                 continue;
+            }
+            if let Some(wsid) = window.info.sys_id {
+                if reactor
+                    .transaction_manager
+                    .get_target_frame(wsid)
+                    .is_some_and(|pending| pending.same_as(target_frame))
+                {
+                    trace!(?wid, ?target_frame, "Skipping redundant instant layout request");
+                    continue;
+                }
             }
             any_frame_changed = true;
             trace!(


### PR DESCRIPTION
I have an issue when dragging a window to an external screen, the window basically starts snapping back and forth very fast until I kill rift. 

To fix it, I had to : 
- Make space classification geometry-first in reactor.
- Coalesce duplicate pending layout targets in animation/instant layout update paths.