### PR TITLE
fix: broadcast windows_changed on all MoveWindowToWorkspace paths

### DIFF
--- a/src/layout_engine/engine.rs
+++ b/src/layout_engine/engine.rs
@@ -2164,6 +2164,7 @@ impl LayoutEngine {
                     if is_floating {
                         self.floating.add_active(op_space, focused_window.pid, focused_window);
                     }
+                    self.broadcast_windows_changed(op_space);
                     return EventResponse {
                         focus_window: Some(focused_window),
                         raise_windows: vec![],
@@ -2180,6 +2181,7 @@ impl LayoutEngine {
                     let remaining_windows =
                         self.virtual_workspace_manager.windows_in_active_workspace(op_space);
                     if let Some(&new_focus) = remaining_windows.first() {
+                        self.broadcast_windows_changed(op_space);
                         return EventResponse {
                             focus_window: Some(new_focus),
                             raise_windows: vec![],


### PR DESCRIPTION
## Summary

- `MoveWindowToWorkspace` has three return paths but only the last one called `broadcast_windows_changed()`
- The two early returns (moving a window to/from the active workspace) skipped the broadcast
- External subscribers (e.g. SketchyBar workspace indicators) were not notified until a subsequent workspace switch triggered an update

## Fix

Add `broadcast_windows_changed(op_space)` before both early returns in the `MoveWindowToWorkspace` handler.