### PR TITLE
feat: Decouple Master/Stack Side Placement from Window Arrangement Direction

### DIFF
--- a/rift.default.toml
+++ b/rift.default.toml
@@ -92,7 +92,7 @@ new_window_placement = "master"
 # master_arrangement = "vertical"
 # Orientation arrangement for the stack area (horizontal | vertical)
 # If omitted, defaults to the direction perpendicular to master_side's split
-# non_master_arrangement = "vertical"
+# stack_arrangement = "vertical"
 
 # these settings only apply when layout mode == "scrolling"
 [settings.layout.scrolling]

--- a/rift.default.toml
+++ b/rift.default.toml
@@ -87,6 +87,12 @@ master_count = 1
 master_side = "left"
 # Where new windows go when the master area is already full (master | stack | focused)
 new_window_placement = "master"
+# Orientation arrangement for the master area (horizontal | vertical)
+# If omitted, defaults to the direction perpendicular to master_side's split
+# master_arrangement = "vertical"
+# Orientation arrangement for the stack area (horizontal | vertical)
+# If omitted, defaults to the direction perpendicular to master_side's split
+# non_master_arrangement = "vertical"
 
 # these settings only apply when layout mode == "scrolling"
 [settings.layout.scrolling]

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -715,6 +715,12 @@ pub struct MasterStackSettings {
     /// Where new windows are inserted when the master area is already full
     #[serde(default = "default_master_stack_new_window_placement")]
     pub new_window_placement: MasterStackNewWindowPlacement,
+    /// Orientation arrangement for the master area (override default derived from master_side)
+    #[serde(default)]
+    pub master_arrangement: Option<crate::layout_engine::Orientation>,
+    /// Orientation arrangement for the stack area (override default derived from master_side)
+    #[serde(default)]
+    pub non_master_arrangement: Option<crate::layout_engine::Orientation>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
@@ -866,6 +872,8 @@ impl Default for MasterStackSettings {
             master_count: default_master_stack_count(),
             master_side: MasterStackSide::Left,
             new_window_placement: default_master_stack_new_window_placement(),
+            master_arrangement: None,
+            non_master_arrangement: None,
         }
     }
 }

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -720,7 +720,7 @@ pub struct MasterStackSettings {
     pub master_arrangement: Option<crate::layout_engine::Orientation>,
     /// Orientation arrangement for the stack area (override default derived from master_side)
     #[serde(default)]
-    pub non_master_arrangement: Option<crate::layout_engine::Orientation>,
+    pub stack_arrangement: Option<crate::layout_engine::Orientation>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
@@ -873,7 +873,7 @@ impl Default for MasterStackSettings {
             master_side: MasterStackSide::Left,
             new_window_placement: default_master_stack_new_window_placement(),
             master_arrangement: None,
-            non_master_arrangement: None,
+            stack_arrangement: None,
         }
     }
 }

--- a/src/layout_engine/systems/master_stack.rs
+++ b/src/layout_engine/systems/master_stack.rs
@@ -63,6 +63,18 @@ impl MasterStackLayoutSystem {
         }
     }
 
+    fn master_orientation(&self) -> Orientation {
+        self.settings
+            .master_arrangement
+            .unwrap_or_else(|| self.container_orientation())
+    }
+
+    fn stack_orientation(&self) -> Orientation {
+        self.settings
+            .non_master_arrangement
+            .unwrap_or_else(|| self.container_orientation())
+    }
+
     fn master_first(&self) -> bool {
         matches!(
             self.settings.master_side,
@@ -140,16 +152,16 @@ impl MasterStackLayoutSystem {
 
     fn create_containers(&mut self, root: NodeId) -> (NodeId, NodeId) {
         self.inner.set_layout(root, LayoutKind::from(self.root_orientation()));
-        let container_kind = LayoutKind::from(self.container_orientation());
         let first = self.inner.tree.mk_node().push_back(root);
-        self.inner.set_layout(first, container_kind);
         let second = self.inner.tree.mk_node().push_back(root);
-        self.inner.set_layout(second, container_kind);
-        if self.master_first() {
+        let (master, stack) = if self.master_first() {
             (first, second)
         } else {
             (second, first)
-        }
+        };
+        self.inner.set_layout(master, LayoutKind::from(self.master_orientation()));
+        self.inner.set_layout(stack, LayoutKind::from(self.stack_orientation()));
+        (master, stack)
     }
 
     fn apply_master_ratio(&mut self, root: NodeId, master: NodeId, stack: NodeId) {
@@ -180,14 +192,13 @@ impl MasterStackLayoutSystem {
         let first = children[0];
         let second = children[1];
         self.inner.set_layout(root, LayoutKind::from(self.root_orientation()));
-        let container_kind = LayoutKind::from(self.container_orientation());
-        self.inner.set_layout(first, container_kind);
-        self.inner.set_layout(second, container_kind);
         let (master, stack) = if self.master_first() {
             (first, second)
         } else {
             (second, first)
         };
+        self.inner.set_layout(master, LayoutKind::from(self.master_orientation()));
+        self.inner.set_layout(stack, LayoutKind::from(self.stack_orientation()));
         self.apply_master_ratio(root, master, stack);
         (root, master, stack)
     }
@@ -665,7 +676,11 @@ impl LayoutSystem for MasterStackLayoutSystem {
         let Some(container) = self.focused_container(layout, master, stack) else {
             return false;
         };
-        let container_axis = self.container_orientation();
+        let container_axis = if container == master {
+            self.master_orientation()
+        } else {
+            self.stack_orientation()
+        };
         let (towards_master, towards_stack) = match self.settings.master_side {
             MasterStackSide::Left => (direction == Direction::Left, direction == Direction::Right),
             MasterStackSide::Right => (direction == Direction::Right, direction == Direction::Left),

--- a/src/layout_engine/systems/master_stack.rs
+++ b/src/layout_engine/systems/master_stack.rs
@@ -64,15 +64,11 @@ impl MasterStackLayoutSystem {
     }
 
     fn master_orientation(&self) -> Orientation {
-        self.settings
-            .master_arrangement
-            .unwrap_or_else(|| self.container_orientation())
+        self.settings.master_arrangement.unwrap_or_else(|| self.container_orientation())
     }
 
     fn stack_orientation(&self) -> Orientation {
-        self.settings
-            .stack_arrangement
-            .unwrap_or_else(|| self.container_orientation())
+        self.settings.stack_arrangement.unwrap_or_else(|| self.container_orientation())
     }
 
     fn master_first(&self) -> bool {

--- a/src/layout_engine/systems/master_stack.rs
+++ b/src/layout_engine/systems/master_stack.rs
@@ -71,7 +71,7 @@ impl MasterStackLayoutSystem {
 
     fn stack_orientation(&self) -> Orientation {
         self.settings
-            .non_master_arrangement
+            .stack_arrangement
             .unwrap_or_else(|| self.container_orientation())
     }
 


### PR DESCRIPTION
I Implemented the feature requested in #366 , allowing users to decouple the `master_side` placement from the internal layout arrangement of the master and stack windows. Already tested on my side and worked so far without problems.

The changes are rather small and incremental. Therefore they should be safe to merge.