### PR TITLE
feat: add follow option to app rules for auto workspace switching

### DIFF
--- a/rift.default.toml
+++ b/rift.default.toml
@@ -275,6 +275,7 @@ workspace_names = [
 #     Alternatively, `workspace` may be a workspace name string to target by name.
 #   - floating (boolean): whether matched windows should float by default.
 #   - manage (boolean): whether Rift should manage the matching window. Set to false to ignore the window completely (default = true).
+#   - follow (boolean): if true, switch to the assigned workspace when a matching window opens and the app is frontmost (default = false).
 #
 # Matching behavior (summary):
 #   1. All rules that match a window are evaluated.
@@ -315,6 +316,11 @@ workspace_names = [
 #   - Match by app name substring and workspace:
 #       app_rules = [
 #         { app_name = "Calendar", workspace = 2, floating = true },
+#       ]
+#
+#   - Open an app and automatically switch to its assigned workspace:
+#       app_rules = [
+#         { app_id = "com.apple.dt.Xcode", workspace = 0, follow = true },
 #       ]
 #
 #   - Accessibility example: float dialog windows for a specific app:

--- a/src/actor/reactor.rs
+++ b/src/actor/reactor.rs
@@ -516,7 +516,7 @@ impl Reactor {
                 continue;
             };
 
-            self.process_windows_for_app_rules(pid, window_ids, app_state.info.clone());
+            let _ = self.process_windows_for_app_rules(pid, window_ids, app_state.info.clone());
         }
     }
 
@@ -1457,7 +1457,7 @@ impl Reactor {
             self.app_manager.mark_wsids_recent(std::iter::once(window_server_id));
         }
 
-        self.process_windows_for_app_rules(window_id.pid, vec![window_id], app_info);
+        let _ = self.process_windows_for_app_rules(window_id.pid, vec![window_id], app_info);
     }
 
     fn try_apply_pending_space_change(&mut self) {
@@ -1515,8 +1515,8 @@ impl Reactor {
         new: Vec<(WindowId, WindowInfo)>,
         known_visible: Vec<WindowId>,
         app_info: Option<AppInfo>,
-    ) {
-        WindowDiscoveryHandler::handle_discovery(self, pid, new, known_visible, app_info);
+    ) -> bool {
+        WindowDiscoveryHandler::handle_discovery(self, pid, new, known_visible, app_info)
     }
 
     fn best_space_for_window(
@@ -1882,9 +1882,9 @@ impl Reactor {
         pid: pid_t,
         window_ids: Vec<WindowId>,
         app_info: AppInfo,
-    ) {
+    ) -> bool {
         if window_ids.is_empty() {
-            return;
+            return false;
         }
 
         let mut windows_by_space: BTreeMap<SpaceId, Vec<WindowId>> = BTreeMap::new();
@@ -1900,6 +1900,8 @@ impl Reactor {
             };
             windows_by_space.entry(space).or_default().push(wid);
         }
+
+        let mut needs_follow = false;
 
         for (space, wids) in windows_by_space {
             if !self.is_space_active(space) {
@@ -1941,6 +1943,9 @@ impl Reactor {
 
                 match assign_result {
                     Ok(AppRuleResult::Managed(assignment)) => {
+                        if assignment.follow && (!was_assigned || was_ignored) {
+                            needs_follow = true;
+                        }
                         if let Some(window) = self.window_manager.windows.get_mut(wid) {
                             window.ignore_app_rule = false;
                         }
@@ -2028,6 +2033,8 @@ impl Reactor {
                 Some(app_info.clone()),
             ));
         }
+
+        needs_follow
     }
 
     fn handle_app_activation_workspace_switch(&mut self, pid: pid_t) {
@@ -2749,6 +2756,8 @@ impl Reactor {
     }
 
     fn main_window(&self) -> Option<WindowId> { self.main_window_tracker.main_window() }
+
+    fn is_app_frontmost(&self, pid: pid_t) -> bool { self.main_window_tracker.is_frontmost(pid) }
 
     fn main_window_space(&self) -> Option<SpaceId> {
         // TODO: Optimize this with a cache or something.

--- a/src/actor/reactor/events/app.rs
+++ b/src/actor/reactor/events/app.rs
@@ -16,12 +16,16 @@ impl AppEventHandler {
         handle: AppThreadHandle,
         visible_windows: Vec<(WindowId, WindowInfo)>,
         window_server_info: Vec<WindowServerInfo>,
-        _is_frontmost: bool,
+        is_frontmost: bool,
         _main_window: Option<WindowId>,
     ) {
         reactor.app_manager.apps.insert(pid, AppState { info: info.clone(), handle });
         reactor.update_partial_window_server_info(window_server_info);
-        reactor.on_windows_discovered_with_app_info(pid, visible_windows, vec![], Some(info));
+        let needs_follow =
+            reactor.on_windows_discovered_with_app_info(pid, visible_windows, vec![], Some(info));
+        if is_frontmost && needs_follow {
+            reactor.handle_app_activation_workspace_switch(pid);
+        }
     }
 
     pub fn handle_application_terminated(reactor: &mut Reactor, pid: i32) {

--- a/src/actor/reactor/events/window.rs
+++ b/src/actor/reactor/events/window.rs
@@ -63,7 +63,11 @@ impl WindowEventHandler {
                     if let Some(wsid) = server_id {
                         reactor.app_manager.mark_wsids_recent(std::iter::once(wsid));
                     }
-                    reactor.process_windows_for_app_rules(wid.pid, vec![wid], app_info);
+                    let needs_follow =
+                        reactor.process_windows_for_app_rules(wid.pid, vec![wid], app_info);
+                    if needs_follow && reactor.is_app_frontmost(wid.pid) {
+                        reactor.handle_app_activation_workspace_switch(wid.pid);
+                    }
                 }
                 maybe_dispatch_window_added_in_space(reactor, wid, space);
             }

--- a/src/actor/reactor/events/window_discovery.rs
+++ b/src/actor/reactor/events/window_discovery.rs
@@ -25,6 +25,7 @@ impl WindowDiscoveryHandler {
     }
 
     /// Handle a windows discovered event with app info.
+    /// Returns true if any matched app rule requested a workspace follow.
     pub fn handle_discovery(
         reactor: &mut Reactor,
         pid: pid_t,
@@ -32,7 +33,7 @@ impl WindowDiscoveryHandler {
         known_visible: Vec<WindowId>,
         // pending_refresh: bool,
         app_info: Option<AppInfo>,
-    ) {
+    ) -> bool {
         // If app_info wasn't provided, try to look it up from our running app state so
         // we can apply workspace rules immediately on first discovery.
         let app_info =
@@ -44,7 +45,7 @@ impl WindowDiscoveryHandler {
         let new_windows = Self::process_window_list(reactor, new, &app_info);
         Self::update_window_states(reactor, new_windows, &app_info);
 
-        Self::emit_layout_events(reactor, pid, &known_visible, &app_info);
+        Self::emit_layout_events(reactor, pid, &known_visible, &app_info)
     }
 
     fn sync_window_server_id_mapping(
@@ -406,9 +407,9 @@ impl WindowDiscoveryHandler {
         pid: pid_t,
         known_visible: &[WindowId],
         app_info: &Option<AppInfo>,
-    ) {
+    ) -> bool {
         if !reactor.window_manager.windows.iter().any(|(wid, _)| wid.pid == pid) {
-            return;
+            return false;
         }
 
         let mut app_windows: BTreeMap<SpaceId, Vec<WindowId>> = BTreeMap::new();
@@ -474,6 +475,10 @@ impl WindowDiscoveryHandler {
             }
         }
 
+        let needs_follow = assignment_results.values().any(|r| {
+            matches!(r, Ok(AppRuleResult::Managed(a)) if a.follow)
+        });
+
         let screens = reactor.space_manager.screens.clone();
         for screen in screens {
             let Some(space) = screen.space else {
@@ -537,5 +542,7 @@ impl WindowDiscoveryHandler {
         {
             reactor.send_layout_event(LayoutEvent::WindowFocused(space, main_window));
         }
+
+        needs_follow
     }
 }

--- a/src/actor/reactor/main_window.rs
+++ b/src/actor/reactor/main_window.rs
@@ -82,6 +82,10 @@ impl MainWindowTracker {
             _ => None,
         }
     }
+
+    pub fn is_frontmost(&self, pid: pid_t) -> bool {
+        self.apps.get(&pid).map(|app| app.is_frontmost).unwrap_or(false)
+    }
 }
 
 #[cfg(test)]

--- a/src/actor/reactor/tests.rs
+++ b/src/actor/reactor/tests.rs
@@ -1483,3 +1483,105 @@ fn discovery_after_display_change_places_window_on_correct_display() {
         "window must be laid out on screen2"
     );
 }
+
+#[test]
+fn process_windows_for_app_rules_returns_follow_for_new_assignment() {
+    let mut settings = crate::common::config::VirtualWorkspaceSettings::default();
+    settings.app_rules = vec![crate::common::config::AppWorkspaceRule {
+        app_id: Some("com.test.follow".into()),
+        workspace: Some(crate::common::config::WorkspaceSelector::Index(1)),
+        floating: false,
+        manage: true,
+        follow: true,
+        app_name: None,
+        title_regex: None,
+        title_substring: None,
+        ax_role: None,
+        ax_subrole: None,
+    }];
+
+    let mut reactor = Reactor::new_for_test(LayoutEngine::new(
+        &settings,
+        &crate::common::config::LayoutSettings::default(),
+        None,
+    ));
+    let screen = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
+    let space = SpaceId::new(1);
+    reactor.handle_event(screen_params_event(vec![screen], vec![Some(space)], vec![]));
+
+    let pid: pid_t = 42;
+    let wid = WindowId::new(pid, 1);
+    let mut window_state: super::WindowState = make_window(1).into();
+    window_state.is_manageable = true;
+    reactor.window_manager.windows.insert(wid, window_state);
+    reactor.app_manager.apps.insert(
+        pid,
+        super::AppState {
+            info: crate::actor::app::AppInfo {
+                bundle_id: Some("com.test.follow".into()),
+                localized_name: Some("FollowApp".into()),
+            },
+            handle: crate::actor::app::AppThreadHandle::new_for_test(
+                crate::actor::channel().0,
+            ),
+        },
+    );
+
+    let needs_follow = reactor.process_windows_for_app_rules(
+        pid,
+        vec![wid],
+        crate::actor::app::AppInfo {
+            bundle_id: Some("com.test.follow".into()),
+            localized_name: Some("FollowApp".into()),
+        },
+    );
+    assert!(needs_follow, "process_windows_for_app_rules should return true when follow=true and window is newly assigned");
+}
+
+#[test]
+fn maybe_auto_switch_to_window_workspace_changes_active_workspace() {
+    let mut reactor = Reactor::new_for_test(LayoutEngine::new(
+        &crate::common::config::VirtualWorkspaceSettings::default(),
+        &crate::common::config::LayoutSettings::default(),
+        None,
+    ));
+    let screen = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
+    let space = SpaceId::new(1);
+    reactor.handle_event(screen_params_event(vec![screen], vec![Some(space)], vec![]));
+
+    let pid: pid_t = 42;
+    let wid = WindowId::new(pid, 1);
+    let mut window_state: super::WindowState = make_window(1).into();
+    window_state.is_manageable = true;
+    reactor.window_manager.windows.insert(wid, window_state);
+
+    // Assign window to workspace 1
+    let workspace1 = reactor
+        .layout_manager
+        .layout_engine
+        .virtual_workspace_manager_mut()
+        .list_workspaces(space)[1]
+        .0;
+    reactor
+        .layout_manager
+        .layout_engine
+        .virtual_workspace_manager_mut()
+        .assign_window_to_workspace(space, wid, workspace1);
+
+    // Active workspace should still be 0 (the default)
+    let active_before = reactor
+        .layout_manager
+        .layout_engine
+        .active_workspace(space)
+        .expect("active workspace should exist");
+    assert_ne!(active_before, workspace1, "test setup: window should be on a different workspace than active");
+
+    reactor.maybe_auto_switch_to_window_workspace(pid, wid, space);
+
+    let active_after = reactor
+        .layout_manager
+        .layout_engine
+        .active_workspace(space)
+        .expect("active workspace should exist");
+    assert_eq!(active_after, workspace1, "maybe_auto_switch_to_window_workspace should switch to the window's workspace");
+}

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -119,6 +119,9 @@ pub struct AppWorkspaceRule {
     /// window invisible to Rift (no tiling, floating, or assignments).
     #[serde(default = "yes")]
     pub manage: bool,
+    /// If true, switch to the assigned workspace when this rule matches a newly opened window.
+    #[serde(default)]
+    pub follow: bool,
     /// Optional: Application name pattern (alternative to app_id)
     pub app_name: Option<String>,
     /// Optional: Regular expression to match window title (applies to window.title)

--- a/src/layout_engine/engine.rs
+++ b/src/layout_engine/engine.rs
@@ -1204,6 +1204,7 @@ impl LayoutEngine {
                                     workspace_id: ws,
                                     floating: was_floating,
                                     prev_rule_decision: false,
+                                    follow: false,
                                 }),
                                 Err(_) => {
                                     warn!(
@@ -1220,6 +1221,7 @@ impl LayoutEngine {
                         workspace_id: assigned_workspace,
                         floating: rule_says_float,
                         prev_rule_decision,
+                        follow: _,
                     } = match assignment {
                         Some(assign) => assign,
                         None => continue,

--- a/src/model/virtual_workspace.rs
+++ b/src/model/virtual_workspace.rs
@@ -47,6 +47,7 @@ pub struct AppRuleAssignment {
     pub workspace_id: VirtualWorkspaceId,
     pub floating: bool,
     pub prev_rule_decision: bool,
+    pub follow: bool,
 }
 
 /// Result of evaluating app rules for a window.
@@ -1244,6 +1245,7 @@ impl VirtualWorkspaceManager {
                     workspace_id: existing_ws,
                     floating: rule.floating,
                     prev_rule_decision,
+                    follow: rule.follow,
                 }));
             }
 
@@ -1257,6 +1259,7 @@ impl VirtualWorkspaceManager {
                     workspace_id: target_workspace_id,
                     floating: rule.floating,
                     prev_rule_decision,
+                    follow: rule.follow,
                 }));
             } else {
                 error!("Failed to assign window to workspace from app rule");
@@ -1269,6 +1272,7 @@ impl VirtualWorkspaceManager {
                 workspace_id: existing_ws,
                 floating: false,
                 prev_rule_decision,
+                follow: false,
             }));
         }
 
@@ -1279,6 +1283,7 @@ impl VirtualWorkspaceManager {
                 workspace_id: default_workspace_id,
                 floating: false,
                 prev_rule_decision,
+                follow: false,
             }))
         } else {
             error!("Failed to assign window to default workspace");
@@ -1728,6 +1733,7 @@ mod tests {
                 workspace: None,
                 floating: true,
                 manage: true,
+                follow: false,
                 app_name: None,
                 title_regex: None,
                 title_substring: None,
@@ -1740,6 +1746,7 @@ mod tests {
                 workspace: Some(WorkspaceSelector::Index(1)),
                 floating: false,
                 manage: true,
+                follow: false,
                 app_name: Some("Calendar".into()),
                 title_regex: None,
                 title_substring: None,
@@ -1752,6 +1759,7 @@ mod tests {
                 workspace: Some(WorkspaceSelector::Index(0)),
                 floating: false,
                 manage: true,
+                follow: false,
                 app_name: None,
                 title_regex: None,
                 title_substring: Some("Preferences".into()),
@@ -1764,6 +1772,7 @@ mod tests {
                 workspace: Some(WorkspaceSelector::Index(2)),
                 floating: false,
                 manage: true,
+                follow: false,
                 app_name: None,
                 title_regex: Some(r"Dialog\s+\d+".into()),
                 title_substring: None,
@@ -1776,6 +1785,7 @@ mod tests {
                 workspace: None,
                 floating: true,
                 manage: true,
+                follow: false,
                 app_name: None,
                 title_regex: None,
                 title_substring: None,
@@ -1788,6 +1798,7 @@ mod tests {
                 workspace: Some(WorkspaceSelector::Name("coding".into())),
                 floating: false,
                 manage: true,
+                follow: false,
                 app_name: None,
                 title_regex: None,
                 title_substring: None,
@@ -1800,6 +1811,7 @@ mod tests {
                 workspace: Some(WorkspaceSelector::Index(0)),
                 floating: false,
                 manage: true,
+                follow: false,
                 app_name: None,
                 title_regex: None,
                 title_substring: None,
@@ -1811,6 +1823,7 @@ mod tests {
                 workspace: Some(WorkspaceSelector::Index(2)),
                 floating: false,
                 manage: true,
+                follow: false,
                 app_name: None,
                 title_regex: None,
                 title_substring: Some("Editor".into()),
@@ -1823,6 +1836,7 @@ mod tests {
                 workspace: None,
                 floating: true,
                 manage: true,
+                follow: false,
                 app_name: None,
                 title_regex: None,
                 title_substring: Some("Bitwarden".into()),
@@ -1834,6 +1848,7 @@ mod tests {
                 workspace: Some(WorkspaceSelector::Index(2)),
                 floating: false,
                 manage: true,
+                follow: false,
                 app_name: None,
                 title_regex: None,
                 title_substring: None,
@@ -1846,6 +1861,7 @@ mod tests {
                 workspace: Some(WorkspaceSelector::Index(1)),
                 floating: false,
                 manage: true,
+                follow: false,
                 app_name: None,
                 title_regex: None,
                 title_substring: None,
@@ -1857,6 +1873,7 @@ mod tests {
                 workspace: Some(WorkspaceSelector::Index(3)),
                 floating: true,
                 manage: true,
+                follow: false,
                 app_name: None,
                 title_regex: None,
                 title_substring: Some("bitwarden".into()),
@@ -2054,5 +2071,66 @@ mod tests {
                 || bw2_updated_assignment.workspace_id == expected_updated
         );
         assert!(bw2_updated_assignment.floating);
+    }
+
+    #[test]
+    fn app_rule_follow_propagated() {
+        let space = SpaceId::new(1);
+        let mut settings = VirtualWorkspaceSettings::default();
+        settings.app_rules = vec![
+            AppWorkspaceRule {
+                app_id: Some("com.example.follow".into()),
+                workspace: Some(WorkspaceSelector::Index(1)),
+                floating: false,
+                manage: true,
+                follow: true,
+                app_name: None,
+                title_regex: None,
+                title_substring: None,
+                ax_role: None,
+                ax_subrole: None,
+            },
+            AppWorkspaceRule {
+                app_id: Some("com.example.nofollow".into()),
+                workspace: Some(WorkspaceSelector::Index(1)),
+                floating: false,
+                manage: true,
+                follow: false,
+                app_name: None,
+                title_regex: None,
+                title_substring: None,
+                ax_role: None,
+                ax_subrole: None,
+            },
+        ];
+
+        let mut manager =
+            VirtualWorkspaceManager::new_with_config(&settings, &LayoutSettings::default());
+
+        let w_follow = WindowId::new(1, 1);
+        let assignment = assign(
+            &mut manager,
+            w_follow,
+            space,
+            Some("com.example.follow"),
+            None,
+            None,
+            None,
+            None,
+        );
+        assert!(assignment.follow);
+
+        let w_nofollow = WindowId::new(2, 1);
+        let assignment_no = assign(
+            &mut manager,
+            w_nofollow,
+            space,
+            Some("com.example.nofollow"),
+            None,
+            None,
+            None,
+            None,
+        );
+        assert!(!assignment_no.follow);
     }
 }


### PR DESCRIPTION
## Summary

Adds a `follow` option to `app_rules` that, when `true`, automatically switches the user to the assigned workspace when a matching window opens and the app is frontmost.

## Problem

Before this change, if you had an app rule like:

```toml
{ app_id = "com.apple.dt.Xcode", workspace = 0 }
```

and opened Xcode while on workspace 2, the window would be created on workspace 0 but you'd stay on workspace 2. You had to manually switch to see it.

## Solution

Add a `follow` boolean field to `AppWorkspaceRule`:

```toml
{ app_id = "com.apple.dt.Xcode", workspace = 0, follow = true }
```

When `follow = true` and the app is frontmost on open, the reactor triggers the existing `handle_app_activation_workspace_switch` path to switch to the target workspace.

## Changes

- **Config**: add `follow` field to `AppWorkspaceRule`
- **Model**: propagate `follow` through `AppRuleAssignment`
- **Actor/Reactor**:
  - `handle_application_launched`: switch workspace when app opens frontmost and rule has `follow = true`
  - `handle_window_created`: switch workspace when new window opens and app is frontmost with `follow = true`
  - `process_windows_for_app_rules`: returns whether a follow is needed
  - `emit_layout_events` / `on_windows_discovered_with_app_info`: propagate follow flag
- **Tests**: add unit tests for model-level follow propagation, reactor-level follow detection, and the actual workspace switch mechanism
- **Docs**: update `rift.default.toml` with the new option and an example