### PR TITLE
fix(exec): focus windows launched by hotkey

### DIFF
--- a/src/actor/reactor.rs
+++ b/src/actor/reactor.rs
@@ -21,7 +21,7 @@ mod testing;
 mod tests;
 
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use events::app::AppEventHandler;
 use events::command::CommandEventHandler;
@@ -63,6 +63,8 @@ use crate::sys::window_server::{
 pub type Sender = actor::Sender<Event>;
 type Receiver = actor::Receiver<Event>;
 pub use query::ReactorQueryHandle;
+
+const FOCUS_NEXT_WINDOW_TIMEOUT: Duration = Duration::from_secs(8);
 
 pub(crate) use crate::model::reactor::{
     AppState, FullscreenSpaceTrack, FullscreenWindowTrack, PendingSpaceChange, WindowFilter,
@@ -368,6 +370,7 @@ impl Reactor {
             refocus_manager: managers::RefocusManager {
                 stale_cleanup_state: StaleCleanupState::Enabled,
                 refocus_state: RefocusState::None,
+                focus_next_window_deadline: None,
             },
             pending_space_change_manager: managers::PendingSpaceChangeManager {
                 pending_space_change: None,
@@ -2653,6 +2656,64 @@ impl Reactor {
                 app_handles,
                 focus_quiet: quiet,
             }));
+    }
+
+    pub(crate) fn request_focus_next_window(&mut self) {
+        self.refocus_manager.focus_next_window_deadline =
+            Some(Instant::now() + FOCUS_NEXT_WINDOW_TIMEOUT);
+    }
+
+    pub(crate) fn cancel_focus_next_window(&mut self) {
+        self.refocus_manager.focus_next_window_deadline = None;
+    }
+
+    fn consume_focus_next_window_for(&mut self, wid: WindowId) -> bool {
+        let Some(deadline) = self.refocus_manager.focus_next_window_deadline else {
+            return false;
+        };
+
+        if Instant::now() > deadline {
+            self.cancel_focus_next_window();
+            return false;
+        }
+
+        let Some(window) = self.window_manager.windows.get(&wid) else {
+            return false;
+        };
+        if !window.matches_filter(WindowFilter::EffectivelyManageable) {
+            return false;
+        }
+
+        let Some(space) = self.best_space_for_window_state(window) else {
+            return false;
+        };
+        if !self.is_space_active(space)
+            || !self.layout_manager.layout_engine.is_window_in_active_workspace(space, wid)
+        {
+            return false;
+        }
+
+        self.cancel_focus_next_window();
+        let warp = if self.config.settings.mouse_follows_focus {
+            self.window_center_on_known_screen(wid)
+        } else {
+            None
+        };
+        self.raise_window(wid, Quiet::No, warp);
+        self.send_layout_event(LayoutEvent::WindowFocused(space, wid));
+        true
+    }
+
+    fn consume_focus_next_window_from<I>(&mut self, windows: I) -> bool
+    where
+        I: IntoIterator<Item = WindowId>,
+    {
+        for wid in windows {
+            if self.consume_focus_next_window_for(wid) {
+                return true;
+            }
+        }
+        false
     }
 
     fn clear_menu_state_for_pid(&mut self, pid: pid_t) {

--- a/src/actor/reactor/events/command.rs
+++ b/src/actor/reactor/events/command.rs
@@ -181,6 +181,8 @@ impl CommandEventHandler {
             ReactorCommand::FocusWindow { window_id, window_server_id } => {
                 Self::handle_command_reactor_focus_window(reactor, window_id, window_server_id)
             }
+            ReactorCommand::FocusNextWindow => reactor.request_focus_next_window(),
+            ReactorCommand::CancelFocusNextWindow => reactor.cancel_focus_next_window(),
             ReactorCommand::ShowMissionControlAll => {
                 send_wm_cmd(
                     reactor,

--- a/src/actor/reactor/events/window.rs
+++ b/src/actor/reactor/events/window.rs
@@ -66,6 +66,7 @@ impl WindowEventHandler {
                     reactor.process_windows_for_app_rules(wid.pid, vec![wid], app_info);
                 }
                 maybe_dispatch_window_added_in_space(reactor, wid, space);
+                reactor.consume_focus_next_window_for(wid);
             }
         }
         // TODO: drag state is maybe managed by ensure_active_drag

--- a/src/actor/reactor/events/window_discovery.rs
+++ b/src/actor/reactor/events/window_discovery.rs
@@ -42,9 +42,12 @@ impl WindowDiscoveryHandler {
             Self::identify_stale_windows(reactor, pid, &known_visible);
         Self::cleanup_stale_windows(reactor, pid, stale_windows, pending_refresh);
         let new_windows = Self::process_window_list(reactor, new, &app_info);
+        let discovered_new_windows: Vec<WindowId> =
+            new_windows.iter().map(|(wid, _)| *wid).collect();
         Self::update_window_states(reactor, new_windows, &app_info);
 
         Self::emit_layout_events(reactor, pid, &known_visible, &app_info);
+        reactor.consume_focus_next_window_from(discovered_new_windows);
     }
 
     fn sync_window_server_id_mapping(

--- a/src/actor/reactor/managers.rs
+++ b/src/actor/reactor/managers.rs
@@ -167,6 +167,7 @@ impl WorkspaceSwitchManager {
 pub struct RefocusManager {
     pub stale_cleanup_state: super::StaleCleanupState,
     pub refocus_state: super::RefocusState,
+    pub focus_next_window_deadline: Option<Instant>,
 }
 
 /// Manages communication channels to other actors

--- a/src/actor/reactor/tests.rs
+++ b/src/actor/reactor/tests.rs
@@ -352,6 +352,76 @@ fn handle_layout_response_includes_handles_for_raise_and_focus_windows() {
 }
 
 #[test]
+fn focus_next_window_focuses_discovered_new_window() {
+    let mut apps = Apps::new();
+    let mut reactor = Reactor::new_for_test(LayoutEngine::new(
+        &crate::common::config::VirtualWorkspaceSettings::default(),
+        &crate::common::config::LayoutSettings::default(),
+        None,
+    ));
+    let (raise_manager_tx, mut raise_manager_rx) = actor::channel();
+    reactor.communication_manager.raise_manager_tx = raise_manager_tx;
+    let screen = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
+    let space = SpaceId::new(1);
+    reactor.handle_event(screen_params_event(vec![screen], vec![Some(space)], vec![]));
+
+    reactor.handle_event(Event::Command(Command::Reactor(ReactorCommand::FocusNextWindow)));
+    reactor.handle_events(apps.make_app(1, make_windows(1)));
+
+    let mut focus_requests = Vec::new();
+    while let Ok((_, msg)) = raise_manager_rx.try_recv() {
+        if let raise_manager::Event::RaiseRequest(RaiseRequest {
+            focus_window: Some((wid, _)),
+            ..
+        }) = msg
+        {
+            focus_requests.push(wid);
+        }
+    }
+
+    assert!(
+        focus_requests.contains(&WindowId::new(1, 1)),
+        "FocusNextWindow should focus the first manageable window discovered after an exec"
+    );
+    assert_eq!(
+        reactor.layout_manager.layout_engine.selected_window(space),
+        Some(WindowId::new(1, 1))
+    );
+}
+
+#[test]
+fn canceled_focus_next_window_does_not_focus_discovered_window() {
+    let mut apps = Apps::new();
+    let mut reactor = Reactor::new_for_test(LayoutEngine::new(
+        &crate::common::config::VirtualWorkspaceSettings::default(),
+        &crate::common::config::LayoutSettings::default(),
+        None,
+    ));
+    let (raise_manager_tx, mut raise_manager_rx) = actor::channel();
+    reactor.communication_manager.raise_manager_tx = raise_manager_tx;
+    let screen = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
+    reactor.handle_event(screen_params_event(
+        vec![screen],
+        vec![Some(SpaceId::new(1))],
+        vec![],
+    ));
+
+    reactor.handle_event(Event::Command(Command::Reactor(ReactorCommand::FocusNextWindow)));
+    reactor.handle_event(Event::Command(Command::Reactor(ReactorCommand::CancelFocusNextWindow)));
+    reactor.handle_events(apps.make_app(1, make_windows(1)));
+
+    while let Ok((_, msg)) = raise_manager_rx.try_recv() {
+        if let raise_manager::Event::RaiseRequest(RaiseRequest {
+            focus_window: Some((WindowId { pid: 1, .. }, _)),
+            ..
+        }) = msg
+        {
+            panic!("CancelFocusNextWindow should cancel the pending exec focus request");
+        }
+    }
+}
+
+#[test]
 fn workspace_switch_batches_all_windows_with_eui_enabled() {
     let mut apps = Apps::new();
     let mut reactor = Reactor::new_for_test(LayoutEngine::new(

--- a/src/actor/wm_controller.rs
+++ b/src/actor/wm_controller.rs
@@ -443,21 +443,39 @@ impl WmController {
     }
 
     fn exec_cmd(&self, cmd_args: ExecCmd) {
+        let cmd_args = cmd_args.as_array().into_owned();
+        if cmd_args.is_empty() {
+            error!("Empty argument list passed to exec");
+            return;
+        }
+
+        self.events_tx.send(reactor::Event::Command(reactor::Command::Reactor(
+            reactor::ReactorCommand::FocusNextWindow,
+        )));
+
+        let events_tx = self.events_tx.clone();
         std::thread::spawn(move || {
-            let cmd_args = cmd_args.as_array();
             let [cmd, args @ ..] = &*cmd_args else {
-                error!("Empty argument list passed to exec");
+                events_tx.send(reactor::Event::Command(reactor::Command::Reactor(
+                    reactor::ReactorCommand::CancelFocusNextWindow,
+                )));
                 return;
             };
             let output = std::process::Command::new(cmd).args(args).output();
             let output = match output {
                 Ok(o) => o,
                 Err(e) => {
+                    events_tx.send(reactor::Event::Command(reactor::Command::Reactor(
+                        reactor::ReactorCommand::CancelFocusNextWindow,
+                    )));
                     error!("Failed to execute command {cmd:?}: {e:?}");
                     return;
                 }
             };
             if !output.status.success() {
+                events_tx.send(reactor::Event::Command(reactor::Command::Reactor(
+                    reactor::ReactorCommand::CancelFocusNextWindow,
+                )));
                 error!(
                     "Exec command exited with status {}: {cmd:?} {args:?}",
                     output.status

--- a/src/model/reactor.rs
+++ b/src/model/reactor.rs
@@ -39,6 +39,8 @@ pub enum ReactorCommand {
         window_id: WindowId,
         window_server_id: Option<WindowServerId>,
     },
+    FocusNextWindow,
+    CancelFocusNextWindow,
     ShowMissionControlAll,
     ShowMissionControlCurrent,
     DismissMissionControl,


### PR DESCRIPTION
## Summary
- arm a short-lived focus request when an `exec` hotkey succeeds
- consume that request when the next manageable new window is discovered
- add tests for focus and cancellation paths

## Tests
- `cargo test focus_next_window --lib`
- `cargo test --lib`
- `cargo check --bins`
- `git diff --check upstream/main...HEAD`