### PR TITLE
feat: add wrap_size option to app rules for natural window sizing in tiles

### DIFF
--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -142,6 +142,10 @@ pub struct AppWorkspaceRule {
     /// non-empty string and will be compared against the accessibility subrole
     /// reported by the AX APIs for a window (exact string match).
     pub ax_subrole: Option<String>,
+    /// When true and floating is false, the layout will size the window's tile/column
+    /// to the window's current natural size rather than stretching it to fill.
+    #[serde(default)]
+    pub wrap_size: bool,
 }
 
 impl Default for VirtualWorkspaceSettings {
@@ -1535,5 +1539,27 @@ mod tests {
         assert!(suggestion.is_some());
         let (s, _maybe_dep) = suggestion.unwrap();
         assert_eq!(s, "toggle_stack");
+    }
+
+    #[test]
+    fn parse_wrap_size_in_app_rules() {
+        let toml = r#"
+            [settings]
+            animate = false
+
+            [virtual_workspaces]
+            app_rules = [
+                { app_id = "com.example.wrap", wrap_size = true },
+                { app_id = "com.example.nofloat", floating = false, wrap_size = true },
+            ]
+
+            [keys]
+        "#;
+
+        let cfg = Config::parse(toml).unwrap();
+        assert_eq!(cfg.virtual_workspaces.app_rules.len(), 2);
+        assert!(cfg.virtual_workspaces.app_rules[0].wrap_size);
+        assert!(cfg.virtual_workspaces.app_rules[1].wrap_size);
+        assert!(!cfg.virtual_workspaces.app_rules[1].floating);
     }
 }

--- a/src/layout_engine/engine.rs
+++ b/src/layout_engine/engine.rs
@@ -1166,20 +1166,6 @@ impl LayoutEngine {
                     max_size,
                 ) in windows_with_titles
                 {
-                    self.window_layout_constraints.insert(
-                        wid,
-                        WindowLayoutConstraints {
-                            is_resizable,
-                            locked_width: size_hint.width,
-                            locked_height: size_hint.height,
-                            min_width: min_size.map_or(0.0, |s| s.width),
-                            min_height: min_size.map_or(0.0, |s| s.height),
-                            max_width: max_size.map_or(0.0, |s| s.width),
-                            max_height: max_size.map_or(0.0, |s| s.height),
-                        }
-                        .normalized(),
-                    );
-
                     let title_ref = title_opt.as_deref();
                     let ax_role_ref = ax_role_opt.as_deref();
                     let ax_subrole_ref = ax_subrole_opt.as_deref();
@@ -1204,6 +1190,7 @@ impl LayoutEngine {
                                     workspace_id: ws,
                                     floating: was_floating,
                                     prev_rule_decision: false,
+                                    wrap_size: false,
                                 }),
                                 Err(_) => {
                                     warn!(
@@ -1220,10 +1207,28 @@ impl LayoutEngine {
                         workspace_id: assigned_workspace,
                         floating: rule_says_float,
                         prev_rule_decision,
+                        wrap_size: rule_wrap_size,
                     } = match assignment {
                         Some(assign) => assign,
                         None => continue,
                     };
+
+                    let has_valid_size = size_hint.width > 0.0 && size_hint.height > 0.0;
+                    let effective_wrap = rule_wrap_size && has_valid_size;
+                    self.window_layout_constraints.insert(
+                        wid,
+                        WindowLayoutConstraints {
+                            is_resizable: if effective_wrap { false } else { is_resizable },
+                            locked_width: size_hint.width,
+                            locked_height: size_hint.height,
+                            min_width: min_size.map_or(0.0, |s| s.width),
+                            min_height: min_size.map_or(0.0, |s| s.height),
+                            max_width: max_size.map_or(0.0, |s| s.width),
+                            max_height: max_size.map_or(0.0, |s| s.height),
+                            wrap_size: effective_wrap,
+                        }
+                        .normalized(),
+                    );
 
                     let should_float = rule_says_float || (!prev_rule_decision && was_floating);
 
@@ -1300,6 +1305,13 @@ impl LayoutEngine {
                 new_frame,
                 screens,
             } => {
+                // Update wrap_size constraints so calculate_layout sees the new size immediately.
+                if let Some(c) = self.window_layout_constraints.get_mut(&wid) {
+                    if c.wrap_size {
+                        c.locked_width = new_frame.size.width;
+                        c.locked_height = new_frame.size.height;
+                    }
+                }
                 for (space, screen_frame, display_uuid) in screens {
                     let Some((ws_id, layout)) = self.workspace_and_layout(space) else {
                         debug!(
@@ -3162,5 +3174,108 @@ mod tests {
             ),
             before
         );
+    }
+
+    #[test]
+    fn windows_on_screen_updated_sets_wrap_size_constraints() {
+        let mut engine = test_engine();
+        let space = SpaceId::new(42);
+        let screen = CGRect::new(CGPoint::new(0.0, 0.0), CGSize::new(1000.0, 800.0));
+        let pid = 1;
+        let wid = WindowId::new(pid, 1);
+
+        // Configure app rule with wrap_size
+        let mut settings = VirtualWorkspaceSettings::default();
+        settings.app_rules = vec![crate::common::config::AppWorkspaceRule {
+            app_id: Some("com.example.wrap".into()),
+            workspace: None,
+            floating: false,
+            manage: true,
+            app_name: None,
+            title_regex: None,
+            title_substring: None,
+            ax_role: None,
+            ax_subrole: None,
+            wrap_size: true,
+        }];
+        engine.update_virtual_workspace_settings(&settings);
+
+        let app_info = crate::actor::app::AppInfo {
+            bundle_id: Some("com.example.wrap".into()),
+            localized_name: None,
+        };
+
+        let _ = engine.handle_event(LayoutEvent::SpaceExposed(space, screen.size));
+        let _ = engine.handle_event(LayoutEvent::WindowsOnScreenUpdated(
+            space,
+            pid,
+            vec![(
+                wid,
+                None,
+                None,
+                None,
+                true,
+                CGSize::new(400.0, 600.0),
+                None,
+                None,
+            )],
+            Some(app_info),
+        ));
+
+        let c = engine
+            .window_layout_constraints
+            .get(&wid)
+            .copied()
+            .expect("constraint missing");
+        assert!(c.wrap_size);
+        assert!(!c.is_resizable);
+        assert_eq!(c.locked_width, 400.0);
+        assert_eq!(c.locked_height, 600.0);
+    }
+
+    #[test]
+    fn window_resized_updates_wrap_size_locked_dimensions() {
+        let mut engine = test_engine();
+        let space = SpaceId::new(42);
+        let screen = CGRect::new(CGPoint::new(0.0, 0.0), CGSize::new(1000.0, 800.0));
+        let pid = 1;
+        let wid = WindowId::new(pid, 1);
+
+        let _ = engine.handle_event(LayoutEvent::SpaceExposed(space, screen.size));
+        let _ = engine.handle_event(LayoutEvent::WindowsOnScreenUpdated(
+            space,
+            pid,
+            vec![(
+                wid,
+                None,
+                None,
+                None,
+                true,
+                CGSize::new(400.0, 600.0),
+                None,
+                None,
+            )],
+            None,
+        ));
+
+        // Manually mark as wrap_size to simulate what the app rule would have done
+        if let Some(c) = engine.window_layout_constraints.get_mut(&wid) {
+            c.wrap_size = true;
+        }
+
+        let _ = engine.handle_event(LayoutEvent::WindowResized {
+            wid,
+            old_frame: CGRect::new(CGPoint::new(0.0, 0.0), CGSize::new(400.0, 600.0)),
+            new_frame: CGRect::new(CGPoint::new(0.0, 0.0), CGSize::new(500.0, 700.0)),
+            screens: vec![(space, screen, None)],
+        });
+
+        let c = engine
+            .window_layout_constraints
+            .get(&wid)
+            .copied()
+            .expect("constraint missing");
+        assert_eq!(c.locked_width, 500.0);
+        assert_eq!(c.locked_height, 700.0);
     }
 }

--- a/src/layout_engine/systems.rs
+++ b/src/layout_engine/systems.rs
@@ -17,6 +17,7 @@ pub struct WindowLayoutConstraints {
     pub min_height: f64,
     pub max_width: f64,
     pub max_height: f64,
+    pub wrap_size: bool,
 }
 
 impl WindowLayoutConstraints {
@@ -40,6 +41,7 @@ impl WindowLayoutConstraints {
             min_height,
             max_width,
             max_height,
+            wrap_size: self.wrap_size,
         }
     }
 
@@ -192,7 +194,8 @@ mod tests {
             min_height: 470.0,
             max_width: 723.0,
             max_height: 0.0,
-        }
+                        wrap_size: false,
+            }
         .normalized();
 
         assert_eq!(c.fixed_for_axis(true), Some(723.0));
@@ -212,7 +215,8 @@ mod tests {
             min_height: 0.0,
             max_width: 0.0,
             max_height: 0.0,
-        }
+                        wrap_size: false,
+            }
         .normalized();
 
         assert_eq!(c.fixed_for_axis(true), None);
@@ -231,7 +235,8 @@ mod tests {
             min_height: 0.0,
             max_width: 0.0,
             max_height: 0.0,
-        }
+                        wrap_size: false,
+            }
         .normalized();
 
         assert_eq!(c.fixed_for_axis(true), Some(640.0));
@@ -251,7 +256,8 @@ mod tests {
             min_height: 0.0,
             max_width: 600.0,
             max_height: 480.0,
-        }
+                        wrap_size: false,
+            }
         .normalized();
 
         assert_eq!(c.fixed_for_axis(true), None);

--- a/src/layout_engine/systems/bsp.rs
+++ b/src/layout_engine/systems/bsp.rs
@@ -830,6 +830,7 @@ mod tests {
                 min_height: 0.0,
                 max_width: 600.0,
                 max_height: 0.0,
+                            wrap_size: false,
             }
             .normalized(),
         );
@@ -882,6 +883,7 @@ mod tests {
                 min_height: 0.0,
                 max_width: 0.0,
                 max_height: 200.0,
+                            wrap_size: false,
             }
             .normalized(),
         );

--- a/src/layout_engine/systems/scrolling.rs
+++ b/src/layout_engine/systems/scrolling.rs
@@ -607,13 +607,21 @@ impl LayoutSystem for ScrollingLayoutSystem {
         let mut column_ratios = Vec::with_capacity(state.columns.len());
         for col in state.columns.iter() {
             let ratio = self.clamp_ratio(base_ratio + col.width_offset);
-            let base_width = (tiling.size.width * ratio).max(1.0);
+            let normal_base_width = (tiling.size.width * ratio).max(1.0);
             let mut min_w: f64 = 1.0;
             let mut fixed_w: Option<f64> = None;
             let mut max_w: Option<f64> = None;
+            let mut col_has_wrap = false;
+            let mut wrap_width = 0.0f64;
             for wid in &col.windows {
                 if let Some(c) = constraints.get(wid).copied() {
                     let c = c.normalized();
+                    if c.wrap_size {
+                        col_has_wrap = true;
+                        if let Some(locked) = c.fixed_for_axis(true) {
+                            wrap_width = wrap_width.max(locked);
+                        }
+                    }
                     min_w = min_w.max(c.min_for_axis(true));
                     if let Some(locked) = c.fixed_for_axis(true) {
                         fixed_w = Some(match fixed_w {
@@ -630,6 +638,11 @@ impl LayoutSystem for ScrollingLayoutSystem {
                 }
             }
             let required_w = fixed_w.unwrap_or(min_w).max(min_w);
+            let base_width = if col_has_wrap && wrap_width > 0.0 {
+                wrap_width
+            } else {
+                normal_base_width
+            };
             let mut width = base_width.max(required_w);
             if let Some(max_w) = max_w {
                 width = width.min(max_w).max(required_w);
@@ -1446,6 +1459,7 @@ mod tests {
                 min_height: 500.0,
                 max_width: 0.0,
                 max_height: 0.0,
+                            wrap_size: false,
             }
             .normalized(),
         );
@@ -1492,6 +1506,7 @@ mod tests {
                 min_height: 350.0,
                 max_width: 0.0,
                 max_height: 0.0,
+                            wrap_size: false,
             }
             .normalized(),
         );
@@ -1529,6 +1544,7 @@ mod tests {
                 min_height: 0.0,
                 max_width: 600.0,
                 max_height: 0.0,
+                            wrap_size: false,
             }
             .normalized(),
         );
@@ -1574,6 +1590,7 @@ mod tests {
                 min_height: 0.0,
                 max_width: 700.0,
                 max_height: 0.0,
+                            wrap_size: false,
             }
             .normalized(),
         );
@@ -1587,6 +1604,7 @@ mod tests {
                 min_height: 0.0,
                 max_width: 500.0,
                 max_height: 0.0,
+                            wrap_size: false,
             }
             .normalized(),
         );
@@ -1626,6 +1644,7 @@ mod tests {
                 min_height: 0.0,
                 max_width: 0.0,
                 max_height: 0.0,
+                            wrap_size: false,
             }
             .normalized(),
         );
@@ -2011,6 +2030,78 @@ mod tests {
             "expected centered x to persist, got {} -> {}",
             before.origin.x,
             after.origin.x
+        );
+    }
+
+    #[test]
+    fn wrap_size_shrinks_column_to_window_size() {
+        let mut system = ScrollingLayoutSystem::new(&ScrollingLayoutSettings::default());
+        let layout = system.create_layout();
+        let w1 = wid(1, 1);
+        let w2 = wid(1, 2);
+        system.add_window_after_selection(layout, w1);
+        system.add_window_after_selection(layout, w2);
+
+        let mut constraints = HashMap::default();
+        constraints.insert(
+            w1,
+            WindowLayoutConstraints {
+                is_resizable: false,
+                locked_width: 400.0,
+                locked_height: 600.0,
+                min_width: 0.0,
+                min_height: 0.0,
+                max_width: 0.0,
+                max_height: 0.0,
+                wrap_size: true,
+            }
+            .normalized(),
+        );
+        constraints.insert(
+            w2,
+            WindowLayoutConstraints {
+                is_resizable: true,
+                locked_width: 0.0,
+                locked_height: 0.0,
+                min_width: 0.0,
+                min_height: 0.0,
+                max_width: 0.0,
+                max_height: 0.0,
+                wrap_size: false,
+            }
+            .normalized(),
+        );
+
+        let s = screen(1000.0, 800.0);
+        let gaps = GapSettings::default();
+        let frames = system.calculate_layout(
+            layout,
+            s,
+            0.0,
+            &constraints,
+            &gaps,
+            0.0,
+            Default::default(),
+            Default::default(),
+        );
+
+        let f1 = frame_for(&frames, w1);
+        let f2 = frame_for(&frames, w2);
+
+        // Wrapped column should be sized to the window's locked width
+        assert!(
+            (f1.size.width - 400.0).abs() < 1.0,
+            "expected wrapped column width ~400, got {}",
+            f1.size.width
+        );
+
+        // Non-wrapped column should use the normal ratio-based width (~700)
+        let expected_normal = 1000.0 * ScrollingLayoutSettings::default().column_width_ratio;
+        assert!(
+            (f2.size.width - expected_normal).abs() < 5.0,
+            "expected normal column width ~{}, got {}",
+            expected_normal,
+            f2.size.width
         );
     }
 }

--- a/src/layout_engine/systems/traditional.rs
+++ b/src/layout_engine/systems/traditional.rs
@@ -3448,7 +3448,8 @@ mod tests {
                     min_height: 120.0,
                     max_width: 280.0,
                     max_height: 120.0,
-                }
+                                wrap_size: false,
+            }
                 .normalized(),
             );
         }
@@ -3509,6 +3510,7 @@ mod tests {
                 min_height: 200.0,
                 max_width: 320.0,
                 max_height: 200.0,
+                            wrap_size: false,
             }
             .normalized(),
         );
@@ -3572,6 +3574,7 @@ mod tests {
                 min_height: 200.0,
                 max_width: 320.0,
                 max_height: 200.0,
+                            wrap_size: false,
             }
             .normalized(),
         );
@@ -3655,6 +3658,7 @@ mod tests {
                 min_height: 200.0,
                 max_width: 360.0,
                 max_height: 200.0,
+                            wrap_size: false,
             }
             .normalized(),
         );
@@ -3711,6 +3715,7 @@ mod tests {
                 min_height: 300.0,
                 max_width: 200.0,
                 max_height: 300.0,
+                            wrap_size: false,
             }
             .normalized(),
         );
@@ -3767,6 +3772,7 @@ mod tests {
                 min_height: 0.0,
                 max_width: 360.0,
                 max_height: 0.0,
+                            wrap_size: false,
             }
             .normalized(),
         );
@@ -3823,6 +3829,7 @@ mod tests {
                 min_height: 0.0,
                 max_width: 320.0,
                 max_height: 0.0,
+                            wrap_size: false,
             }
             .normalized(),
         );
@@ -3936,6 +3943,7 @@ mod tests {
                 min_height: 0.0,
                 max_width: 0.0,
                 max_height: 200.0,
+                            wrap_size: false,
             }
             .normalized(),
         );
@@ -4000,6 +4008,7 @@ mod tests {
                 min_height: 0.0,
                 max_width: 320.0,
                 max_height: 0.0,
+                            wrap_size: false,
             }
             .normalized(),
         );
@@ -4061,7 +4070,8 @@ mod tests {
                     min_height: 0.0,
                     max_width: 320.0,
                     max_height: 0.0,
-                }
+                                wrap_size: false,
+            }
                 .normalized(),
             );
         }
@@ -4125,7 +4135,8 @@ mod tests {
                     min_height: 0.0,
                     max_width: 0.0,
                     max_height: 0.0,
-                }
+                                wrap_size: false,
+            }
                 .normalized(),
             );
         }
@@ -4180,6 +4191,7 @@ mod tests {
                 min_height: 0.0,
                 max_width: 0.0,
                 max_height: 0.0,
+                            wrap_size: false,
             }
             .normalized(),
         );
@@ -4278,6 +4290,7 @@ mod tests {
                 min_height: 0.0,
                 max_width: 0.0,
                 max_height: 200.0,
+                            wrap_size: false,
             }
             .normalized(),
         );
@@ -4343,6 +4356,7 @@ mod tests {
                 min_height: 200.0,
                 max_width: 280.0,
                 max_height: 200.0,
+                            wrap_size: false,
             }
             .normalized(),
         );
@@ -4691,6 +4705,7 @@ mod tests {
                 min_height: 0.0,
                 max_width: 0.0,
                 max_height: 0.0,
+                            wrap_size: false,
             }
             .normalized(),
         );
@@ -4704,6 +4719,7 @@ mod tests {
                 min_height: 0.0,
                 max_width: 0.0,
                 max_height: 0.0,
+                            wrap_size: false,
             }
             .normalized(),
         );
@@ -4758,6 +4774,7 @@ mod tests {
                 min_height: 0.0,
                 max_width: 0.0,
                 max_height: 0.0,
+                            wrap_size: false,
             }
             .normalized(),
         );
@@ -4771,6 +4788,7 @@ mod tests {
                 min_height: 0.0,
                 max_width: 0.0,
                 max_height: 0.0,
+                            wrap_size: false,
             }
             .normalized(),
         );
@@ -4821,6 +4839,7 @@ mod tests {
                 min_height: 0.0,
                 max_width: 1000.0,
                 max_height: 0.0,
+                            wrap_size: false,
             }
             .normalized(),
         );
@@ -4834,6 +4853,7 @@ mod tests {
                 min_height: 0.0,
                 max_width: 0.0,
                 max_height: 0.0,
+                            wrap_size: false,
             }
             .normalized(),
         );
@@ -4885,6 +4905,7 @@ mod tests {
                 min_height: 0.0,
                 max_width: 600.0,
                 max_height: 0.0,
+                            wrap_size: false,
             }
             .normalized(),
         );

--- a/src/model/virtual_workspace.rs
+++ b/src/model/virtual_workspace.rs
@@ -47,6 +47,7 @@ pub struct AppRuleAssignment {
     pub workspace_id: VirtualWorkspaceId,
     pub floating: bool,
     pub prev_rule_decision: bool,
+    pub wrap_size: bool,
 }
 
 /// Result of evaluating app rules for a window.
@@ -163,6 +164,8 @@ pub struct VirtualWorkspaceManager {
     #[serde(skip)]
     window_rule_floating: HashMap<(SpaceId, WindowId), bool>,
     #[serde(skip)]
+    window_rule_wrap_size: HashMap<(SpaceId, WindowId), bool>,
+    #[serde(skip)]
     last_rule_decision: HashMap<(SpaceId, WindowId), bool>,
     floating_positions: HashMap<(SpaceId, VirtualWorkspaceId), FloatingWindowPositions>,
     workspace_counter: usize,
@@ -220,6 +223,7 @@ impl VirtualWorkspaceManager {
             active_workspace_per_space: HashMap::default(),
             window_to_workspace: HashMap::default(),
             window_rule_floating: HashMap::default(),
+            window_rule_wrap_size: HashMap::default(),
             last_rule_decision: HashMap::default(),
             floating_positions: HashMap::default(),
             workspace_counter: 1,
@@ -398,6 +402,16 @@ impl VirtualWorkspaceManager {
             new_window_rule_floating.insert((target_space, wid), is_float);
         }
         self.window_rule_floating = new_window_rule_floating;
+
+        let mut new_window_rule_wrap_size = HashMap::default();
+        for ((space, wid), wrap) in std::mem::take(&mut self.window_rule_wrap_size) {
+            if space == new_space && old_space != new_space {
+                continue;
+            }
+            let target_space = if space == old_space { new_space } else { space };
+            new_window_rule_wrap_size.insert((target_space, wid), wrap);
+        }
+        self.window_rule_wrap_size = new_window_rule_wrap_size;
 
         let mut new_last_rule_decision = HashMap::default();
         for ((space, wid), decision) in std::mem::take(&mut self.last_rule_decision) {
@@ -690,6 +704,7 @@ impl VirtualWorkspaceManager {
                     workspace.remove_window(wid);
                 }
                 self.window_rule_floating.remove(&(space, wid));
+                self.window_rule_wrap_size.remove(&(space, wid));
                 self.last_rule_decision.remove(&(space, wid));
             }
         }
@@ -714,6 +729,7 @@ impl VirtualWorkspaceManager {
                     workspace.remove_window(window_id);
                 }
                 self.window_rule_floating.remove(&(space, window_id));
+                self.window_rule_wrap_size.remove(&(space, window_id));
                 self.last_rule_decision.remove(&(space, window_id));
             }
         }
@@ -736,6 +752,10 @@ impl VirtualWorkspaceManager {
             }
         }
         true
+    }
+
+    pub fn is_window_wrap_size(&self, space: SpaceId, window_id: WindowId) -> bool {
+        self.window_rule_wrap_size.get(&(space, window_id)).copied().unwrap_or(false)
     }
 
     pub fn windows_in_inactive_workspaces(&self, space: SpaceId) -> Vec<WindowId> {
@@ -1240,10 +1260,16 @@ impl VirtualWorkspaceManager {
                 } else {
                     self.window_rule_floating.remove(&(space, window_id));
                 }
+                if rule.wrap_size && !rule.floating {
+                    self.window_rule_wrap_size.insert((space, window_id), true);
+                } else {
+                    self.window_rule_wrap_size.remove(&(space, window_id));
+                }
                 return Ok(AppRuleResult::Managed(AppRuleAssignment {
                     workspace_id: existing_ws,
                     floating: rule.floating,
                     prev_rule_decision,
+                    wrap_size: rule.wrap_size && !rule.floating,
                 }));
             }
 
@@ -1253,10 +1279,16 @@ impl VirtualWorkspaceManager {
                 } else {
                     self.window_rule_floating.remove(&(space, window_id));
                 }
+                if rule.wrap_size && !rule.floating {
+                    self.window_rule_wrap_size.insert((space, window_id), true);
+                } else {
+                    self.window_rule_wrap_size.remove(&(space, window_id));
+                }
                 return Ok(AppRuleResult::Managed(AppRuleAssignment {
                     workspace_id: target_workspace_id,
                     floating: rule.floating,
                     prev_rule_decision,
+                    wrap_size: rule.wrap_size && !rule.floating,
                 }));
             } else {
                 error!("Failed to assign window to workspace from app rule");
@@ -1265,20 +1297,24 @@ impl VirtualWorkspaceManager {
 
         if let Some(existing_ws) = existing_assignment {
             self.window_rule_floating.remove(&(space, window_id));
+            self.window_rule_wrap_size.remove(&(space, window_id));
             return Ok(AppRuleResult::Managed(AppRuleAssignment {
                 workspace_id: existing_ws,
                 floating: false,
                 prev_rule_decision,
+                wrap_size: false,
             }));
         }
 
         let default_workspace_id = self.get_default_workspace(space)?;
         if self.assign_window_to_workspace(space, window_id, default_workspace_id) {
             self.window_rule_floating.remove(&(space, window_id));
+            self.window_rule_wrap_size.remove(&(space, window_id));
             Ok(AppRuleResult::Managed(AppRuleAssignment {
                 workspace_id: default_workspace_id,
                 floating: false,
                 prev_rule_decision,
+                wrap_size: false,
             }))
         } else {
             error!("Failed to assign window to default workspace");
@@ -1733,6 +1769,7 @@ mod tests {
                 title_substring: None,
                 ax_role: None,
                 ax_subrole: None,
+                wrap_size: false,
             },
             // Match by app_name -> workspace 1
             AppWorkspaceRule {
@@ -1745,6 +1782,7 @@ mod tests {
                 title_substring: None,
                 ax_role: None,
                 ax_subrole: None,
+                wrap_size: false,
             },
             // Title substring -> workspace 0
             AppWorkspaceRule {
@@ -1757,6 +1795,7 @@ mod tests {
                 title_substring: Some("Preferences".into()),
                 ax_role: None,
                 ax_subrole: None,
+                wrap_size: false,
             },
             // Title regex -> workspace 2
             AppWorkspaceRule {
@@ -1769,6 +1808,7 @@ mod tests {
                 title_substring: None,
                 ax_role: None,
                 ax_subrole: None,
+                wrap_size: false,
             },
             // AX role + subrole floating
             AppWorkspaceRule {
@@ -1781,6 +1821,7 @@ mod tests {
                 title_substring: None,
                 ax_role: Some("AXWindow".into()),
                 ax_subrole: Some("AXDialog".into()),
+                wrap_size: false,
             },
             // Workspace by name
             AppWorkspaceRule {
@@ -1793,6 +1834,7 @@ mod tests {
                 title_substring: None,
                 ax_role: None,
                 ax_subrole: None,
+                wrap_size: false,
             },
             // Specificity tie breaking generic vs substring (generic workspace 0, specific workspace 2)
             AppWorkspaceRule {
@@ -1805,6 +1847,7 @@ mod tests {
                 title_substring: None,
                 ax_role: None,
                 ax_subrole: None,
+                wrap_size: false,
             },
             AppWorkspaceRule {
                 app_id: Some("com.example.tie".into()),
@@ -1816,6 +1859,7 @@ mod tests {
                 title_substring: Some("Editor".into()),
                 ax_role: None,
                 ax_subrole: None,
+                wrap_size: false,
             },
             // Reapplication: Bitwarden title becomes floating
             AppWorkspaceRule {
@@ -1828,6 +1872,7 @@ mod tests {
                 title_substring: Some("Bitwarden".into()),
                 ax_role: None,
                 ax_subrole: None,
+                wrap_size: false,
             },
             AppWorkspaceRule {
                 app_id: Some("app.zen-browser.zen".into()),
@@ -1839,6 +1884,7 @@ mod tests {
                 title_substring: None,
                 ax_role: None,
                 ax_subrole: None,
+                wrap_size: false,
             },
             // Workspace override when specific rule matches different workspace + floating
             AppWorkspaceRule {
@@ -1851,6 +1897,7 @@ mod tests {
                 title_substring: None,
                 ax_role: None,
                 ax_subrole: None,
+                wrap_size: false,
             },
             AppWorkspaceRule {
                 app_id: Some("app.zen-browser.zen".into()),
@@ -1862,6 +1909,7 @@ mod tests {
                 title_substring: Some("bitwarden".into()),
                 ax_role: None,
                 ax_subrole: None,
+                wrap_size: false,
             },
         ];
 
@@ -2054,5 +2102,61 @@ mod tests {
                 || bw2_updated_assignment.workspace_id == expected_updated
         );
         assert!(bw2_updated_assignment.floating);
+    }
+
+    #[test]
+    fn app_rule_wrap_size_sets_assignment_and_persists() {
+        let space = SpaceId::new(1);
+        let mut settings = VirtualWorkspaceSettings::default();
+        settings.app_rules = vec![AppWorkspaceRule {
+            app_id: Some("com.example.wrap".into()),
+            workspace: None,
+            floating: false,
+            manage: true,
+            app_name: None,
+            title_regex: None,
+            title_substring: None,
+            ax_role: None,
+            ax_subrole: None,
+            wrap_size: true,
+        }];
+
+        let mut manager = VirtualWorkspaceManager::new_with_config(&settings, &LayoutSettings::default());
+        let w = WindowId::new(1, 1);
+
+        let assignment = assign(&mut manager, w, space, Some("com.example.wrap"), None, None, None, None);
+        assert!(!assignment.floating);
+        assert!(assignment.wrap_size);
+        assert!(manager.is_window_wrap_size(space, w));
+
+        // Reassignment should preserve wrap_size
+        let again = assign(&mut manager, w, space, Some("com.example.wrap"), None, None, None, None);
+        assert!(again.wrap_size);
+    }
+
+    #[test]
+    fn app_rule_wrap_size_ignored_when_floating() {
+        let space = SpaceId::new(1);
+        let mut settings = VirtualWorkspaceSettings::default();
+        settings.app_rules = vec![AppWorkspaceRule {
+            app_id: Some("com.example.both".into()),
+            workspace: None,
+            floating: true,
+            manage: true,
+            app_name: None,
+            title_regex: None,
+            title_substring: None,
+            ax_role: None,
+            ax_subrole: None,
+            wrap_size: true,
+        }];
+
+        let mut manager = VirtualWorkspaceManager::new_with_config(&settings, &LayoutSettings::default());
+        let w = WindowId::new(1, 1);
+
+        let assignment = assign(&mut manager, w, space, Some("com.example.both"), None, None, None, None);
+        assert!(assignment.floating);
+        assert!(!assignment.wrap_size);
+        assert!(!manager.is_window_wrap_size(space, w));
     }
 }


### PR DESCRIPTION
## Problem

There is a convenient option to force tiling for some apps using `app_rules`:

```toml
{ app_id = "com.apple.iphonesimulator", workspace = 0, floating = false }
```

This prevents the Simulator from floating, but it leads to weird sizing behavior because the layout still stretches the window to fill the allocated column size.

## Solution

This PR adds a `wrap_size` option to `app_rules`. When `wrap_size = true` and `floating = false`, the layout column shrinks to wrap the window's actual natural size instead of stretching it to the default column ratio.

### Usage

```toml
{ app_id = "com.apple.iphonesimulator", workspace = 0, floating = false, wrap_size = true }
```

### How it works

1. **Config**: Added `wrap_size: bool` to `AppWorkspaceRule`
2. **Virtual Workspace Manager**: `wrap_size` is propagated through `AppRuleAssignment` and stored per-window in `window_rule_wrap_size`
3. **Layout Engine**: During `WindowsOnScreenUpdated`, windows with `wrap_size` get `WindowLayoutConstraints` with `wrap_size: true` and `is_resizable: false`, using their current natural size as locked dimensions
4. **Scrolling Layout**: In `calculate_layout`, if a column contains a `wrap_size` window, the column width uses the locked width directly instead of the ratio-based width
5. **Resize handling**: `WindowResized` updates the locked dimensions so the column tracks the window's new size

### Testing

Added unit tests covering:
- Config TOML parsing of `wrap_size`
- VWM rule assignment producing `wrap_size`
- `wrap_size` suppression when `floating = true`
- Layout engine constraint creation
- Resize-driven constraint updates
- Scrolling layout column width wrapping