### PR TITLE
fix(engine): mitigate focus corruption from boundary raise races

### DIFF
--- a/src/layout_engine/engine.rs
+++ b/src/layout_engine/engine.rs
@@ -762,7 +762,7 @@ impl LayoutEngine {
             {
                 let response = EventResponse {
                     focus_window: Some(fallback_focus),
-                    raise_windows: visible_windows,
+                    raise_windows: vec![],
                     boundary_hit: None,
                 };
                 self.apply_focus_response(space, ws_id, layout, &response);
@@ -1279,19 +1279,25 @@ impl LayoutEngine {
                 self.remove_window_internal(wid, true);
             }
             LayoutEvent::WindowFocused(space, wid) => {
-                self.focused_window = Some(wid);
                 if self.floating.is_floating(wid) {
+                    self.focused_window = Some(wid);
                     self.floating.set_last_focus(Some(wid));
-                } else {
-                    let Some((ws_id, layout)) = self.workspace_and_layout(space) else {
+                } else if let Some((ws_id, layout)) = self.workspace_and_layout(space) {
+                    if !self.workspace_tree(ws_id).contains_window(layout, wid) {
                         warn!(
-                            "No active workspace/layout for focused window {:?} on space {:?}",
+                            "WindowFocused ignored: wid={:?} not in active layout for space {:?}",
                             wid, space
                         );
                         return EventResponse::default();
-                    };
+                    }
+                    self.focused_window = Some(wid);
                     let _ = self.workspace_tree_mut(ws_id).select_window(layout, wid);
                     self.virtual_workspace_manager.set_last_focused_window(space, ws_id, Some(wid));
+                } else {
+                    warn!(
+                        "No active workspace/layout for focused window {:?} on space {:?}",
+                        wid, space
+                    );
                 }
             }
             LayoutEvent::WindowResized {


### PR DESCRIPTION
## Summary
This PR mitigates a bug where keyboard focus can become stuck or behave erratically when repeatedly moving focus at layout boundaries (e.g., holding down the focus-left key in a scrolling layout).

**Contributing factor:** When a directional focus command hits a boundary, the engine previously fell back by queuing a raise request for **every visible tiled window**. Rapidly sending focus commands floods the `RaiseManager` queue, causing focus confirmations from the OS to arrive out of order. These delayed `WindowFocused` events can then interfere with the engine's current focus state.

## Changes
- **Boundary fallback (`move_focus_internal`):** When there is no adjacent focus target, only keep focus on the current selection. Previously the engine returned all visible windows as `raise_windows`, causing an unbounded queue backlog when the focus key is held at the edge. Now returns `raise_windows: vec![]`.
- **Stale event guard (`WindowFocused`):** Before accepting a `WindowFocused` event, verify the reported window is still present in the active workspace/layout. Stale/delayed focus confirmations for windows that have left the layout are now dropped instead of corrupting `focused_window`.

## Scope
This mitigates the focus corruption described in #285. Further work may be needed to fully eliminate races between delayed OS confirmations and subsequent focus commands (e.g., tracking a focus generation number to ignore confirmations older than the last explicit `MoveFocus`).

## Files changed
- `src/layout_engine/engine.rs` (+12 / −6)