### PR TITLE
fix: skip inactive-space windows in discovery fallback path

### DIFF
--- a/src/actor/reactor/events/window_discovery.rs
+++ b/src/actor/reactor/events/window_discovery.rs
@@ -379,7 +379,9 @@ impl WindowDiscoveryHandler {
             // Guard against this by skipping windows the window server confirms
             // are NOT on any active Space.
             if let Some(wsid) = state.info.sys_id {
-                if !reactor.window_manager.visible_windows.contains(&wsid) {
+                if !reactor.window_manager.visible_windows.is_empty()
+                    && !reactor.window_manager.visible_windows.contains(&wsid)
+                {
                     continue;
                 }
             }

--- a/src/actor/reactor/events/window_discovery.rs
+++ b/src/actor/reactor/events/window_discovery.rs
@@ -371,6 +371,19 @@ impl WindowDiscoveryHandler {
             let Some(state) = reactor.window_manager.windows.get(&wid) else {
                 continue;
             };
+
+            // The AX API returns all windows regardless of which Space they are
+            // on. Windows on inactive Spaces whose frames overlap an active
+            // display would be frame-mapped to the active Space on that display,
+            // causing every window to cluster on one screen after a Space switch.
+            // Guard against this by skipping windows the window server confirms
+            // are NOT on any active Space.
+            if let Some(wsid) = state.info.sys_id {
+                if !reactor.window_manager.visible_windows.contains(&wsid) {
+                    continue;
+                }
+            }
+
             let Some(space) =
                 reactor.best_space_for_window(&state.frame_monotonic, state.info.sys_id)
             else {


### PR DESCRIPTION
## Summary

- Windows from inactive Spaces were being included in the layout after a Space switch, causing all windows to cluster on one screen and sometimes oscillate
- Root cause: the AX API returns all windows regardless of Space; the fallback path in `emit_layout_events` frame-mapped these windows to the active Space on the same display
- Fix: check `visible_windows` (authoritatively filtered to active spaces) before including a fallback window, skipping any whose window server ID is not on an active Space