### PR TITLE
fix: prevent window oscillation after display topology change

### DIFF
--- a/src/actor/reactor/events/window_discovery.rs
+++ b/src/actor/reactor/events/window_discovery.rs
@@ -380,9 +380,42 @@ impl WindowDiscoveryHandler {
             app_windows.entry(space).or_default().push(wid);
         }
 
-        // For now, we'll assume known_visible is handled elsewhere or we need to pass it.
-        // Looking back, the original method processes known_visible in the main logic.
-        // Actually, the emit_layout_events should be called after processing, and we need to collect all windows.
+        // Pre-pass: update the VWM for all windows definitively assigned to a space before
+        // processing any per-space layout events. Without this, the ordering of space events
+        // determines whether a window removed from one space's tree gets re-added by the
+        // loop in sync_tiled_windows_for_app (which reads the VWM state at event time).
+        // By updating the VWM upfront, the guard logic in sync_tiled_windows_for_app can
+        // correctly identify cross-space moves regardless of event ordering.
+        for (&space, windows_for_space) in &app_windows {
+            if !reactor.is_space_active(space) {
+                continue;
+            }
+            for &wid in windows_for_space {
+                let title_opt =
+                    reactor.window_manager.windows.get(&wid).map(|w| w.info.title.clone());
+                let _ = reactor
+                    .layout_manager
+                    .layout_engine
+                    .virtual_workspace_manager_mut()
+                    .assign_window_with_app_info(
+                        wid,
+                        space,
+                        app_info.as_ref().and_then(|a| a.bundle_id.as_deref()),
+                        app_info.as_ref().and_then(|a| a.localized_name.as_deref()),
+                        title_opt.as_deref(),
+                        reactor
+                            .window_manager
+                            .windows
+                            .get(&wid)
+                            .and_then(|w| w.info.ax_role.as_deref()),
+                        reactor
+                            .window_manager
+                            .windows
+                            .get(&wid)
+                            .and_then(|w| w.info.ax_subrole.as_deref()),
+                    );
+            }
+        }
 
         let screens = reactor.space_manager.screens.clone();
         for screen in screens {

--- a/src/actor/reactor/events/window_discovery.rs
+++ b/src/actor/reactor/events/window_discovery.rs
@@ -3,7 +3,7 @@ use tracing::{trace, warn};
 use crate::actor::app::{AppInfo, WindowId, WindowInfo, pid_t};
 use crate::actor::reactor::{Event, LayoutEvent, Reactor, WindowFilter, WindowState, utils};
 use crate::common::collections::{BTreeMap, HashSet};
-use crate::model::virtual_workspace::AppRuleResult;
+use crate::model::virtual_workspace::{AppRuleResult, WorkspaceError};
 use crate::sys::screen::SpaceId;
 use crate::sys::window_server::{self, WindowServerId};
 
@@ -332,6 +332,63 @@ impl WindowDiscoveryHandler {
     }
 
     /// Send layout events for discovered windows.
+    fn assign_discovered_window_to_space(
+        reactor: &mut Reactor,
+        wid: WindowId,
+        space: SpaceId,
+        app_info: &Option<AppInfo>,
+    ) -> Result<AppRuleResult, WorkspaceError> {
+        let Some(window) = reactor.window_manager.windows.get(&wid) else {
+            return Err(WorkspaceError::AssignmentFailed);
+        };
+        let title = window.info.title.clone();
+        let ax_role = window.info.ax_role.clone();
+        let ax_subrole = window.info.ax_subrole.clone();
+
+        reactor
+            .layout_manager
+            .layout_engine
+            .virtual_workspace_manager_mut()
+            .assign_window_with_app_info(
+                wid,
+                space,
+                app_info.as_ref().and_then(|a| a.bundle_id.as_deref()),
+                app_info.as_ref().and_then(|a| a.localized_name.as_deref()),
+                Some(title.as_str()),
+                ax_role.as_deref(),
+                ax_subrole.as_deref(),
+            )
+    }
+
+    fn apply_assignment_result(
+        reactor: &mut Reactor,
+        wid: WindowId,
+        space: SpaceId,
+        assign_result: Result<AppRuleResult, WorkspaceError>,
+    ) {
+        match assign_result {
+            Ok(AppRuleResult::Managed(_)) => {
+                if let Some(window) = reactor.window_manager.windows.get_mut(&wid) {
+                    window.ignore_app_rule = false;
+                }
+            }
+            Ok(AppRuleResult::Unmanaged) => {
+                if let Some(window) = reactor.window_manager.windows.get_mut(&wid) {
+                    window.ignore_app_rule = true;
+                }
+                let needs_removal = {
+                    let engine = &reactor.layout_manager.layout_engine;
+                    engine.virtual_workspace_manager().workspace_for_window(space, wid).is_some()
+                        || engine.is_window_floating(wid)
+                };
+                if needs_removal {
+                    reactor.send_layout_event(LayoutEvent::WindowRemoved(wid));
+                }
+            }
+            Err(e) => warn!("Failed to assign window {:?} to workspace: {:?}", wid, e),
+        }
+    }
+
     fn emit_layout_events(
         reactor: &mut Reactor,
         pid: pid_t,
@@ -386,34 +443,16 @@ impl WindowDiscoveryHandler {
         // loop in sync_tiled_windows_for_app (which reads the VWM state at event time).
         // By updating the VWM upfront, the guard logic in sync_tiled_windows_for_app can
         // correctly identify cross-space moves regardless of event ordering.
+        let mut assignment_results = BTreeMap::new();
         for (&space, windows_for_space) in &app_windows {
             if !reactor.is_space_active(space) {
                 continue;
             }
             for &wid in windows_for_space {
-                let title_opt =
-                    reactor.window_manager.windows.get(&wid).map(|w| w.info.title.clone());
-                let _ = reactor
-                    .layout_manager
-                    .layout_engine
-                    .virtual_workspace_manager_mut()
-                    .assign_window_with_app_info(
-                        wid,
-                        space,
-                        app_info.as_ref().and_then(|a| a.bundle_id.as_deref()),
-                        app_info.as_ref().and_then(|a| a.localized_name.as_deref()),
-                        title_opt.as_deref(),
-                        reactor
-                            .window_manager
-                            .windows
-                            .get(&wid)
-                            .and_then(|w| w.info.ax_role.as_deref()),
-                        reactor
-                            .window_manager
-                            .windows
-                            .get(&wid)
-                            .and_then(|w| w.info.ax_subrole.as_deref()),
-                    );
+                assignment_results.insert(
+                    (space, wid),
+                    Self::assign_discovered_window_to_space(reactor, wid, space, app_info),
+                );
             }
         }
 
@@ -428,55 +467,12 @@ impl WindowDiscoveryHandler {
             let windows_for_space = app_windows.remove(&space).unwrap_or_default();
 
             if !windows_for_space.is_empty() {
-                for wid in &windows_for_space {
-                    let title_opt =
-                        reactor.window_manager.windows.get(wid).map(|w| w.info.title.clone());
-                    let assign_result = reactor
-                        .layout_manager
-                        .layout_engine
-                        .virtual_workspace_manager_mut()
-                        .assign_window_with_app_info(
-                            *wid,
-                            space,
-                            app_info.as_ref().and_then(|a| a.bundle_id.as_deref()),
-                            app_info.as_ref().and_then(|a| a.localized_name.as_deref()),
-                            title_opt.as_deref(),
-                            reactor
-                                .window_manager
-                                .windows
-                                .get(wid)
-                                .and_then(|w| w.info.ax_role.as_deref()),
-                            reactor
-                                .window_manager
-                                .windows
-                                .get(wid)
-                                .and_then(|w| w.info.ax_subrole.as_deref()),
-                        );
-
-                    match assign_result {
-                        Ok(AppRuleResult::Managed(_)) => {
-                            if let Some(window) = reactor.window_manager.windows.get_mut(wid) {
-                                window.ignore_app_rule = false;
-                            }
-                        }
-                        Ok(AppRuleResult::Unmanaged) => {
-                            if let Some(window) = reactor.window_manager.windows.get_mut(wid) {
-                                window.ignore_app_rule = true;
-                            }
-                            let needs_removal = {
-                                let engine = &reactor.layout_manager.layout_engine;
-                                engine
-                                    .virtual_workspace_manager()
-                                    .workspace_for_window(space, *wid)
-                                    .is_some()
-                                    || engine.is_window_floating(*wid)
-                            };
-                            if needs_removal {
-                                reactor.send_layout_event(LayoutEvent::WindowRemoved(*wid));
-                            }
-                        }
-                        Err(e) => warn!("Failed to assign window {:?} to workspace: {:?}", wid, e),
-                    }
+                for &wid in &windows_for_space {
+                    let assign_result =
+                        assignment_results.remove(&(space, wid)).unwrap_or_else(|| {
+                            Self::assign_discovered_window_to_space(reactor, wid, space, app_info)
+                        });
+                    Self::apply_assignment_result(reactor, wid, space, assign_result);
                 }
             }
 

--- a/src/actor/reactor/tests.rs
+++ b/src/actor/reactor/tests.rs
@@ -4,8 +4,8 @@ use test_log::test;
 use super::display_topology::TopologyState;
 use super::testing::*;
 use super::*;
-use crate::actor::app::Request;
-use crate::layout_engine::{Direction, LayoutCommand, LayoutEngine};
+use crate::actor::app::{Request, pid_t};
+use crate::layout_engine::{Direction, LayoutCommand, LayoutEngine, LayoutEvent};
 use crate::sys::app::WindowInfo;
 use crate::sys::window_server::WindowServerId;
 
@@ -876,5 +876,269 @@ fn fullscreen_space_in_screen_params_does_not_trigger_topology_relayout() {
     assert_eq!(
         reactor.layout_manager.layout_engine.last_space_for_display_uuid(&display_uuid),
         Some(user_space)
+    );
+}
+
+// Helper: check whether any window owned by `pid` appears in the layout tree for `space`.
+fn has_windows_in_layout(reactor: &mut Reactor, space: SpaceId, screen: CGRect, pid: pid_t) -> bool {
+    let gaps = reactor.config.settings.layout.gaps.clone();
+    reactor
+        .layout_manager
+        .layout_engine
+        .calculate_layout(space, screen, &gaps, 0.0, Default::default(), Default::default())
+        .iter()
+        .any(|(wid, _)| wid.pid == pid)
+}
+
+fn window_update_tuple(
+    wid: WindowId,
+) -> (WindowId, Option<String>, Option<String>, Option<String>, bool, CGSize, Option<CGSize>, Option<CGSize>)
+{
+    (wid, None, None, None, true, CGSize::new(100.0, 100.0), None, None)
+}
+
+// --- Display oscillation bug regression tests ---
+//
+// These tests cover the bug where a window enters a permanent oscillation state after a
+// display topology change (e.g. MacBook lid open/close with an external monitor).  The
+// root cause was that `sync_tiled_windows_for_app` could leave a window in two space
+// layout trees simultaneously: after the window moved to the destination space its
+// original source space still retained it, causing both spaces to issue conflicting
+// SetWindowFrame calls that fed back into each other indefinitely.
+
+#[test]
+fn window_removed_from_source_space_when_dest_claims_it_first() {
+    // Case 1: the destination space's WindowsOnScreenUpdated event fires before the
+    // source space's empty event.  The VWM is updated by the destination event, so when
+    // the source guard logic runs it can see that the window was moved away.
+    let mut reactor = Reactor::new_for_test(LayoutEngine::new(
+        &crate::common::config::VirtualWorkspaceSettings::default(),
+        &crate::common::config::LayoutSettings::default(),
+        None,
+    ));
+    let screen1 = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
+    let screen2 = CGRect::new(CGPoint::new(1000., 0.), CGSize::new(1000., 1000.));
+    let space1 = SpaceId::new(1);
+    let space2 = SpaceId::new(2);
+    let pid: pid_t = 42;
+    let wid = WindowId::new(pid, 1);
+
+    reactor.handle_event(screen_params_event(
+        vec![screen1, screen2],
+        vec![Some(space1), Some(space2)],
+        vec![],
+    ));
+
+    // Place window in space1's layout tree via a direct layout event.
+    let _ = reactor.layout_manager.layout_engine.handle_event(LayoutEvent::WindowsOnScreenUpdated(
+        space1,
+        pid,
+        vec![window_update_tuple(wid)],
+        None,
+    ));
+    assert!(has_windows_in_layout(&mut reactor, space1, screen1, pid));
+
+    // Destination space2 claims the window first (updates VWM: wid moves out of space1).
+    let _ = reactor.layout_manager.layout_engine.handle_event(LayoutEvent::WindowsOnScreenUpdated(
+        space2,
+        pid,
+        vec![window_update_tuple(wid)],
+        None,
+    ));
+
+    // Source space1 receives the authoritative empty update.
+    // Before the fix the guard in sync_tiled_windows_for_app checked only
+    // has_windows_for_app (true) and skipped removal.  After the fix it also checks
+    // whether those tree windows have been moved away in the VWM, and proceeds with
+    // removal when they have.
+    let _ = reactor.layout_manager.layout_engine.handle_event(LayoutEvent::WindowsOnScreenUpdated(
+        space1,
+        pid,
+        vec![],
+        None,
+    ));
+
+    assert!(
+        !has_windows_in_layout(&mut reactor, space1, screen1, pid),
+        "window must be removed from source space after destination claimed it"
+    );
+    assert!(
+        has_windows_in_layout(&mut reactor, space2, screen2, pid),
+        "window must remain in destination space"
+    );
+}
+
+#[test]
+fn window_removed_from_source_space_when_source_empty_event_fires_first() {
+    // Case 2: the source space's empty WindowsOnScreenUpdated fires before the
+    // destination claims the window.  The reactor-level pre-pass in emit_layout_events
+    // updates the VWM for all claimed windows upfront, so by the time the source event
+    // is processed the VWM no longer lists the window in the source space.  The loop in
+    // sync_tiled_windows_for_app then correctly skips re-adding it to `desired`.
+    //
+    // This test replicates that pre-pass by updating the VWM directly before sending
+    // the source's empty event, mirroring what emit_layout_events does at the reactor
+    // level.
+    let mut reactor = Reactor::new_for_test(LayoutEngine::new(
+        &crate::common::config::VirtualWorkspaceSettings::default(),
+        &crate::common::config::LayoutSettings::default(),
+        None,
+    ));
+    let screen1 = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
+    let screen2 = CGRect::new(CGPoint::new(1000., 0.), CGSize::new(1000., 1000.));
+    let space1 = SpaceId::new(1);
+    let space2 = SpaceId::new(2);
+    let pid: pid_t = 42;
+    let wid = WindowId::new(pid, 1);
+
+    reactor.handle_event(screen_params_event(
+        vec![screen1, screen2],
+        vec![Some(space1), Some(space2)],
+        vec![],
+    ));
+
+    let _ = reactor.layout_manager.layout_engine.handle_event(LayoutEvent::WindowsOnScreenUpdated(
+        space1,
+        pid,
+        vec![window_update_tuple(wid)],
+        None,
+    ));
+    assert!(has_windows_in_layout(&mut reactor, space1, screen1, pid));
+
+    // Simulate the pre-pass: move wid from space1 to space2 in the VWM before any
+    // per-space events fire.
+    let space2_workspace = reactor
+        .layout_manager
+        .layout_engine
+        .virtual_workspace_manager()
+        .active_workspace(space2)
+        .expect("space2 must have an active workspace");
+    reactor.layout_manager.layout_engine.virtual_workspace_manager_mut().assign_window_to_workspace(
+        space2,
+        wid,
+        space2_workspace,
+    );
+
+    // Source space1's empty event fires first.  Because the VWM was pre-updated the
+    // loop no longer re-adds wid to `desired`, so removal proceeds.
+    let _ = reactor.layout_manager.layout_engine.handle_event(LayoutEvent::WindowsOnScreenUpdated(
+        space1,
+        pid,
+        vec![],
+        None,
+    ));
+
+    assert!(
+        !has_windows_in_layout(&mut reactor, space1, screen1, pid),
+        "window must be removed from source space when VWM was pre-updated (pre-pass scenario)"
+    );
+
+    // Destination space2 event fires after.
+    let _ = reactor.layout_manager.layout_engine.handle_event(LayoutEvent::WindowsOnScreenUpdated(
+        space2,
+        pid,
+        vec![window_update_tuple(wid)],
+        None,
+    ));
+    assert!(has_windows_in_layout(&mut reactor, space2, screen2, pid));
+}
+
+#[test]
+fn window_preserved_in_space_on_empty_discovery_without_cross_space_move() {
+    // Regression guard for the login-screen / AX-failure scenario: when the
+    // accessibility API returns an empty window list but the window has NOT been moved
+    // to another space in the VWM, the empty update must not destroy the layout.
+    let mut reactor = Reactor::new_for_test(LayoutEngine::new(
+        &crate::common::config::VirtualWorkspaceSettings::default(),
+        &crate::common::config::LayoutSettings::default(),
+        None,
+    ));
+    let screen = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
+    let space = SpaceId::new(1);
+    let pid: pid_t = 42;
+    let wid = WindowId::new(pid, 1);
+
+    reactor.handle_event(screen_params_event(vec![screen], vec![Some(space)], vec![]));
+
+    let _ = reactor.layout_manager.layout_engine.handle_event(LayoutEvent::WindowsOnScreenUpdated(
+        space,
+        pid,
+        vec![window_update_tuple(wid)],
+        None,
+    ));
+    assert!(has_windows_in_layout(&mut reactor, space, screen, pid));
+
+    // AX returns empty — window is still in the VWM for this space (it was never moved).
+    let _ = reactor.layout_manager.layout_engine.handle_event(LayoutEvent::WindowsOnScreenUpdated(
+        space,
+        pid,
+        vec![],
+        None,
+    ));
+
+    assert!(
+        has_windows_in_layout(&mut reactor, space, screen, pid),
+        "window must be preserved when empty update has no cross-space move (login screen / AX failure)"
+    );
+}
+
+#[test]
+fn discovery_after_display_change_places_window_on_correct_display() {
+    // End-to-end integration test: a window that physically moved to a different
+    // display after a topology change (lid open/close) must end up in only the new
+    // display's layout tree, with no conflicting SetWindowFrame from the old one.
+    //
+    // This exercises the full WindowsDiscovered → emit_layout_events path including
+    // the pre-pass VWM update (Case 2: source space processed first in screen order).
+    let mut apps = Apps::new();
+    let mut reactor = Reactor::new_for_test(LayoutEngine::new(
+        &crate::common::config::VirtualWorkspaceSettings::default(),
+        &crate::common::config::LayoutSettings::default(),
+        None,
+    ));
+    let screen1 = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
+    let screen2 = CGRect::new(CGPoint::new(1000., 0.), CGSize::new(1000., 1000.));
+    let space1 = SpaceId::new(1);
+    let space2 = SpaceId::new(2);
+
+    reactor.handle_event(screen_params_event(
+        vec![screen1, screen2],
+        vec![Some(space1), Some(space2)],
+        vec![],
+    ));
+
+    // Window starts on screen1.
+    reactor.handle_events(apps.make_app(1, make_windows(1)));
+    apps.simulate_until_quiet(&mut reactor);
+    assert_eq!(screen1, apps.windows[&WindowId::new(1, 1)].frame);
+
+    // Simulate a topology change: the window has moved to screen2.
+    // Passing it in `new` with an updated frame causes process_window_list to update
+    // frame_monotonic so emit_layout_events assigns it to space2.
+    // Note: without the fix this triggers the oscillation and simulate_until_quiet
+    // would loop forever; the test itself documents that termination is part of the
+    // expected behaviour.
+    reactor.handle_event(Event::WindowsDiscovered {
+        pid: 1,
+        new: vec![(WindowId::new(1, 1), WindowInfo {
+            frame: CGRect::new(CGPoint::new(1100., 100.), CGSize::new(50., 50.)),
+            ..make_window(1)
+        })],
+        known_visible: vec![WindowId::new(1, 1)],
+    });
+    apps.simulate_until_quiet(&mut reactor);
+
+    assert!(
+        !has_windows_in_layout(&mut reactor, space1, screen1, 1),
+        "space1 layout tree must not contain the window after it moved to screen2"
+    );
+    assert!(
+        has_windows_in_layout(&mut reactor, space2, screen2, 1),
+        "space2 layout tree must contain the window after it moved to screen2"
+    );
+    assert_eq!(
+        screen2,
+        apps.windows[&WindowId::new(1, 1)].frame,
+        "window must be laid out on screen2"
     );
 }

--- a/src/actor/reactor/tests.rs
+++ b/src/actor/reactor/tests.rs
@@ -1065,6 +1065,21 @@ fn has_windows_in_layout(
         .any(|(wid, _)| wid.pid == pid)
 }
 
+fn has_window_in_layout(
+    reactor: &mut Reactor,
+    space: SpaceId,
+    screen: CGRect,
+    wid: WindowId,
+) -> bool {
+    let gaps = reactor.config.settings.layout.gaps.clone();
+    reactor
+        .layout_manager
+        .layout_engine
+        .calculate_layout(space, screen, &gaps, 0.0, Default::default(), Default::default())
+        .iter()
+        .any(|(layout_wid, _)| *layout_wid == wid)
+}
+
 type WindowUpdateTuple = (
     WindowId,
     Option<String>,
@@ -1253,6 +1268,72 @@ fn empty_update_removes_window_when_vwm_was_preupdated() {
             None,
         ));
     assert!(has_windows_in_layout(&mut reactor, space2, screen2, pid));
+}
+
+#[test]
+fn empty_update_only_removes_same_app_windows_moved_to_another_space() {
+    // Mixed same-app case: one window moved to another space, while another window is
+    // still assigned here but temporarily omitted from discovery. The empty update
+    // should remove only the moved window from the source layout tree.
+    let TwoSpaceFixture {
+        mut reactor,
+        screen1,
+        screen2,
+        space1,
+        space2,
+    } = two_space_fixture();
+    let pid: pid_t = 42;
+    let moved = WindowId::new(pid, 1);
+    let retained = WindowId::new(pid, 2);
+
+    let _ = reactor
+        .layout_manager
+        .layout_engine
+        .handle_event(LayoutEvent::WindowsOnScreenUpdated(
+            space1,
+            pid,
+            vec![window_update_tuple(moved), window_update_tuple(retained)],
+            None,
+        ));
+    assert!(has_window_in_layout(&mut reactor, space1, screen1, moved));
+    assert!(has_window_in_layout(&mut reactor, space1, screen1, retained));
+
+    let space2_workspace = reactor
+        .layout_manager
+        .layout_engine
+        .virtual_workspace_manager()
+        .active_workspace(space2)
+        .expect("space2 must have an active workspace");
+    reactor
+        .layout_manager
+        .layout_engine
+        .virtual_workspace_manager_mut()
+        .assign_window_to_workspace(space2, moved, space2_workspace);
+
+    let _ = reactor
+        .layout_manager
+        .layout_engine
+        .handle_event(LayoutEvent::WindowsOnScreenUpdated(space1, pid, vec![], None));
+
+    assert!(
+        !has_window_in_layout(&mut reactor, space1, screen1, moved),
+        "moved window must be removed from the source layout tree"
+    );
+    assert!(
+        has_window_in_layout(&mut reactor, space1, screen1, retained),
+        "same-app window still assigned to source space must be preserved"
+    );
+
+    let _ = reactor
+        .layout_manager
+        .layout_engine
+        .handle_event(LayoutEvent::WindowsOnScreenUpdated(
+            space2,
+            pid,
+            vec![window_update_tuple(moved)],
+            None,
+        ));
+    assert!(has_window_in_layout(&mut reactor, space2, screen2, moved));
 }
 
 #[test]

--- a/src/actor/reactor/tests.rs
+++ b/src/actor/reactor/tests.rs
@@ -880,7 +880,12 @@ fn fullscreen_space_in_screen_params_does_not_trigger_topology_relayout() {
 }
 
 // Helper: check whether any window owned by `pid` appears in the layout tree for `space`.
-fn has_windows_in_layout(reactor: &mut Reactor, space: SpaceId, screen: CGRect, pid: pid_t) -> bool {
+fn has_windows_in_layout(
+    reactor: &mut Reactor,
+    space: SpaceId,
+    screen: CGRect,
+    pid: pid_t,
+) -> bool {
     let gaps = reactor.config.settings.layout.gaps.clone();
     reactor
         .layout_manager
@@ -890,11 +895,62 @@ fn has_windows_in_layout(reactor: &mut Reactor, space: SpaceId, screen: CGRect, 
         .any(|(wid, _)| wid.pid == pid)
 }
 
-fn window_update_tuple(
-    wid: WindowId,
-) -> (WindowId, Option<String>, Option<String>, Option<String>, bool, CGSize, Option<CGSize>, Option<CGSize>)
-{
-    (wid, None, None, None, true, CGSize::new(100.0, 100.0), None, None)
+type WindowUpdateTuple = (
+    WindowId,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    bool,
+    CGSize,
+    Option<CGSize>,
+    Option<CGSize>,
+);
+
+fn window_update_tuple(wid: WindowId) -> WindowUpdateTuple {
+    (
+        wid,
+        None,
+        None,
+        None,
+        true,
+        CGSize::new(100.0, 100.0),
+        None,
+        None,
+    )
+}
+
+struct TwoSpaceFixture {
+    reactor: Reactor,
+    screen1: CGRect,
+    screen2: CGRect,
+    space1: SpaceId,
+    space2: SpaceId,
+}
+
+fn two_space_fixture() -> TwoSpaceFixture {
+    let mut reactor = Reactor::new_for_test(LayoutEngine::new(
+        &crate::common::config::VirtualWorkspaceSettings::default(),
+        &crate::common::config::LayoutSettings::default(),
+        None,
+    ));
+    let screen1 = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
+    let screen2 = CGRect::new(CGPoint::new(1000., 0.), CGSize::new(1000., 1000.));
+    let space1 = SpaceId::new(1);
+    let space2 = SpaceId::new(2);
+
+    reactor.handle_event(screen_params_event(
+        vec![screen1, screen2],
+        vec![Some(space1), Some(space2)],
+        vec![],
+    ));
+
+    TwoSpaceFixture {
+        reactor,
+        screen1,
+        screen2,
+        space1,
+        space2,
+    }
 }
 
 // --- Display oscillation bug regression tests ---
@@ -911,52 +967,48 @@ fn window_removed_from_source_space_when_dest_claims_it_first() {
     // Case 1: the destination space's WindowsOnScreenUpdated event fires before the
     // source space's empty event.  The VWM is updated by the destination event, so when
     // the source guard logic runs it can see that the window was moved away.
-    let mut reactor = Reactor::new_for_test(LayoutEngine::new(
-        &crate::common::config::VirtualWorkspaceSettings::default(),
-        &crate::common::config::LayoutSettings::default(),
-        None,
-    ));
-    let screen1 = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
-    let screen2 = CGRect::new(CGPoint::new(1000., 0.), CGSize::new(1000., 1000.));
-    let space1 = SpaceId::new(1);
-    let space2 = SpaceId::new(2);
+    let TwoSpaceFixture {
+        mut reactor,
+        screen1,
+        screen2,
+        space1,
+        space2,
+    } = two_space_fixture();
     let pid: pid_t = 42;
     let wid = WindowId::new(pid, 1);
 
-    reactor.handle_event(screen_params_event(
-        vec![screen1, screen2],
-        vec![Some(space1), Some(space2)],
-        vec![],
-    ));
-
     // Place window in space1's layout tree via a direct layout event.
-    let _ = reactor.layout_manager.layout_engine.handle_event(LayoutEvent::WindowsOnScreenUpdated(
-        space1,
-        pid,
-        vec![window_update_tuple(wid)],
-        None,
-    ));
+    let _ = reactor
+        .layout_manager
+        .layout_engine
+        .handle_event(LayoutEvent::WindowsOnScreenUpdated(
+            space1,
+            pid,
+            vec![window_update_tuple(wid)],
+            None,
+        ));
     assert!(has_windows_in_layout(&mut reactor, space1, screen1, pid));
 
     // Destination space2 claims the window first (updates VWM: wid moves out of space1).
-    let _ = reactor.layout_manager.layout_engine.handle_event(LayoutEvent::WindowsOnScreenUpdated(
-        space2,
-        pid,
-        vec![window_update_tuple(wid)],
-        None,
-    ));
+    let _ = reactor
+        .layout_manager
+        .layout_engine
+        .handle_event(LayoutEvent::WindowsOnScreenUpdated(
+            space2,
+            pid,
+            vec![window_update_tuple(wid)],
+            None,
+        ));
 
     // Source space1 receives the authoritative empty update.
     // Before the fix the guard in sync_tiled_windows_for_app checked only
     // has_windows_for_app (true) and skipped removal.  After the fix it also checks
     // whether those tree windows have been moved away in the VWM, and proceeds with
     // removal when they have.
-    let _ = reactor.layout_manager.layout_engine.handle_event(LayoutEvent::WindowsOnScreenUpdated(
-        space1,
-        pid,
-        vec![],
-        None,
-    ));
+    let _ = reactor
+        .layout_manager
+        .layout_engine
+        .handle_event(LayoutEvent::WindowsOnScreenUpdated(space1, pid, vec![], None));
 
     assert!(
         !has_windows_in_layout(&mut reactor, space1, screen1, pid),
@@ -969,40 +1021,29 @@ fn window_removed_from_source_space_when_dest_claims_it_first() {
 }
 
 #[test]
-fn window_removed_from_source_space_when_source_empty_event_fires_first() {
-    // Case 2: the source space's empty WindowsOnScreenUpdated fires before the
-    // destination claims the window.  The reactor-level pre-pass in emit_layout_events
-    // updates the VWM for all claimed windows upfront, so by the time the source event
-    // is processed the VWM no longer lists the window in the source space.  The loop in
-    // sync_tiled_windows_for_app then correctly skips re-adding it to `desired`.
-    //
-    // This test replicates that pre-pass by updating the VWM directly before sending
-    // the source's empty event, mirroring what emit_layout_events does at the reactor
-    // level.
-    let mut reactor = Reactor::new_for_test(LayoutEngine::new(
-        &crate::common::config::VirtualWorkspaceSettings::default(),
-        &crate::common::config::LayoutSettings::default(),
-        None,
-    ));
-    let screen1 = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
-    let screen2 = CGRect::new(CGPoint::new(1000., 0.), CGSize::new(1000., 1000.));
-    let space1 = SpaceId::new(1);
-    let space2 = SpaceId::new(2);
+fn empty_update_removes_window_when_vwm_was_preupdated() {
+    // The reactor-level pre-pass in emit_layout_events updates the VWM for all claimed
+    // windows upfront. This test mirrors that by updating the VWM directly before the
+    // source's empty event.
+    let TwoSpaceFixture {
+        mut reactor,
+        screen1,
+        screen2,
+        space1,
+        space2,
+    } = two_space_fixture();
     let pid: pid_t = 42;
     let wid = WindowId::new(pid, 1);
 
-    reactor.handle_event(screen_params_event(
-        vec![screen1, screen2],
-        vec![Some(space1), Some(space2)],
-        vec![],
-    ));
-
-    let _ = reactor.layout_manager.layout_engine.handle_event(LayoutEvent::WindowsOnScreenUpdated(
-        space1,
-        pid,
-        vec![window_update_tuple(wid)],
-        None,
-    ));
+    let _ = reactor
+        .layout_manager
+        .layout_engine
+        .handle_event(LayoutEvent::WindowsOnScreenUpdated(
+            space1,
+            pid,
+            vec![window_update_tuple(wid)],
+            None,
+        ));
     assert!(has_windows_in_layout(&mut reactor, space1, screen1, pid));
 
     // Simulate the pre-pass: move wid from space1 to space2 in the VWM before any
@@ -1013,20 +1054,18 @@ fn window_removed_from_source_space_when_source_empty_event_fires_first() {
         .virtual_workspace_manager()
         .active_workspace(space2)
         .expect("space2 must have an active workspace");
-    reactor.layout_manager.layout_engine.virtual_workspace_manager_mut().assign_window_to_workspace(
-        space2,
-        wid,
-        space2_workspace,
-    );
+    reactor
+        .layout_manager
+        .layout_engine
+        .virtual_workspace_manager_mut()
+        .assign_window_to_workspace(space2, wid, space2_workspace);
 
     // Source space1's empty event fires first.  Because the VWM was pre-updated the
     // loop no longer re-adds wid to `desired`, so removal proceeds.
-    let _ = reactor.layout_manager.layout_engine.handle_event(LayoutEvent::WindowsOnScreenUpdated(
-        space1,
-        pid,
-        vec![],
-        None,
-    ));
+    let _ = reactor
+        .layout_manager
+        .layout_engine
+        .handle_event(LayoutEvent::WindowsOnScreenUpdated(space1, pid, vec![], None));
 
     assert!(
         !has_windows_in_layout(&mut reactor, space1, screen1, pid),
@@ -1034,12 +1073,15 @@ fn window_removed_from_source_space_when_source_empty_event_fires_first() {
     );
 
     // Destination space2 event fires after.
-    let _ = reactor.layout_manager.layout_engine.handle_event(LayoutEvent::WindowsOnScreenUpdated(
-        space2,
-        pid,
-        vec![window_update_tuple(wid)],
-        None,
-    ));
+    let _ = reactor
+        .layout_manager
+        .layout_engine
+        .handle_event(LayoutEvent::WindowsOnScreenUpdated(
+            space2,
+            pid,
+            vec![window_update_tuple(wid)],
+            None,
+        ));
     assert!(has_windows_in_layout(&mut reactor, space2, screen2, pid));
 }
 
@@ -1060,21 +1102,22 @@ fn window_preserved_in_space_on_empty_discovery_without_cross_space_move() {
 
     reactor.handle_event(screen_params_event(vec![screen], vec![Some(space)], vec![]));
 
-    let _ = reactor.layout_manager.layout_engine.handle_event(LayoutEvent::WindowsOnScreenUpdated(
-        space,
-        pid,
-        vec![window_update_tuple(wid)],
-        None,
-    ));
+    let _ = reactor
+        .layout_manager
+        .layout_engine
+        .handle_event(LayoutEvent::WindowsOnScreenUpdated(
+            space,
+            pid,
+            vec![window_update_tuple(wid)],
+            None,
+        ));
     assert!(has_windows_in_layout(&mut reactor, space, screen, pid));
 
     // AX returns empty — window is still in the VWM for this space (it was never moved).
-    let _ = reactor.layout_manager.layout_engine.handle_event(LayoutEvent::WindowsOnScreenUpdated(
-        space,
-        pid,
-        vec![],
-        None,
-    ));
+    let _ = reactor
+        .layout_manager
+        .layout_engine
+        .handle_event(LayoutEvent::WindowsOnScreenUpdated(space, pid, vec![], None));
 
     assert!(
         has_windows_in_layout(&mut reactor, space, screen, pid),
@@ -1091,21 +1134,13 @@ fn discovery_after_display_change_places_window_on_correct_display() {
     // This exercises the full WindowsDiscovered → emit_layout_events path including
     // the pre-pass VWM update (Case 2: source space processed first in screen order).
     let mut apps = Apps::new();
-    let mut reactor = Reactor::new_for_test(LayoutEngine::new(
-        &crate::common::config::VirtualWorkspaceSettings::default(),
-        &crate::common::config::LayoutSettings::default(),
-        None,
-    ));
-    let screen1 = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
-    let screen2 = CGRect::new(CGPoint::new(1000., 0.), CGSize::new(1000., 1000.));
-    let space1 = SpaceId::new(1);
-    let space2 = SpaceId::new(2);
-
-    reactor.handle_event(screen_params_event(
-        vec![screen1, screen2],
-        vec![Some(space1), Some(space2)],
-        vec![],
-    ));
+    let TwoSpaceFixture {
+        mut reactor,
+        screen1,
+        screen2,
+        space1,
+        space2,
+    } = two_space_fixture();
 
     // Window starts on screen1.
     reactor.handle_events(apps.make_app(1, make_windows(1)));

--- a/src/layout_engine/engine.rs
+++ b/src/layout_engine/engine.rs
@@ -977,14 +977,28 @@ impl LayoutEngine {
         for (ws_id, layout) in self.workspace_layouts.active_layouts_for_space(space) {
             let mut desired = tiled_by_workspace.get(&ws_id).cloned().unwrap_or_default();
             for wid in self.virtual_workspace_manager.workspace_windows(space, ws_id) {
-                if wid.pid != pid || self.floating.is_floating(wid) || desired.contains(&wid) {
+                // Skip re-adding if the VWM no longer assigns this window to this space
+                // (it was moved to another space during this discovery cycle).
+                if wid.pid != pid
+                    || self.floating.is_floating(wid)
+                    || desired.contains(&wid)
+                    || self.virtual_workspace_manager.workspace_for_window(space, wid).is_none()
+                {
                     continue;
                 }
                 desired.push(wid);
             }
 
             if desired.is_empty() && total_tiled_count == 0 {
-                if self.workspace_tree(ws_id).has_windows_for_app(layout, pid) {
+                // Only skip removal if the windows still in the layout tree are genuinely
+                // assigned to this space in the VWM. If the VWM no longer tracks them here
+                // (they were moved to another space), the empty update is authoritative and
+                // removal should proceed.
+                let tree_windows = self.workspace_tree(ws_id).windows_for_app(layout, pid);
+                let any_moved_away = tree_windows.iter().any(|wid| {
+                    self.virtual_workspace_manager.workspace_for_window(space, *wid).is_none()
+                });
+                if !tree_windows.is_empty() && !any_moved_away {
                     continue;
                 }
             }

--- a/src/layout_engine/engine.rs
+++ b/src/layout_engine/engine.rs
@@ -994,17 +994,17 @@ impl LayoutEngine {
             }
 
             if desired.is_empty() && total_tiled_count == 0 {
-                // Only skip removal if the windows still in the layout tree are genuinely
-                // assigned to this space in the VWM. If the VWM no longer tracks them here
-                // (they were moved to another space), the empty update is authoritative and
-                // removal should proceed.
+                // Empty discovery can mean AX temporarily omitted the app. Preserve
+                // windows still assigned to this workspace, but allow moved windows
+                // to be removed from this layout tree.
                 let tree_windows = self.workspace_tree(ws_id).windows_for_app(layout, pid);
-                let any_moved_away = tree_windows
-                    .iter()
-                    .any(|wid| self.window_no_longer_assigned_to_space(space, *wid));
-                if !tree_windows.is_empty() && !any_moved_away {
-                    continue;
-                }
+                desired = tree_windows
+                    .into_iter()
+                    .filter(|wid| {
+                        self.virtual_workspace_manager.workspace_for_window(space, *wid)
+                            == Some(ws_id)
+                    })
+                    .collect();
             }
 
             desired.sort_unstable();

--- a/src/layout_engine/engine.rs
+++ b/src/layout_engine/engine.rs
@@ -965,6 +965,10 @@ impl LayoutEngine {
         Some((workspace_id, workspace_name))
     }
 
+    fn window_no_longer_assigned_to_space(&self, space: SpaceId, wid: WindowId) -> bool {
+        self.virtual_workspace_manager.workspace_for_window(space, wid).is_none()
+    }
+
     fn sync_tiled_windows_for_app(
         &mut self,
         space: SpaceId,
@@ -982,7 +986,7 @@ impl LayoutEngine {
                 if wid.pid != pid
                     || self.floating.is_floating(wid)
                     || desired.contains(&wid)
-                    || self.virtual_workspace_manager.workspace_for_window(space, wid).is_none()
+                    || self.window_no_longer_assigned_to_space(space, wid)
                 {
                     continue;
                 }
@@ -995,9 +999,9 @@ impl LayoutEngine {
                 // (they were moved to another space), the empty update is authoritative and
                 // removal should proceed.
                 let tree_windows = self.workspace_tree(ws_id).windows_for_app(layout, pid);
-                let any_moved_away = tree_windows.iter().any(|wid| {
-                    self.virtual_workspace_manager.workspace_for_window(space, *wid).is_none()
-                });
+                let any_moved_away = tree_windows
+                    .iter()
+                    .any(|wid| self.window_no_longer_assigned_to_space(space, *wid));
                 if !tree_windows.is_empty() && !any_moved_away {
                     continue;
                 }


### PR DESCRIPTION
## Summary

Fixes a bug where windows oscillate ~30 times/second between two display layout trees after a lid open/close cycle with an external monitor.

**Root cause:** `sync_tiled_windows_for_app` left windows in two space layout trees simultaneously after a cross-display move. Both spaces issued conflicting `SetWindowFrame` calls that fed back into each other indefinitely.

Two bugs in `engine.rs` conspired to keep the window in the source space's tree even after the VWM had moved it to the destination:

1. **Loop re-add bug:** The loop that re-adds known VWM windows to `desired` did not check whether the VWM still assigned each window to *this* space. A moved window was re-added to the source tree from a stale VWM snapshot.

2. **Guard bug:** The "AX login-screen guard" (`if desired.is_empty() && total_tiled_count == 0`) only checked `has_windows_for_app`, not whether those tree windows had been moved to another space. It skipped removal when it should have allowed it.

**Fix (engine.rs):**
- Loop: skip re-adding any window whose VWM assignment for this space is gone (`workspace_for_window` returns `None`).
- Guard: check if the windows in the layout tree have been moved away in the VWM; if so, allow removal to proceed. The login-screen/AX-failure case is still preserved: when the VWM still lists the window here (nothing moved it), the guard continues to skip removal.

**Fix (window_discovery.rs):**
- Add a pre-pass in `emit_layout_events` that updates the VWM for all claimed windows *before* sending any per-space `WindowsOnScreenUpdated` events. This makes the engine fix order-independent regardless of which space's event fires first.

**Tests:**
- `window_removed_from_source_space_when_dest_claims_it_first` — Case 1: destination space fires first (engine guard fix)
- `window_removed_from_source_space_when_source_empty_event_fires_first` — Case 2: source empty event fires first (loop fix + pre-pass)
- `window_preserved_in_space_on_empty_discovery_without_cross_space_move` — regression guard for login-screen / AX-failure scenario
- `discovery_after_display_change_places_window_on_correct_display` — end-to-end integration test through the full `WindowsDiscovered → emit_layout_events` path

> **Note:** `discovery_after_display_change_places_window_on_correct_display` calls `simulate_until_quiet`, which loops forever when the bug is present (faithfully reproducing the oscillation). With the fix applied it terminates normally. This is intentional — the infinite loop *is* the bug — but be aware that running this test without the fix will hang.

> **Disclaimer:** The root cause analysis was performed by Claude Opus 4.6 (via DeepWiki analysis). The fix and tests were implemented by Claude Sonnet 4.6 (Claude Code). Guided and verified by the PR author.

> **Testing notice:** I was unable to consistently reproduce the original oscillation issue in manual testing after applying the fix, but I haven't been able to test this exhaustively. Given that this fix involves AI-generated changes to core layout logic and could introduce subtle edge cases, I'd strongly appreciate careful review and real-world testing from others before merging.

## Test plan

- [x] `cargo test` passes (all tests including 4 new regression tests)
- [x] New unit tests fail without the fix, pass with it
- [x] End-to-end test terminates with fix applied (would loop forever without it)
- [x] Manual testing: lid open/close with external monitor no longer causes window oscillation