### PR TITLE
fix: handle zero window server ids

### DIFF
--- a/src/actor/app.rs
+++ b/src/actor/app.rs
@@ -889,15 +889,24 @@ impl State {
 
         let is_frontmost = trace("is_frontmost", &this.app, || this.app.frontmost())?;
 
-        let make_key_result = window_server::make_key_window(
-            this.pid,
-            WindowServerId::try_from(&this.window(first)?.elem)?,
-        );
-        if make_key_result.is_err() {
-            warn!(?this.pid, "Failed to activate app");
+        let window_server_id = match WindowServerId::try_from(&this.window(first)?.elem) {
+            Ok(wsid) => Some(wsid),
+            Err(AxError::NotFound) => {
+                debug!(
+                    ?first,
+                    "Skipping make-key request because window has no server id yet"
+                );
+                None
+            }
+            Err(err) => return Err(err.into()),
+        };
+        let make_key_result =
+            window_server_id.map(|wsid| window_server::make_key_window(this.pid, wsid));
+        if let Some(Err(err)) = &make_key_result {
+            warn!(?this.pid, ?err, "Failed to activate app");
         }
 
-        if !is_frontmost && make_key_result.is_ok() && is_standard {
+        if !is_frontmost && make_key_result.as_ref().is_some_and(Result::is_ok) && is_standard {
             let (tx, rx) = continuation();
             let (quiet_activation, quiet_window_change);
             if wids.len() == 1 {
@@ -1171,7 +1180,7 @@ impl State {
             info.is_root = true;
         }
 
-        let window_server_id = info.sys_id.or_else(|| {
+        let window_server_id = info.sys_id.filter(|sid| sid.as_nonzero().is_some()).or_else(|| {
             WindowServerId::try_from(&elem)
                 .or_else(|e| {
                     info!("Could not get window server id for {elem:?}: {e}");
@@ -1180,12 +1189,10 @@ impl State {
                 .ok()
         });
 
-        let idx = window_server_id
-            .map(|sid| NonZeroU32::new(sid.as_u32()).expect("Window server id was 0"))
-            .unwrap_or_else(|| {
-                self.last_window_idx += 1;
-                NonZeroU32::new(self.last_window_idx).unwrap()
-            });
+        let idx = window_server_id.and_then(WindowServerId::as_nonzero).unwrap_or_else(|| {
+            self.last_window_idx += 1;
+            NonZeroU32::new(self.last_window_idx).unwrap()
+        });
         let wid = WindowId { pid: self.pid, idx };
         if self.windows.contains_key(&wid) {
             trace!(?wid, "Window already registered; skipping duplicate");
@@ -1318,12 +1325,11 @@ impl State {
 
     fn id(&self, elem: &AXUIElement) -> Result<WindowId, AxError> {
         if let Ok(id) = WindowServerId::try_from(elem) {
-            let wid = WindowId {
-                pid: self.pid,
-                idx: NonZeroU32::new(id.as_u32()).expect("Window server id was 0"),
-            };
-            if self.windows.contains_key(&wid) {
-                return Ok(wid);
+            if let Some(idx) = id.as_nonzero() {
+                let wid = WindowId { pid: self.pid, idx };
+                if self.windows.contains_key(&wid) {
+                    return Ok(wid);
+                }
             }
         } else if let Some((&wid, _)) = self.windows.iter().find(|(_, w)| &w.elem == elem) {
             return Ok(wid);

--- a/src/sys/app.rs
+++ b/src/sys/app.rs
@@ -426,6 +426,7 @@ impl WindowInfo {
         let mut server_info = server_info_hint;
         let id = server_info
             .map(|info| info.id)
+            .filter(|id| id.as_nonzero().is_some())
             .or_else(|| WindowServerId::try_from(element).ok());
         let is_minimized = element.minimized().unwrap_or_default();
         let is_resizable = element.can_resize().unwrap_or(true);

--- a/src/sys/window_server.rs
+++ b/src/sys/window_server.rs
@@ -1,4 +1,5 @@
 use std::ffi::{c_int, c_void};
+use std::num::NonZeroU32;
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -44,6 +45,9 @@ impl WindowServerId {
 
     #[inline]
     pub fn as_u32(self) -> u32 { self.0 }
+
+    #[inline]
+    pub fn as_nonzero(self) -> Option<NonZeroU32> { NonZeroU32::new(self.0) }
 }
 
 impl From<WindowServerId> for u32 {
@@ -59,6 +63,9 @@ impl TryFrom<&AXUIElement> for WindowServerId {
         let res = unsafe { _AXUIElementGetWindow(element.raw_ptr().as_ptr(), &mut id) };
         if res != AXError::Success {
             return Err(AxError::Ax(res));
+        }
+        if id == 0 {
+            return Err(AxError::NotFound);
         }
         Ok(Self(id))
     }
@@ -915,4 +922,15 @@ pub unsafe fn switch_space(direction: Direction) {
             };
         },
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WindowServerId;
+
+    #[test]
+    fn zero_window_server_id_is_not_a_window_id() {
+        assert!(WindowServerId::new(0).as_nonzero().is_none());
+        assert_eq!(WindowServerId::new(42).as_nonzero().map(|id| id.get()), Some(42));
+    }
 }


### PR DESCRIPTION
Fixes #361, avoiding panic when cmux is launched.