### PR TITLE
fix: stackline appears behind floating window (#279)

### DIFF
--- a/src/actor/event_tap.rs
+++ b/src/actor/event_tap.rs
@@ -70,6 +70,7 @@ pub struct EventTap {
     hotkeys: RefCell<HashMap<Hotkey, Vec<WmCommand>>>,
     wm_sender: Option<wm_controller::Sender>,
     stack_line_tx: Option<stack_line::Sender>,
+    stack_line_hit_rects: Option<stack_line::SharedHitRects>,
 }
 
 struct State {
@@ -263,6 +264,22 @@ impl EventTap {
         state.stack_line_enabled && self.stack_line_tx.is_some()
     }
 
+    /// Check whether `point` falls inside any active stack-line indicator
+    /// hit-rect and the indicator is not occluded by an external window.
+    fn point_hits_stack_line(&self, point: CGPoint) -> bool {
+        let Some(hit_rects) = &self.stack_line_hit_rects else {
+            return false;
+        };
+        let rects = hit_rects.borrow();
+        let geometrically_hit = rects.iter().any(|hr| {
+            point.x >= hr.frame.origin.x - hr.margin_x
+                && point.x < hr.frame.origin.x + hr.frame.size.width + hr.margin_x
+                && point.y >= hr.frame.origin.y - hr.margin_y
+                && point.y < hr.frame.origin.y + hr.frame.size.height + hr.margin_y
+        });
+        geometrically_hit && !window_server::is_point_occluded_by_external_window(point)
+    }
+
     #[inline]
     fn focus_follows_mouse_handler_enabled(state: &State) -> bool {
         state.focus_follows_mouse_config_enabled && state.focus_follows_mouse_enabled
@@ -372,6 +389,7 @@ impl EventTap {
         requests_rx: Receiver,
         wm_sender: Option<wm_controller::Sender>,
         stack_line_tx: Option<stack_line::Sender>,
+        stack_line_hit_rects: Option<stack_line::SharedHitRects>,
     ) -> Self {
         let disable_hotkey = config
             .settings
@@ -408,6 +426,7 @@ impl EventTap {
             hotkeys: RefCell::new(HashMap::default()),
             wm_sender,
             stack_line_tx,
+            stack_line_hit_rects,
         }
     }
 
@@ -651,6 +670,13 @@ impl EventTap {
                 if let Some(tx) = &self.stack_line_tx {
                     let loc = CGEvent::location(Some(event));
                     let _ = tx.try_send(stack_line::Event::MouseDown(loc));
+
+                    // Suppress the event when the click lands on a visible
+                    // stack-line indicator so it does not propagate to
+                    // desktop widgets behind the indicator.
+                    if self.point_hits_stack_line(loc) {
+                        return false;
+                    }
                 }
             }
             CGEventType::LeftMouseDragged | CGEventType::RightMouseDragged => {

--- a/src/actor/event_tap.rs
+++ b/src/actor/event_tap.rs
@@ -32,6 +32,7 @@ use crate::sys::hotkey::{
 use crate::sys::screen::{CoordinateConverter, SpaceId};
 use crate::sys::window_server::{self, WindowServerId, window_level};
 use crate::sys::{haptics, power};
+use crate::ui::stack_line::point_hits_indicator_frame;
 
 // Window levels can change for transient UI windows; cache briefly to reduce
 // query overhead without pinning stale values for long.
@@ -262,22 +263,6 @@ impl EventTap {
     #[inline]
     fn stack_line_hover_enabled(&self, state: &State) -> bool {
         state.stack_line_enabled && self.stack_line_tx.is_some()
-    }
-
-    /// Check whether `point` falls inside any active stack-line indicator
-    /// hit-rect and the indicator is not occluded by an external window.
-    fn point_hits_stack_line(&self, point: CGPoint) -> bool {
-        let Some(hit_rects) = &self.stack_line_hit_rects else {
-            return false;
-        };
-        let rects = hit_rects.borrow();
-        let geometrically_hit = rects.iter().any(|hr| {
-            point.x >= hr.frame.origin.x - hr.margin_x
-                && point.x < hr.frame.origin.x + hr.frame.size.width + hr.margin_x
-                && point.y >= hr.frame.origin.y - hr.margin_y
-                && point.y < hr.frame.origin.y + hr.frame.size.height + hr.margin_y
-        });
-        geometrically_hit && !window_server::is_point_occluded_by_external_window(point)
     }
 
     #[inline]
@@ -674,7 +659,19 @@ impl EventTap {
                     // stack-line indicators. Only forward the click and
                     // suppress propagation when it lands on a visible,
                     // non-occluded indicator.
-                    if self.point_hits_stack_line(loc) {
+                    let hits_stack_line = self
+                        .stack_line_hit_rects
+                        .as_ref()
+                        .map(|hit_rects| {
+                            hit_rects
+                                .borrow()
+                                .iter()
+                                .copied()
+                                .any(|frame| point_hits_indicator_frame(loc, frame))
+                        })
+                        .unwrap_or(false);
+                    if hits_stack_line && !window_server::is_point_occluded_by_external_window(loc)
+                    {
                         let _ = tx.try_send(stack_line::Event::MouseDown(loc));
                         return false;
                     }
@@ -722,7 +719,18 @@ impl EventTap {
                 if state.stack_line_enabled
                     && let Some(tx) = &self.stack_line_tx
                 {
-                    let hits = self.point_hits_stack_line(loc);
+                    let hits = self
+                        .stack_line_hit_rects
+                        .as_ref()
+                        .map(|hit_rects| {
+                            hit_rects
+                                .borrow()
+                                .iter()
+                                .copied()
+                                .any(|frame| point_hits_indicator_frame(loc, frame))
+                        })
+                        .unwrap_or(false)
+                        && !window_server::is_point_occluded_by_external_window(loc);
                     let _ = tx.try_send(stack_line::Event::MouseMoved {
                         point: loc,
                         hits_indicator: hits,

--- a/src/actor/event_tap.rs
+++ b/src/actor/event_tap.rs
@@ -669,12 +669,13 @@ impl EventTap {
 
                 if let Some(tx) = &self.stack_line_tx {
                     let loc = CGEvent::location(Some(event));
-                    let _ = tx.try_send(stack_line::Event::MouseDown(loc));
 
-                    // Suppress the event when the click lands on a visible
-                    // stack-line indicator so it does not propagate to
-                    // desktop widgets behind the indicator.
+                    // The event tap is the single source of hit-testing for
+                    // stack-line indicators. Only forward the click and
+                    // suppress propagation when it lands on a visible,
+                    // non-occluded indicator.
                     if self.point_hits_stack_line(loc) {
+                        let _ = tx.try_send(stack_line::Event::MouseDown(loc));
                         return false;
                     }
                 }
@@ -721,7 +722,11 @@ impl EventTap {
                 if state.stack_line_enabled
                     && let Some(tx) = &self.stack_line_tx
                 {
-                    let _ = tx.try_send(stack_line::Event::MouseMoved(loc));
+                    let hits = self.point_hits_stack_line(loc);
+                    let _ = tx.try_send(stack_line::Event::MouseMoved {
+                        point: loc,
+                        hits_indicator: hits,
+                    });
                 }
 
                 // ffm

--- a/src/actor/stack_line.rs
+++ b/src/actor/stack_line.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::collections::hash_map::Entry;
 use std::rc::Rc;
 
@@ -14,7 +15,23 @@ use crate::common::config::{Config, HorizontalPlacement, VerticalPlacement};
 use crate::layout_engine::LayoutKind;
 use crate::model::tree::NodeId;
 use crate::sys::screen::{CoordinateConverter, SpaceId};
+use crate::sys::window_server;
 use crate::ui::stack_line::{GroupDisplayData, GroupIndicatorWindow, GroupKind, IndicatorConfig};
+
+/// Shared indicator hit-rect state readable from the event tap callback.
+///
+/// Each entry is the screen-space frame of an active indicator together with
+/// the hit-test margins used for that indicator.
+pub type SharedHitRects = Rc<RefCell<Vec<HitRect>>>;
+
+#[derive(Clone, Copy)]
+pub struct HitRect {
+    pub frame: CGRect,
+    pub margin_x: f64,
+    pub margin_y: f64,
+}
+
+pub fn new_shared_hit_rects() -> SharedHitRects { Rc::new(RefCell::new(Vec::new())) }
 
 #[derive(Debug, Clone)]
 pub struct GroupInfo {
@@ -52,6 +69,7 @@ pub struct StackLine {
     coordinate_converter: CoordinateConverter,
     group_sigs_by_space: HashMap<SpaceId, Vec<GroupSig>>,
     cursor_over_indicator: bool,
+    shared_hit_rects: SharedHitRects,
 }
 
 pub type Sender = actor::Sender<Event>;
@@ -64,6 +82,7 @@ impl StackLine {
         mtm: MainThreadMarker,
         reactor_tx: reactor::Sender,
         coordinate_converter: CoordinateConverter,
+        shared_hit_rects: SharedHitRects,
     ) -> Self {
         Self {
             config,
@@ -74,6 +93,7 @@ impl StackLine {
             coordinate_converter,
             group_sigs_by_space: HashMap::default(),
             cursor_over_indicator: false,
+            shared_hit_rects,
         }
     }
 
@@ -89,6 +109,25 @@ impl StackLine {
     }
 
     fn is_enabled(&self) -> bool { self.config.settings.ui.stack_line.enabled }
+
+    /// Publish the current indicator frames so the event tap can suppress
+    /// clicks that land on a visible, non-occluded indicator.
+    fn sync_shared_hit_rects(&self) {
+        let mut rects = self.shared_hit_rects.borrow_mut();
+        rects.clear();
+        if !self.is_enabled() {
+            return;
+        }
+        for indicator in self.indicators.values() {
+            let frame = indicator.frame();
+            let (mx, my) = hit_margins(frame, indicator.recommended_thickness());
+            rects.push(HitRect {
+                frame,
+                margin_x: mx,
+                margin_y: my,
+            });
+        }
+    }
 
     #[instrument(name = "stack_line::handle_event", skip(self))]
     fn handle_event(&mut self, event: Event) {
@@ -116,12 +155,14 @@ impl StackLine {
                     groups,
                     active_workspace_for_space_has_fullscreen,
                 );
+                self.sync_shared_hit_rects();
             }
             Event::ScreenParametersChanged(converter) => {
                 self.handle_screen_parameters_changed(converter);
             }
             Event::ConfigUpdated(config) => {
                 self.handle_config_updated(config);
+                self.sync_shared_hit_rects();
             }
             Event::MouseDown(point) => {
                 self.handle_mouse_down(point);
@@ -244,6 +285,17 @@ impl StackLine {
             let (mx, my) = hit_margins(frame, indicator.recommended_thickness());
 
             if point_in_hit_area(screen_point, frame, mx, my) {
+                // The stack line window is ordered below normal windows, so an
+                // external window at this point would visually occlude the
+                // indicator. Ignore the click if another window is in front.
+                if window_server::is_point_occluded_by_external_window(screen_point) {
+                    tracing::trace!(
+                        ?node_id,
+                        "Ignoring stack line click: occluded by another window"
+                    );
+                    return;
+                }
+
                 let local_point =
                     CGPoint::new(screen_point.x - frame.origin.x, screen_point.y - frame.origin.y);
 
@@ -277,6 +329,7 @@ impl StackLine {
                 };
 
                 point_in_hit_area(screen_point, frame, mx, my)
+                    && !window_server::is_point_occluded_by_external_window(screen_point)
             })
         } else {
             false

--- a/src/actor/stack_line.rs
+++ b/src/actor/stack_line.rs
@@ -15,20 +15,12 @@ use crate::common::config::{Config, HorizontalPlacement, VerticalPlacement};
 use crate::layout_engine::LayoutKind;
 use crate::model::tree::NodeId;
 use crate::sys::screen::{CoordinateConverter, SpaceId};
-use crate::ui::stack_line::{GroupDisplayData, GroupIndicatorWindow, GroupKind, IndicatorConfig};
+use crate::ui::stack_line::{
+    GroupDisplayData, GroupIndicatorWindow, GroupKind, IndicatorConfig, point_hits_indicator_frame,
+};
 
 /// Shared indicator hit-rect state readable from the event tap callback.
-///
-/// Each entry is the screen-space frame of an active indicator together with
-/// the hit-test margins used for that indicator.
-pub type SharedHitRects = Rc<RefCell<Vec<HitRect>>>;
-
-#[derive(Clone, Copy)]
-pub struct HitRect {
-    pub frame: CGRect,
-    pub margin_x: f64,
-    pub margin_y: f64,
-}
+pub type SharedHitRects = Rc<RefCell<Vec<CGRect>>>;
 
 pub fn new_shared_hit_rects() -> SharedHitRects { Rc::new(RefCell::new(Vec::new())) }
 
@@ -59,7 +51,10 @@ pub enum Event {
     /// Cursor moved; `hits_indicator` is `true` when the event tap's
     /// hit-test (geometry + occlusion) determined the point is over an
     /// indicator.
-    MouseMoved { point: CGPoint, hits_indicator: bool },
+    MouseMoved {
+        point: CGPoint,
+        hits_indicator: bool,
+    },
 }
 
 pub struct StackLine {
@@ -123,13 +118,7 @@ impl StackLine {
             return;
         }
         for indicator in self.indicators.values() {
-            let frame = indicator.frame();
-            let (mx, my) = hit_margins(frame, indicator.recommended_thickness());
-            rects.push(HitRect {
-                frame,
-                margin_x: mx,
-                margin_y: my,
-            });
+            rects.push(indicator.frame());
         }
     }
 
@@ -288,9 +277,12 @@ impl StackLine {
         // non-occluded indicator. We only need to find the matching segment.
         for (&node_id, indicator) in &self.indicators {
             let frame = indicator.frame();
+            if !point_hits_indicator_frame(screen_point, frame) {
+                continue;
+            }
+
             let local_point =
                 CGPoint::new(screen_point.x - frame.origin.x, screen_point.y - frame.origin.y);
-
             if let Some(segment_index) = indicator.check_click(local_point) {
                 tracing::debug!(
                     ?node_id,
@@ -490,25 +482,6 @@ impl GroupSig {
             selected_index: g.selected_index,
             window_ids: g.window_ids.clone(),
         }
-    }
-}
-
-fn hit_margins(frame: CGRect, thickness: f64) -> (f64, f64) {
-    let base = (thickness * 0.25).clamp(1.0, 5.0);
-    let target_short = 14.0;
-
-    if frame.size.width < frame.size.height {
-        // vertical: widen hitbox more in X
-        let mx =
-            (base + ((target_short - frame.size.width as f64) * 0.5).max(0.0)).clamp(1.0, 10.0);
-        let my = base.clamp(1.0, 4.0);
-        (mx, my)
-    } else {
-        // horizontal: expand more in Y
-        let mx = base.clamp(1.0, 4.0);
-        let my =
-            (base + ((target_short - frame.size.height as f64) * 0.5).max(0.0)).clamp(1.0, 10.0);
-        (mx, my)
     }
 }
 

--- a/src/actor/stack_line.rs
+++ b/src/actor/stack_line.rs
@@ -15,7 +15,6 @@ use crate::common::config::{Config, HorizontalPlacement, VerticalPlacement};
 use crate::layout_engine::LayoutKind;
 use crate::model::tree::NodeId;
 use crate::sys::screen::{CoordinateConverter, SpaceId};
-use crate::sys::window_server;
 use crate::ui::stack_line::{GroupDisplayData, GroupIndicatorWindow, GroupKind, IndicatorConfig};
 
 /// Shared indicator hit-rect state readable from the event tap callback.
@@ -54,8 +53,13 @@ pub enum Event {
     },
     ScreenParametersChanged(CoordinateConverter),
     ConfigUpdated(Config),
+    /// A click that the event tap already confirmed lands on a visible,
+    /// non-occluded stack-line indicator.
     MouseDown(CGPoint),
-    MouseMoved(CGPoint),
+    /// Cursor moved; `hits_indicator` is `true` when the event tap's
+    /// hit-test (geometry + occlusion) determined the point is over an
+    /// indicator.
+    MouseMoved { point: CGPoint, hits_indicator: bool },
 }
 
 pub struct StackLine {
@@ -137,7 +141,7 @@ impl StackLine {
                 Event::ConfigUpdated(_)
                     | Event::ScreenParametersChanged(_)
                     | Event::MouseDown(_)
-                    | Event::MouseMoved(_)
+                    | Event::MouseMoved { .. }
             )
         {
             return;
@@ -167,8 +171,8 @@ impl StackLine {
             Event::MouseDown(point) => {
                 self.handle_mouse_down(point);
             }
-            Event::MouseMoved(point) => {
-                self.handle_mouse_moved(point);
+            Event::MouseMoved { point, hits_indicator } => {
+                self.handle_mouse_moved(point, hits_indicator);
             }
         }
     }
@@ -280,62 +284,29 @@ impl StackLine {
             return;
         }
 
+        // The event tap already verified that this click lands on a visible,
+        // non-occluded indicator. We only need to find the matching segment.
         for (&node_id, indicator) in &self.indicators {
             let frame = indicator.frame();
-            let (mx, my) = hit_margins(frame, indicator.recommended_thickness());
+            let local_point =
+                CGPoint::new(screen_point.x - frame.origin.x, screen_point.y - frame.origin.y);
 
-            if point_in_hit_area(screen_point, frame, mx, my) {
-                // The stack line window is ordered below normal windows, so an
-                // external window at this point would visually occlude the
-                // indicator. Ignore the click if another window is in front.
-                if window_server::is_point_occluded_by_external_window(screen_point) {
-                    tracing::trace!(
-                        ?node_id,
-                        "Ignoring stack line click: occluded by another window"
-                    );
-                    return;
-                }
-
-                let local_point =
-                    CGPoint::new(screen_point.x - frame.origin.x, screen_point.y - frame.origin.y);
-
-                if let Some(segment_index) = indicator.check_click(local_point) {
-                    tracing::debug!(
-                        ?node_id,
-                        segment_index,
-                        "Detected click on stack line indicator segment"
-                    );
-                    self.handle_indicator_clicked(node_id, segment_index);
-                    return;
-                }
+            if let Some(segment_index) = indicator.check_click(local_point) {
+                tracing::debug!(
+                    ?node_id,
+                    segment_index,
+                    "Detected click on stack line indicator segment"
+                );
+                self.handle_indicator_clicked(node_id, segment_index);
+                return;
             }
         }
     }
 
     // this is very hacky but we don't use nswindow so we have to roll this ourselves
-    fn handle_mouse_moved(&mut self, screen_point: CGPoint) {
-        let over_indicator = if self.is_enabled() {
-            self.indicators.values().any(|indicator| {
-                let frame = indicator.frame();
-                let (mx, my) = hit_margins(frame, indicator.recommended_thickness());
-                let enter_mul = 1.0;
-                let exit_mul = 0.65;
+    fn handle_mouse_moved(&mut self, _screen_point: CGPoint, hits_indicator: bool) {
+        let over_indicator = self.is_enabled() && hits_indicator;
 
-                // enter hitbox is larger than exit
-                let (mx, my) = if self.cursor_over_indicator {
-                    (mx * exit_mul, my * exit_mul)
-                } else {
-                    (mx * enter_mul, my * enter_mul)
-                };
-
-                point_in_hit_area(screen_point, frame, mx, my)
-                    && !window_server::is_point_occluded_by_external_window(screen_point)
-            })
-        } else {
-            false
-        };
-
-        // the hack
         if over_indicator != self.cursor_over_indicator {
             self.cursor_over_indicator = over_indicator;
             if over_indicator {
@@ -539,13 +510,6 @@ fn hit_margins(frame: CGRect, thickness: f64) -> (f64, f64) {
             (base + ((target_short - frame.size.height as f64) * 0.5).max(0.0)).clamp(1.0, 10.0);
         (mx, my)
     }
-}
-
-fn point_in_hit_area(point: CGPoint, frame: CGRect, mx: f64, my: f64) -> bool {
-    point.x >= frame.origin.x - mx
-        && point.x < frame.origin.x + frame.size.width + mx
-        && point.y >= frame.origin.y - my
-        && point.y < frame.origin.y + frame.size.height + my
 }
 
 #[cfg(test)]

--- a/src/actor/stack_line.rs
+++ b/src/actor/stack_line.rs
@@ -117,7 +117,7 @@ impl StackLine {
         if !self.is_enabled() {
             return;
         }
-        for indicator in self.indicators.values() {
+        for indicator in self.indicators.values().filter(|indicator| indicator.is_visible()) {
             rects.push(indicator.frame());
         }
     }
@@ -276,6 +276,10 @@ impl StackLine {
         // The event tap already verified that this click lands on a visible,
         // non-occluded indicator. We only need to find the matching segment.
         for (&node_id, indicator) in &self.indicators {
+            if !indicator.is_visible() {
+                continue;
+            }
+
             let frame = indicator.frame();
             if !point_hits_indicator_frame(screen_point, frame) {
                 continue;

--- a/src/bin/rift.rs
+++ b/src/bin/rift.rs
@@ -241,12 +241,14 @@ Enable it in System Settings > Desktop & Dock (Mission Control) and restart Rift
 
     let process_actor = ProcessActor::new(wm_controller_sender.clone());
 
+    let stack_line_hit_rects = rift_wm::actor::stack_line::new_shared_hit_rects();
     let event_tap = EventTap::new(
         config.clone(),
         events_tx.clone(),
         event_tap_rx,
         Some(wm_controller_sender.clone()),
         Some(stack_line_tx.clone()),
+        Some(stack_line_hit_rects.clone()),
     );
     let menu = Menu::new(
         config.clone(),
@@ -261,6 +263,7 @@ Enable it in System Settings > Desktop & Dock (Mission Control) and restart Rift
         mtm,
         events_tx.clone(),
         CoordinateConverter::default(),
+        stack_line_hit_rects,
     );
 
     let mission_control = MissionControlActor::new(config.clone(), mc_rx, reactor.clone(), mtm);

--- a/src/sys/cgs_window.rs
+++ b/src/sys/cgs_window.rs
@@ -248,6 +248,20 @@ impl CgsWindow {
     }
 
     #[inline]
+    pub fn order_below(&self, relative: Option<WindowId>) -> Result<(), CgsWindowError> {
+        let rel = relative.unwrap_or(0);
+        unsafe {
+            cg_ok(SLSOrderWindow(
+                self.connection,
+                self.id,
+                -1, // kCGSOrderBelow
+                rel,
+            ))
+        }
+        .map_err(CgsWindowError::Level)
+    }
+
+    #[inline]
     pub fn order_out(&self) -> Result<(), CgsWindowError> {
         unsafe {
             cg_ok(SLSOrderWindow(

--- a/src/sys/window_server.rs
+++ b/src/sys/window_server.rs
@@ -388,35 +388,66 @@ fn get_num(dict: &CFDictionary<CFString, CFType>, key: &'static CFString) -> Opt
     dict.get(key)?.downcast::<CFNumber>().ok()?.as_i64()
 }
 
-pub fn get_window_at_point(mut point: CGPoint) -> Option<WindowServerId> {
-    unsafe {
-        let mut window_point = CGPoint { x: 0.0, y: 0.0 };
-        let (mut window_id, mut window_cid) = (0u32, 0i32);
+/// Find the topmost window at `point`, or the next window below
+/// `below_window_id` when given. Returns `(window_id, owner_connection_id)`,
+/// or `None` when no window is found.
+fn find_window_at_point(point: &mut CGPoint, below_window_id: Option<u32>) -> Option<(u32, i32)> {
+    let mut window_point = CGPoint { x: 0.0, y: 0.0 };
+    let (mut wid, mut wcid) = (0u32, 0i32);
 
+    let (start_id, direction) = match below_window_id {
+        Some(id) => (id as i32, -1),
+        None => (0, 1),
+    };
+
+    unsafe {
         SLSFindWindowAndOwner(
             *G_CONNECTION,
+            start_id,
+            direction,
             0,
-            1,
-            0,
-            &mut point,
+            point,
             &mut window_point,
-            &mut window_id,
-            &mut window_cid,
+            &mut wid,
+            &mut wcid,
         );
-        if *G_CONNECTION == window_cid {
-            SLSFindWindowAndOwner(
-                *G_CONNECTION,
-                window_id as i32,
-                -1,
-                0,
-                &mut point,
-                &mut window_point,
-                &mut window_id,
-                &mut window_cid,
-            );
-        }
-        (window_id != 0).then(|| WindowServerId(window_id))
     }
+
+    (wid != 0).then_some((wid, wcid))
+}
+
+fn is_own_window(cid: i32) -> bool { *G_CONNECTION == cid }
+
+pub fn get_window_at_point(mut point: CGPoint) -> Option<WindowServerId> {
+    let (mut wid, cid) = find_window_at_point(&mut point, None)?;
+    if is_own_window(cid) {
+        wid = find_window_at_point(&mut point, Some(wid))?.0;
+    }
+    Some(WindowServerId(wid))
+}
+
+/// Returns `true` if an external application window at normal level or above
+/// occludes the given screen point.
+///
+/// Walks down the window stack at `point`, skipping all Rift-owned CGS
+/// windows (there may be more than one at the same point), until a non-Rift
+/// window is found. Desktop/wallpaper windows sit well below
+/// `NSNormalWindowLevel` and are not considered occluders.
+pub fn is_point_occluded_by_external_window(mut point: CGPoint) -> bool {
+    use objc2_app_kit::NSNormalWindowLevel;
+
+    let mut hit = find_window_at_point(&mut point, None);
+
+    // Skip past any Rift-owned windows stacked at this point.
+    while let Some((wid, cid)) = hit {
+        if !is_own_window(cid) {
+            let level = window_level(wid).unwrap_or(NSWindowLevel::MIN);
+            return level >= NSNormalWindowLevel;
+        }
+        hit = find_window_at_point(&mut point, Some(wid));
+    }
+
+    false
 }
 
 pub fn current_cursor_location() -> Result<CGPoint, CGError> {

--- a/src/ui/stack_line.rs
+++ b/src/ui/stack_line.rs
@@ -83,6 +83,13 @@ pub enum GroupKind {
     Vertical,
 }
 
+pub fn point_hits_indicator_frame(point: CGPoint, frame: CGRect) -> bool {
+    point.x >= frame.origin.x
+        && point.x < frame.origin.x + frame.size.width
+        && point.y >= frame.origin.y
+        && point.y < frame.origin.y + frame.size.height
+}
+
 #[derive(Debug, Clone)]
 pub struct GroupDisplayData {
     pub group_kind: GroupKind,
@@ -213,8 +220,6 @@ impl GroupIndicatorWindow {
         }
     }
 
-    pub fn recommended_thickness(&self) -> f64 { self.state.borrow().config.bar_thickness }
-
     pub fn frame(&self) -> CGRect { *self.frame.borrow() }
 
     pub fn set_click_callback(&self, callback: SegmentClickCallback) {
@@ -246,12 +251,7 @@ impl GroupIndicatorWindow {
             return None;
         };
         let bounds = self.bounds();
-        Self::segment_at_point_static(window_point, group_data, &bounds)
-    }
-
-    pub fn segment_at_point(&self, point: CGPoint, group_data: &GroupDisplayData) -> Option<usize> {
-        let bounds = self.bounds();
-        Self::segment_at_point_static(point, group_data, &bounds)
+        Self::segment_at_point_static(window_point, group_data, bounds)
     }
 
     fn bounds(&self) -> CGRect {
@@ -630,15 +630,9 @@ impl GroupIndicatorWindow {
     fn segment_at_point_static(
         point: CGPoint,
         group_data: &GroupDisplayData,
-        bounds: &CGRect,
+        bounds: CGRect,
     ) -> Option<usize> {
-        let bar = *bounds;
-
-        if point.x < bar.origin.x
-            || point.x >= bar.origin.x + bar.size.width
-            || point.y < bar.origin.y
-            || point.y >= bar.origin.y + bar.size.height
-        {
+        if !point_hits_indicator_frame(point, bounds) {
             return None;
         }
 
@@ -647,17 +641,17 @@ impl GroupIndicatorWindow {
         }
 
         let segment_length = match group_data.group_kind {
-            GroupKind::Horizontal => bar.size.width / group_data.total_count as f64,
-            GroupKind::Vertical => bar.size.height / group_data.total_count as f64,
+            GroupKind::Horizontal => bounds.size.width / group_data.total_count as f64,
+            GroupKind::Vertical => bounds.size.height / group_data.total_count as f64,
         };
 
         let segment_index = match group_data.group_kind {
             GroupKind::Horizontal => {
-                let relative_x = point.x - bar.origin.x;
+                let relative_x = point.x - bounds.origin.x;
                 (relative_x / segment_length).floor() as usize
             }
             GroupKind::Vertical => {
-                let relative_y_from_top = (bar.origin.y + bar.size.height) - point.y;
+                let relative_y_from_top = (bounds.origin.y + bounds.size.height) - point.y;
                 (relative_y_from_top / segment_length).floor() as usize
             }
         };

--- a/src/ui/stack_line.rs
+++ b/src/ui/stack_line.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use objc2::rc::Retained;
-use objc2_app_kit::NSStatusWindowLevel;
+use objc2_app_kit::NSNormalWindowLevel;
 use objc2_core_foundation::{CGPoint, CGRect, CGSize};
 use objc2_quartz_core::CALayer;
 use tracing::warn;
@@ -139,8 +139,13 @@ impl GroupIndicatorWindow {
         if let Err(err) = cgs_window.set_alpha(1.0) {
             warn!(error=?err, "failed to set stack line window alpha");
         }
-        if let Err(err) = cgs_window.set_level(NSStatusWindowLevel as i32) {
+        if let Err(err) = cgs_window.set_level(NSNormalWindowLevel as i32) {
             warn!(error=?err, "failed to set stack line window level");
+        }
+        // Disable the system window shadow so that macOS does not draw a
+        // drop-shadow around the indicator when it sits between tiled windows.
+        if let Err(err) = cgs_window.set_tags(1 << 3) {
+            warn!(error=?err, "failed to disable stack line window shadow");
         }
 
         Ok(Self {
@@ -173,7 +178,7 @@ impl GroupIndicatorWindow {
         }
 
         self.present();
-        self.cgs_window.order_above(None)
+        self.cgs_window.order_below(None)
     }
 
     pub fn clear(&self) -> Result<(), CgsWindowError> {
@@ -204,7 +209,7 @@ impl GroupIndicatorWindow {
         if fullscreen {
             self.cgs_window.order_out()
         } else {
-            self.cgs_window.order_above(None)
+            self.cgs_window.order_below(None)
         }
     }
 

--- a/src/ui/stack_line.rs
+++ b/src/ui/stack_line.rs
@@ -108,6 +108,7 @@ struct IndicatorState {
     selected_layer: Option<Retained<CALayer>>,
     click_callback: Option<SegmentClickCallback>,
     space_id: Option<SpaceId>,
+    is_visible: bool,
 }
 
 impl IndicatorState {
@@ -120,6 +121,7 @@ impl IndicatorState {
             selected_layer: None,
             click_callback: None,
             space_id: None,
+            is_visible: false,
         }
     }
 }
@@ -174,6 +176,7 @@ impl GroupIndicatorWindow {
             let mut state = self.state.borrow_mut();
             state.config = config;
             state.group_data = Some(group_data.clone());
+            state.is_visible = true;
         }
 
         self.update_layers();
@@ -190,8 +193,12 @@ impl GroupIndicatorWindow {
 
     pub fn clear(&self) -> Result<(), CgsWindowError> {
         self.clear_layers();
-        self.state.borrow_mut().group_data = None;
-        self.state.borrow_mut().space_id = None;
+        {
+            let mut state = self.state.borrow_mut();
+            state.group_data = None;
+            state.space_id = None;
+            state.is_visible = false;
+        }
         self.present();
         self.cgs_window.order_out()
     }
@@ -213,12 +220,15 @@ impl GroupIndicatorWindow {
     }
 
     pub fn set_visibility(&self, fullscreen: bool) -> Result<(), CgsWindowError> {
+        self.state.borrow_mut().is_visible = !fullscreen;
         if fullscreen {
             self.cgs_window.order_out()
         } else {
             self.cgs_window.order_below(None)
         }
     }
+
+    pub fn is_visible(&self) -> bool { self.state.borrow().is_visible }
 
     pub fn frame(&self) -> CGRect { *self.frame.borrow() }
 


### PR DESCRIPTION
I got too annoyed by this issue #279 . Fixes both stackline appearing at incorrect levels when spotlight ui and floating window are present.

Only caveat is that for some reason, macos applies shadow effect when in-between windows (looks rather cool though and natural) 

<img width="1077" height="926" alt="image" src="https://github.com/user-attachments/assets/3387c7d2-dfe1-4f83-9520-bdc982cb21d3" />
