### PR TITLE
fix: prevent fullscreen spaces from wiping workspace assignments on wake

### DIFF
--- a/src/actor/reactor/events/space.rs
+++ b/src/actor/reactor/events/space.rs
@@ -175,6 +175,27 @@ impl SpaceEventHandler {
     }
 
     pub fn handle_screen_parameters_changed(reactor: &mut Reactor, screens: Vec<ScreenInfo>) {
+        // Null out fullscreen spaces so they are never stored or processed as
+        // regular user spaces.  Fullscreen transitions create temporary space IDs
+        // that would otherwise cause fresh workspace sets to be created and
+        // windows to be re-assigned, wiping workspace assignments when the user
+        // later exits fullscreen (see #308).
+        let mut screens = screens;
+        for screen in &mut screens {
+            if let Some(space) = screen.space {
+                if crate::sys::window_server::space_is_fullscreen(space.get())
+                    || reactor.space_manager.fullscreen_by_space.contains_key(&space.get())
+                {
+                    debug!(
+                        ?space,
+                        display_uuid = %screen.display_uuid,
+                        "Nulling out fullscreen space in ScreenParametersChanged to preserve workspace state"
+                    );
+                    screen.space = None;
+                }
+            }
+        }
+
         let previous_screens = reactor.space_manager.screens.clone();
         let previous_displays: HashSet<String> =
             previous_screens.iter().map(|s| s.display_uuid.clone()).collect();

--- a/src/actor/reactor/tests.rs
+++ b/src/actor/reactor/tests.rs
@@ -878,3 +878,91 @@ fn fullscreen_space_in_screen_params_does_not_trigger_topology_relayout() {
         Some(user_space)
     );
 }
+
+#[test]
+fn fullscreen_screen_params_preserves_window_layout() {
+    // Regression test for #308: waking from sleep while a fullscreen video is
+    // active should not wipe workspace assignments.
+    let mut apps = Apps::new();
+    let mut reactor = Reactor::new_for_test(LayoutEngine::new(
+        &crate::common::config::VirtualWorkspaceSettings::default(),
+        &crate::common::config::LayoutSettings::default(),
+        None,
+    ));
+
+    let user_space = SpaceId::new(1);
+    let fullscreen_space = SpaceId::new(0x400000000 + user_space.get());
+    let full_screen = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
+
+    // Set up a display with a user space and some windows.
+    reactor.handle_event(screen_params_event(
+        vec![full_screen],
+        vec![Some(user_space)],
+        vec![],
+    ));
+    reactor.handle_events(apps.make_app_with_opts(
+        1,
+        make_windows(3),
+        Some(WindowId::new(1, 1)),
+        true,
+        true,
+    ));
+    reactor.handle_event(Event::ApplicationGloballyActivated(1));
+    apps.simulate_until_quiet(&mut reactor);
+
+    // Rearrange layout so we can detect if it gets reset.
+    reactor.handle_event(Event::Command(Command::Layout(LayoutCommand::MoveNode(
+        Direction::Up,
+    ))));
+    apps.simulate_until_quiet(&mut reactor);
+    let layout_before = reactor.layout_manager.layout_engine.calculate_layout(
+        user_space,
+        full_screen,
+        &reactor.config.settings.layout.gaps,
+        0.0,
+        crate::common::config::HorizontalPlacement::Top,
+        crate::common::config::VerticalPlacement::Right,
+    );
+
+    // Simulate sleep/wake while fullscreen: ScreenParametersChanged arrives
+    // with the fullscreen space id.
+    reactor
+        .space_manager
+        .fullscreen_by_space
+        .insert(fullscreen_space.get(), FullscreenSpaceTrack::default());
+    reactor.handle_event(Event::ScreenParametersChanged(vec![ScreenInfo {
+        id: crate::sys::screen::ScreenId::new(0),
+        frame: full_screen,
+        space: Some(fullscreen_space),
+        display_uuid: "test-display-0".to_string(),
+        name: None,
+    }]));
+    apps.simulate_until_quiet(&mut reactor);
+
+    // The fullscreen space must not become the active space for the screen.
+    assert_eq!(
+        reactor.space_manager.screens[0].space, None,
+        "fullscreen space should be nulled out, not stored as screen space"
+    );
+
+    // Return to user space (simulates exiting fullscreen).
+    reactor.handle_event(screen_params_event(
+        vec![full_screen],
+        vec![Some(user_space)],
+        vec![],
+    ));
+    apps.simulate_until_quiet(&mut reactor);
+
+    let layout_after = reactor.layout_manager.layout_engine.calculate_layout(
+        user_space,
+        full_screen,
+        &reactor.config.settings.layout.gaps,
+        0.0,
+        crate::common::config::HorizontalPlacement::Top,
+        crate::common::config::VerticalPlacement::Right,
+    );
+    assert_eq!(
+        layout_before, layout_after,
+        "Window layout on user space must be preserved across fullscreen ScreenParametersChanged"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #308 — windows were incorrectly reset to Workspace 1 upon wake from sleep when a fullscreen video was active.

The previous fix (fa56a8c) only prevented topology relayout detection and display-history remapping for fullscreen spaces, but the fullscreen space still flowed through the rest of `handle_screen_parameters_changed`: it was stored as the screen's active space, had fresh workspaces created for it, and had windows assigned to those new workspaces. When the user later exited fullscreen, all prior workspace assignments were lost.

The fix nulls out fullscreen spaces at the top of `handle_screen_parameters_changed`, before they can be stored or processed. This way the reactor treats a fullscreen space as "no space info available" and preserves all existing workspace state.

- Adds debug logging when a fullscreen space is nulled out
- Adds a regression test that verifies window layout is preserved across a fullscreen `ScreenParametersChanged` cycle (validated by confirming the test fails without the fix)

> **Disclaimer:** The root cause analysis and fix were produced by Claude Code (Opus 4.6), guided and verified by the PR author.

## Test plan

- [x] `cargo test` passes (213 tests, including new regression test)
- [x] New test fails when fix is commented out, passes with fix applied
- [x] Manual testing: reproduced the issue per the steps in #308, confirmed fix resolves it