### PR TITLE
Fix panic when animation_fps is set to 0.0

### DIFF
--- a/src/actor/reactor/animation.rs
+++ b/src/actor/reactor/animation.rs
@@ -34,6 +34,13 @@ pub struct Animation<'a> {
 
 impl<'a> Animation<'a> {
     pub fn new(fps: f64, duration: f64, _: AnimationEasing) -> Self {
+        // When fps is 0 (or negative), use the display's native refresh rate.
+        // Fall back to 60 Hz if the rate cannot be determined.
+        let fps = if fps > 0.0 {
+            fps
+        } else {
+            crate::sys::display_link::get_display_refresh_rate().unwrap_or(60.0)
+        };
         let interval = Duration::from_secs_f64(1.0 / fps);
         // let now = unsafe { CFAbsoluteTimeGetCurrent() };
         let now = Instant::now();


### PR DESCRIPTION
## Summary
- handle `animation_fps = 0.0` without panicking
- use the display refresh rate when the config leaves fps at zero
- fall back to 60 Hz if the refresh rate cannot be determined

## Why
`Animation::new` currently computes `1.0 / fps` directly. When `fps` is `0.0`, that produces infinity and panics during `Duration::from_secs_f64(...)`.

The config comment already implies that `0.0` should mean "use the display refresh rate", so this makes the implementation match the existing configuration contract.

## Verification
- `cargo build --profile release-fast --bin rift`
- `cargo test animation -- --nocapture`
