### PR TITLE
fix: don't drop tiled windows when app has a fullscreen space

### DIFF
--- a/src/actor/reactor.rs
+++ b/src/actor/reactor.rs
@@ -2728,7 +2728,14 @@ impl Reactor {
     }
 
     fn refresh_windows_after_mission_control(&mut self) {
-        debug!("Refreshing window state after Mission Control");
+        // Skip when on a fullscreen space: kAXWindowsAttribute is space-filtered, so
+        // apps omit their Desktop windows. check_for_new_windows sends an untracked
+        // GetVisibleWindows whose response bypasses pending_mission_control_refresh,
+        // causing those Desktop windows to be dropped from the layout, and other
+        // windows in the layout to be incorrecctly resized.
+        if !crate::sys::window_server::active_space_is_user() {
+            return;
+        }
         let ws_info = window_server::get_visible_windows_with_layer(None);
         self.update_partial_window_server_info(ws_info);
         self.mission_control_manager.pending_mission_control_refresh.clear();

--- a/src/actor/reactor.rs
+++ b/src/actor/reactor.rs
@@ -2728,6 +2728,7 @@ impl Reactor {
     }
 
     fn refresh_windows_after_mission_control(&mut self) {
+        debug!("Refreshing window state after Mission Control");
         // Skip when on a fullscreen space: kAXWindowsAttribute is space-filtered, so
         // apps omit their Desktop windows. check_for_new_windows sends an untracked
         // GetVisibleWindows whose response bypasses pending_mission_control_refresh,

--- a/src/actor/reactor/events/window.rs
+++ b/src/actor/reactor/events/window.rs
@@ -79,6 +79,20 @@ impl WindowEventHandler {
             Some(window) => window.info.sys_id,
             None => return false,
         };
+
+        // Suppress false-positive destructions when on a fullscreen space or during MC.
+        // kAXMainWindowChangedNotification triggers remove_stale_windows in app.rs, which
+        // calls kAXWindowsAttribute (space-filtered), omitting Desktop windows and emitting
+        // WindowDestroyed for them. get_window() uses CGWindowListCopyWindowInfo
+        // (not space-filtered), so Some here means the window still exists.
+        if !crate::sys::window_server::active_space_is_user() || reactor.is_mission_control_active() {
+            if let Some(ws_id) = window_server_id {
+                if crate::sys::window_server::get_window(ws_id).is_some() {
+                    return false;
+                }
+            }
+        }
+
         if let Some(ws_id) = window_server_id {
             reactor.transaction_manager.remove_for_window(ws_id);
             reactor.window_manager.window_ids.remove(&ws_id);

--- a/src/actor/reactor/events/window.rs
+++ b/src/actor/reactor/events/window.rs
@@ -85,7 +85,8 @@ impl WindowEventHandler {
         // calls kAXWindowsAttribute (space-filtered), omitting Desktop windows and emitting
         // WindowDestroyed for them. get_window() uses CGWindowListCopyWindowInfo
         // (not space-filtered), so Some here means the window still exists.
-        if !crate::sys::window_server::active_space_is_user() || reactor.is_mission_control_active() {
+        if !crate::sys::window_server::active_space_is_user() || reactor.is_mission_control_active()
+        {
             if let Some(ws_id) = window_server_id {
                 if crate::sys::window_server::get_window(ws_id).is_some() {
                     return false;

--- a/src/sys/window_server.rs
+++ b/src/sys/window_server.rs
@@ -276,7 +276,12 @@ pub fn window_spaces(id: WindowServerId) -> Vec<crate::sys::screen::SpaceId> {
 }
 
 pub fn window_space(id: WindowServerId) -> Option<crate::sys::screen::SpaceId> {
-    window_spaces(id).into_iter().next()
+    let spaces = window_spaces(id);
+    // SLSCopySpacesForWindows can return multiple space IDs for a window during
+    // Mission Control or fullscreen transitions — the window's real home space plus
+    // a transient fullscreen space. Prefer any user space (type 0) in the list so
+    // that Desktop windows are not misidentified as belonging to a fullscreen space.
+    spaces.iter().copied().find(|s| space_is_user(s.get())).or_else(|| spaces.into_iter().next())
 }
 
 pub fn window_is_ordered_in(id: WindowServerId) -> bool {
@@ -695,6 +700,7 @@ pub fn window_space_id(cid: i32, wid: u32) -> u64 {
 pub fn space_is_user(sid: u64) -> bool { unsafe { SLSSpaceGetType(*G_CONNECTION, sid) == 0 } }
 pub fn space_is_fullscreen(sid: u64) -> bool { unsafe { SLSSpaceGetType(*G_CONNECTION, sid) == 4 } }
 pub fn space_is_system(sid: u64) -> bool { unsafe { SLSSpaceGetType(*G_CONNECTION, sid) == 2 } }
+pub fn active_space_is_user() -> bool { unsafe { space_is_user(CGSGetActiveSpace(*G_CONNECTION)) } }
 pub fn wait_for_native_fullscreen_transition() {
     while !space_is_user(unsafe { CGSGetActiveSpace(*G_CONNECTION) }) {
         std::thread::sleep(Duration::from_millis(100));

--- a/src/sys/window_server.rs
+++ b/src/sys/window_server.rs
@@ -281,7 +281,11 @@ pub fn window_space(id: WindowServerId) -> Option<crate::sys::screen::SpaceId> {
     // Mission Control or fullscreen transitions — the window's real home space plus
     // a transient fullscreen space. Prefer any user space (type 0) in the list so
     // that Desktop windows are not misidentified as belonging to a fullscreen space.
-    spaces.iter().copied().find(|s| space_is_user(s.get())).or_else(|| spaces.into_iter().next())
+    spaces
+        .iter()
+        .copied()
+        .find(|s| space_is_user(s.get()))
+        .or_else(|| spaces.into_iter().next())
 }
 
 pub fn window_is_ordered_in(id: WindowServerId) -> bool {


### PR DESCRIPTION
Discovered while investigating #357.

When an app has both a native fullscreen window and a tiled Desktop window, and the active space is a fullscreen space, two code paths falsely destroy the Desktop window:

1. Prefer user spaces when `SCopySpacesForWindows` returns multiple space IDs for a window, as only those on user spaces are managed (observed during MC and fullscreen transitions).

2. `refresh_windows_after_mission_control` calls `check_for_new_windows`, which sends an untracked `GetVisibleWindows`. `kAXWindowsAttribute` is space-filtered, so the Desktop window is absent and identified as stale. Skip the refresh when the active space is not a user space.

3. `kAXMainWindowChangedNotification` triggers `remove_stale_windows`, which also uses `kAXWindowsAttribute` and emits `WindowDestroyed` for the Desktop window. This bypasses `identify_stale_windows` and its MC guards. Suppress `WindowDestroyed` when the window still exists in `CGWindowListCopyWindowInfo` (not space-filtered).