### PR TITLE
fix: keyboard becomes unresponsive after prolonged use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ascii_tree"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1283,6 +1292,7 @@ name = "rift-wm"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "ascii_tree",
  "bitflags 2.11.0",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ doctest = false
 
 [dependencies]
 anyhow = { version = "1.0.83", default-features = false }
+arc-swap = "1"
 ascii_tree = "0.1.1"
 thiserror = { version = "2.0.17", default-features = false }
 bitflags = "2.4.1"

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -8,6 +8,7 @@ pub mod config;
 pub mod config_watcher;
 pub mod drag_swap;
 pub mod event_tap;
+pub mod gesture_tap;
 pub mod menu_bar;
 pub mod mission_control;
 pub mod mission_control_observer;

--- a/src/actor/event_tap.rs
+++ b/src/actor/event_tap.rs
@@ -15,7 +15,7 @@
 //! Requests from the main thread arrive via the actor channel (`Receiver`).
 //! The main thread's `GestureTap` is a separate `ListenOnly` tap for gestures.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::panic::AssertUnwindSafe;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -69,18 +69,17 @@ pub enum Request {
 }
 
 pub struct EventTap {
-    config: RefCell<Config>,
     events_tx: reactor::Sender,
     requests_rx: Option<Receiver>,
     state: RefCell<State>,
-    event_mask: RefCell<CGEventMask>,
+    event_mask: Cell<CGEventMask>,
     tap: RefCell<Option<crate::sys::event_tap::EventTap>>,
     disable_hotkey: RefCell<Option<Hotkey>>,
     hotkey_specs: RefCell<Vec<(String, WmCommand)>>,
     hotkeys: SharedHotkeyTable,
-    wm_sender: Option<wm_controller::Sender>,
-    stack_line_tx: Option<stack_line::Sender>,
-    stack_line_hit_rects: Option<stack_line::SharedHitRects>,
+    wm_sender: wm_controller::Sender,
+    stack_line_tx: stack_line::Sender,
+    stack_line_hit_rects: stack_line::SharedHitRects,
 }
 
 // SAFETY: EventTap is constructed on the input thread and all access occurs on
@@ -150,9 +149,7 @@ unsafe fn drop_mouse_ctx(ptr: *mut std::ffi::c_void) {
 
 impl EventTap {
     #[inline]
-    fn stack_line_hover_enabled(&self, state: &State) -> bool {
-        state.stack_line_enabled && self.stack_line_tx.is_some()
-    }
+    fn stack_line_hover_enabled(&self, state: &State) -> bool { state.stack_line_enabled }
 
     #[inline]
     fn focus_follows_mouse_handler_enabled(state: &State) -> bool {
@@ -203,8 +200,7 @@ impl EventTap {
 
     fn rebuild_event_tap_mask_if_needed(self: &Arc<Self>) {
         let next_mask = self.desired_event_mask();
-        let current_mask = *self.event_mask.borrow();
-        if next_mask == current_mask {
+        if next_mask == self.event_mask.get() {
             return;
         }
 
@@ -215,16 +211,16 @@ impl EventTap {
 
         let old_tap = self.tap.borrow_mut().replace(new_tap);
         drop(old_tap);
-        *self.event_mask.borrow_mut() = next_mask;
+        self.event_mask.set(next_mask);
     }
 
     pub fn new(
         config: Config,
         events_tx: reactor::Sender,
         requests_rx: Receiver,
-        wm_sender: Option<wm_controller::Sender>,
-        stack_line_tx: Option<stack_line::Sender>,
-        stack_line_hit_rects: Option<stack_line::SharedHitRects>,
+        wm_sender: wm_controller::Sender,
+        stack_line_tx: stack_line::Sender,
+        stack_line_hit_rects: stack_line::SharedHitRects,
     ) -> Self {
         let disable_hotkey = config
             .settings
@@ -243,15 +239,14 @@ impl EventTap {
         let event_mask = build_event_mask(
             disable_hotkey.is_some(),
             state.event_processing_enabled
-                && ((state.stack_line_enabled && stack_line_tx.is_some())
+                && (state.stack_line_enabled
                     || Self::focus_follows_mouse_handler_enabled(&state)),
         );
         EventTap {
-            config: RefCell::new(config),
             events_tx,
             requests_rx: Some(requests_rx),
             state: RefCell::new(state),
-            event_mask: RefCell::new(event_mask),
+            event_mask: Cell::new(event_mask),
             tap: RefCell::new(None),
             disable_hotkey: RefCell::new(disable_hotkey),
             hotkey_specs: RefCell::new(Vec::new()),
@@ -275,7 +270,7 @@ impl EventTap {
 
         let this = Arc::new(self);
 
-        let mask = *this.event_mask.borrow();
+        let mask = this.event_mask.get();
         let tap = this.create_tap_with_mask(mask);
 
         if let Some(tap) = tap {
@@ -306,6 +301,7 @@ impl EventTap {
             match tick {
                 Tick::Request(request) => this.on_request(request),
                 Tick::Watchdog => {
+                    let tap_enabled = this.tap.borrow().is_some();
                     if let Some(tap) = this.tap.borrow().as_ref() {
                         tap.set_enabled(true);
                     }
@@ -314,6 +310,8 @@ impl EventTap {
                     let mut state = this.state.borrow_mut();
                     state.reconcile_modifier_keys();
                     trace!(
+                        tap_enabled,
+                        event_mask = this.event_mask.get(),
                         pressed_keys = state.pressed_keys.len(),
                         disable_hotkey_active = state.disable_hotkey_active,
                         event_processing = state.event_processing_enabled,
@@ -399,7 +397,6 @@ impl EventTap {
                     .focus_follows_mouse_disable_hotkey
                     .clone()
                     .and_then(|spec| spec.to_hotkey());
-                *self.config.borrow_mut() = new_config;
                 *self.disable_hotkey.borrow_mut() = disable_hotkey;
                 {
                     let prev_mouse_hides_on_focus = state.mouse_hides_on_focus;
@@ -505,29 +502,21 @@ impl EventTap {
             CGEventType::LeftMouseDown | CGEventType::RightMouseDown => {
                 set_mouse_state(MouseState::Down);
 
-                if let Some(tx) = &self.stack_line_tx {
-                    let loc = CGEvent::location(Some(event));
+                let loc = CGEvent::location(Some(event));
 
-                    // The event tap is the single source of hit-testing for
-                    // stack-line indicators. Only forward the click and
-                    // suppress propagation when it lands on a visible,
-                    // non-occluded indicator.
-                    let hits_stack_line = self
-                        .stack_line_hit_rects
-                        .as_ref()
-                        .map(|hit_rects| {
-                            hit_rects
-                                .load()
-                                .iter()
-                                .copied()
-                                .any(|frame| point_hits_indicator_frame(loc, frame))
-                        })
-                        .unwrap_or(false);
-                    if hits_stack_line && !window_server::is_point_occluded_by_external_window(loc)
-                    {
-                        let _ = tx.try_send(stack_line::Event::MouseDown(loc));
-                        return false;
-                    }
+                // The event tap is the single source of hit-testing for
+                // stack-line indicators. Only forward the click and
+                // suppress propagation when it lands on a visible,
+                // non-occluded indicator.
+                let hits_stack_line = self
+                    .stack_line_hit_rects
+                    .load()
+                    .iter()
+                    .copied()
+                    .any(|frame| point_hits_indicator_frame(loc, frame));
+                if hits_stack_line && !window_server::is_point_occluded_by_external_window(loc) {
+                    let _ = self.stack_line_tx.try_send(stack_line::Event::MouseDown(loc));
+                    return false;
                 }
             }
             CGEventType::LeftMouseDragged | CGEventType::RightMouseDragged => {
@@ -569,22 +558,15 @@ impl EventTap {
                 }
 
                 // stack line hover feedback
-                if state.stack_line_enabled
-                    && let Some(tx) = &self.stack_line_tx
-                {
+                if state.stack_line_enabled {
                     let hits = self
                         .stack_line_hit_rects
-                        .as_ref()
-                        .map(|hit_rects| {
-                            hit_rects
-                                .load()
-                                .iter()
-                                .copied()
-                                .any(|frame| point_hits_indicator_frame(loc, frame))
-                        })
-                        .unwrap_or(false)
+                        .load()
+                        .iter()
+                        .copied()
+                        .any(|frame| point_hits_indicator_frame(loc, frame))
                         && !window_server::is_point_occluded_by_external_window(loc);
-                    let _ = tx.try_send(stack_line::Event::MouseMoved {
+                    let _ = self.stack_line_tx.try_send(stack_line::Event::MouseMoved {
                         point: loc,
                         hits_indicator: hits,
                     });
@@ -639,14 +621,10 @@ impl EventTap {
                     modifiers_from_flags_with_keys(state.current_flags, &state.pressed_keys),
                     key_code,
                 );
-                let Some(wm_sender) = &self.wm_sender else {
-                    debug!(?hotkey, "Hotkey triggered but no WM sender available");
-                    return true;
-                };
                 let bindings = self.hotkeys.load();
                 if let Some(commands) = bindings.get(&hotkey) {
                     for cmd in commands {
-                        wm_sender.send(WmEvent::Command(cmd.clone()));
+                        self.wm_sender.send(WmEvent::Command(cmd.clone()));
                     }
                     return false;
                 }

--- a/src/actor/event_tap.rs
+++ b/src/actor/event_tap.rs
@@ -1,19 +1,35 @@
-use std::cell::RefCell;
-use std::mem::replace;
-use std::panic::AssertUnwindSafe;
-use std::rc::Rc;
-use std::str::FromStr;
+//! Input processing via a CGEventTap on a dedicated thread.
+//!
+//! The `EventTap` (aka input processor) owns a `Default`-mode CGEventTap and
+//! runs its own CFRunLoop on a dedicated thread (`input` thread). This isolates
+//! keyboard/mouse input processing from main-thread stalls (layout computation,
+//! animation, WindowServer IPC).
+//!
+//! Shared state between the input thread and the main thread uses lock-free
+//! `Arc<ArcSwap<T>>` primitives:
+//! - `SharedHotkeyTable`: hotkey bindings, written by the input thread on
+//!   config/layout changes, read by the callback.
+//! - `SharedHitRects`: stack-line indicator frames, written by the main-thread
+//!   `StackLine` actor, read by the callback.
+//!
+//! Requests from the main thread arrive via the actor channel (`Receiver`).
+//! The main thread's `GestureTap` is a separate `ListenOnly` tap for gestures.
 
-use objc2::exception;
-use objc2_app_kit::{
-    NSEvent, NSEventPhase, NSEventType, NSMainMenuWindowLevel, NSPopUpMenuWindowLevel,
-    NSTouchPhase, NSTouchType, NSWindowLevel,
-};
+use std::cell::RefCell;
+use std::panic::AssertUnwindSafe;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use arc_swap::ArcSwap;
+
 use objc2_core_foundation::{CGPoint, CGRect};
 use objc2_core_graphics::{
     CGEvent, CGEventField, CGEventFlags, CGEventMask, CGEventTapOptions as CGTapOpt,
     CGEventTapProxy, CGEventType,
 };
+use tokio_stream::StreamExt;
+use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, error, trace, warn};
 
 use super::reactor::{self, Event};
@@ -21,25 +37,17 @@ use super::stack_line;
 use crate::actor;
 use crate::actor::wm_controller::{self, WmCommand, WmEvent};
 use crate::common::collections::{HashMap, HashSet};
-use crate::common::config::{Config, HapticPattern, LayoutMode};
-use crate::common::log::trace_misc;
-use crate::layout_engine::LayoutCommand as LC;
+use crate::common::config::{Config, LayoutMode};
 use crate::sys::event::{self, Hotkey, KeyCode, MouseState, set_mouse_state};
-use crate::sys::geometry::CGRectExt;
 use crate::sys::hotkey::{
     Modifiers, is_modifier_key, key_code_from_event, modifier_flag_for_key,
     modifiers_from_flags_with_keys,
 };
 use crate::sys::screen::{CoordinateConverter, SpaceId};
-use crate::sys::window_server::{self, WindowServerId, window_level};
-use crate::sys::{haptics, power};
+use crate::sys::window_server::{self, WindowServerId};
+use crate::sys::power;
 use crate::ui::stack_line::point_hits_indicator_frame;
 
-// Window levels can change for transient UI windows; cache briefly to reduce
-// query overhead without pinning stale values for long.
-const WINDOW_LEVEL_CACHE_TTL_NS: u64 = 300_000_000; // 300ms
-const WINDOW_LEVEL_CACHE_PRUNE_INTERVAL_NS: u64 = 1_000_000_000; // 1s
-const WINDOW_LEVEL_CACHE_MAX_ENTRIES: usize = 512;
 const MOUSE_MOVE_MIN_INTERVAL_NS_NORMAL: u64 = 8_000_000; // 8ms ~= 125 Hz
 const MOUSE_MOVE_MIN_DISTANCE_PX_SQ_NORMAL: f64 = 4.0; // 2px^2
 const MOUSE_MOVE_MIN_INTERVAL_NS_LOW_POWER: u64 = 16_000_000; // 16ms ~= 62 Hz
@@ -68,18 +76,22 @@ pub struct EventTap {
     event_mask: RefCell<CGEventMask>,
     tap: RefCell<Option<crate::sys::event_tap::EventTap>>,
     disable_hotkey: RefCell<Option<Hotkey>>,
-    swipe: RefCell<Option<SwipeHandler>>,
-    scroll: RefCell<Option<ScrollHandler>>,
     hotkey_specs: RefCell<Vec<(String, WmCommand)>>,
-    hotkeys: RefCell<HashMap<Hotkey, Vec<WmCommand>>>,
+    hotkeys: SharedHotkeyTable,
     wm_sender: Option<wm_controller::Sender>,
     stack_line_tx: Option<stack_line::Sender>,
     stack_line_hit_rects: Option<stack_line::SharedHitRects>,
 }
 
+// SAFETY: EventTap is constructed on the input thread and all access occurs on
+// that same thread (CFRunLoop callback + channel recv both run on the input
+// thread's run loop). The Send impl is required only to move the struct across
+// the thread::spawn boundary.
+unsafe impl Send for EventTap {}
+
 struct State {
     hidden: bool,
-    above_window: (Option<WindowServerId>, NSWindowLevel),
+    above_window: Option<WindowServerId>,
     mouse_hides_on_focus: bool,
     focus_follows_mouse_config_enabled: bool,
     default_layout_mode: LayoutMode,
@@ -96,21 +108,13 @@ struct State {
     layout_mode_by_space: HashMap<SpaceId, crate::common::config::LayoutMode>,
     last_mouse_move_loc: Option<CGPoint>,
     last_mouse_move_timestamp: u64,
-    window_level_cache: HashMap<WindowServerId, CachedWindowLevel>,
-    window_level_cache_last_prune_at: u64,
-}
-
-#[derive(Debug, Copy, Clone)]
-struct CachedWindowLevel {
-    level: NSWindowLevel,
-    observed_at: u64,
 }
 
 impl Default for State {
     fn default() -> Self {
         Self {
             hidden: false,
-            above_window: (None, NSWindowLevel::MIN),
+            above_window: None,
             mouse_hides_on_focus: false,
             focus_follows_mouse_config_enabled: false,
             default_layout_mode: LayoutMode::Traditional,
@@ -127,8 +131,6 @@ impl Default for State {
             layout_mode_by_space: HashMap::default(),
             last_mouse_move_loc: None,
             last_mouse_move_timestamp: 0,
-            window_level_cache: HashMap::default(),
-            window_level_cache_last_prune_at: 0,
         }
     }
 }
@@ -136,126 +138,10 @@ impl Default for State {
 pub type Sender = actor::Sender<Request>;
 pub type Receiver = actor::Receiver<Request>;
 
+pub type SharedHotkeyTable = Arc<ArcSwap<HashMap<Hotkey, Vec<WmCommand>>>>;
+
 struct CallbackCtx {
-    this: Rc<EventTap>,
-}
-
-#[derive(Debug, Clone)]
-struct SwipeConfig {
-    enabled: bool,
-    invert_horizontal: bool,
-    vertical_tolerance: f64,
-    skip_empty_workspaces: Option<bool>,
-    fingers: usize,
-    distance_pct: f64,
-    haptics_enabled: bool,
-    haptic_pattern: HapticPattern,
-}
-
-impl SwipeConfig {
-    fn from_config(config: &Config) -> Self {
-        let g = &config.settings.gestures;
-        let vt_norm = if g.swipe_vertical_tolerance > 1.0 && g.swipe_vertical_tolerance <= 100.0 {
-            (g.swipe_vertical_tolerance / 100.0).clamp(0.0, 1.0)
-        } else if g.swipe_vertical_tolerance > 100.0 {
-            1.0
-        } else {
-            g.swipe_vertical_tolerance.max(0.0).min(1.0)
-        };
-        SwipeConfig {
-            enabled: g.enabled,
-            invert_horizontal: g.invert_horizontal_swipe,
-            vertical_tolerance: vt_norm,
-            skip_empty_workspaces: if g.skip_empty { Some(true) } else { None },
-            fingers: g.fingers.max(1),
-            distance_pct: g.distance_pct.clamp(0.01, 1.0),
-            haptics_enabled: g.haptics_enabled,
-            haptic_pattern: g.haptic_pattern,
-        }
-    }
-}
-
-#[derive(Default, Debug)]
-struct SwipeState {
-    phase: GesturePhase,
-    start_x: f64,
-    start_y: f64,
-}
-
-impl SwipeState {
-    fn reset(&mut self) {
-        self.phase = GesturePhase::Idle;
-        self.start_x = 0.0;
-        self.start_y = 0.0;
-    }
-}
-
-#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
-enum GesturePhase {
-    #[default]
-    Idle,
-    Armed,
-    Committed,
-}
-
-struct SwipeHandler {
-    cfg: SwipeConfig,
-    state: RefCell<SwipeState>,
-}
-
-#[derive(Debug, Clone)]
-struct ScrollConfig {
-    enabled: bool,
-    invert_horizontal: bool,
-    vertical_tolerance: f64,
-    fingers: usize,
-    distance_pct: f64,
-}
-
-impl ScrollConfig {
-    fn from_config(config: &Config) -> Self {
-        let g = &config.settings.layout.scrolling.gestures;
-        let vt_norm = if g.vertical_tolerance > 1.0 && g.vertical_tolerance <= 100.0 {
-            (g.vertical_tolerance / 100.0).clamp(0.0, 1.0)
-        } else if g.vertical_tolerance > 100.0 {
-            1.0
-        } else {
-            g.vertical_tolerance.max(0.0).min(1.0)
-        };
-        ScrollConfig {
-            enabled: g.enabled,
-            invert_horizontal: g.invert_horizontal,
-            vertical_tolerance: vt_norm,
-            fingers: g.fingers.max(1),
-            distance_pct: g.distance_pct.clamp(0.01, 1.0),
-        }
-    }
-}
-
-#[derive(Default, Debug)]
-struct ScrollState {
-    phase: GesturePhase,
-    start_x: f64,
-    start_y: f64,
-    last_x: f64,
-    last_y: f64,
-    accum_dx: f64,
-}
-
-impl ScrollState {
-    fn reset(&mut self) {
-        self.phase = GesturePhase::Idle;
-        self.start_x = 0.0;
-        self.start_y = 0.0;
-        self.last_x = 0.0;
-        self.last_y = 0.0;
-        self.accum_dx = 0.0;
-    }
-}
-
-struct ScrollHandler {
-    cfg: ScrollConfig,
-    state: RefCell<ScrollState>,
+    this: Arc<EventTap>,
 }
 
 unsafe fn drop_mouse_ctx(ptr: *mut std::ffi::c_void) {
@@ -273,46 +159,8 @@ impl EventTap {
         state.focus_follows_mouse_config_enabled && state.focus_follows_mouse_enabled
     }
 
-    fn build_gesture_handlers(
-        config: &Config,
-        has_wm: bool,
-    ) -> (Option<SwipeHandler>, Option<ScrollHandler>) {
-        let swipe_cfg = SwipeConfig::from_config(config);
-        let swipe = if swipe_cfg.enabled && has_wm {
-            Some(SwipeHandler {
-                cfg: swipe_cfg,
-                state: RefCell::new(SwipeState::default()),
-            })
-        } else {
-            None
-        };
-
-        let scroll_cfg = ScrollConfig::from_config(config);
-        let scroll = if scroll_cfg.enabled && has_wm {
-            Some(ScrollHandler {
-                cfg: scroll_cfg,
-                state: RefCell::new(ScrollState::default()),
-            })
-        } else {
-            None
-        };
-
-        (swipe, scroll)
-    }
-
-    fn update_gesture_handlers(&self) {
-        let config = self.config.borrow();
-        let (swipe, scroll) = Self::build_gesture_handlers(&config, self.wm_sender.is_some());
-        *self.swipe.borrow_mut() = swipe;
-        *self.scroll.borrow_mut() = scroll;
-    }
-
-    fn gesture_handlers_enabled(&self) -> bool {
-        self.swipe.borrow().is_some() || self.scroll.borrow().is_some()
-    }
-
     fn keyboard_handlers_enabled(&self) -> bool {
-        self.disable_hotkey.borrow().is_some() || !self.hotkeys.borrow().is_empty()
+        self.disable_hotkey.borrow().is_some() || !self.hotkeys.load().is_empty()
     }
 
     fn mouse_move_handlers_enabled(&self) -> bool {
@@ -324,17 +172,16 @@ impl EventTap {
 
     fn desired_event_mask(&self) -> CGEventMask {
         build_event_mask(
-            self.gesture_handlers_enabled(),
             self.keyboard_handlers_enabled(),
             self.mouse_move_handlers_enabled(),
         )
     }
 
     fn create_tap_with_mask(
-        self: &Rc<Self>,
+        self: &Arc<Self>,
         mask: CGEventMask,
     ) -> Option<crate::sys::event_tap::EventTap> {
-        let ctx = Box::new(CallbackCtx { this: Rc::clone(self) });
+        let ctx = Box::new(CallbackCtx { this: Arc::clone(self) });
         let ctx_ptr = Box::into_raw(ctx) as *mut std::ffi::c_void;
 
         let tap = unsafe {
@@ -354,7 +201,7 @@ impl EventTap {
         tap
     }
 
-    fn rebuild_event_tap_mask_if_needed(self: &Rc<Self>) {
+    fn rebuild_event_tap_mask_if_needed(self: &Arc<Self>) {
         let next_mask = self.desired_event_mask();
         let current_mask = *self.event_mask.borrow();
         if next_mask == current_mask {
@@ -384,7 +231,6 @@ impl EventTap {
             .focus_follows_mouse_disable_hotkey
             .clone()
             .and_then(|spec| spec.to_hotkey());
-        let (swipe, scroll) = Self::build_gesture_handlers(&config, wm_sender.is_some());
         let mut state = State::default();
         state.mouse_hides_on_focus = config.settings.mouse_hides_on_focus;
         state.focus_follows_mouse_config_enabled = config.settings.focus_follows_mouse;
@@ -395,7 +241,6 @@ impl EventTap {
             .map(|target| state.compute_disable_hotkey_active(target))
             .unwrap_or(false);
         let event_mask = build_event_mask(
-            swipe.is_some() || scroll.is_some(),
             disable_hotkey.is_some(),
             state.event_processing_enabled
                 && ((state.stack_line_enabled && stack_line_tx.is_some())
@@ -409,10 +254,8 @@ impl EventTap {
             event_mask: RefCell::new(event_mask),
             tap: RefCell::new(None),
             disable_hotkey: RefCell::new(disable_hotkey),
-            swipe: RefCell::new(swipe),
-            scroll: RefCell::new(scroll),
             hotkey_specs: RefCell::new(Vec::new()),
-            hotkeys: RefCell::new(HashMap::default()),
+            hotkeys: Arc::new(ArcSwap::from_pointee(HashMap::default())),
             wm_sender,
             stack_line_tx,
             stack_line_hit_rects,
@@ -420,9 +263,17 @@ impl EventTap {
     }
 
     pub async fn run(mut self) {
-        let mut requests_rx = self.requests_rx.take().unwrap();
+        use crate::sys::timer::Timer;
+        use tracing::Span;
 
-        let this = Rc::new(self);
+        enum Tick {
+            Request(Request),
+            Watchdog,
+        }
+
+        let requests_rx = self.requests_rx.take().unwrap();
+
+        let this = Arc::new(self);
 
         let mask = *this.event_mask.borrow();
         let tap = this.create_tap_with_mask(mask);
@@ -442,22 +293,46 @@ impl EventTap {
             }
         }
 
-        while let Some((span, request)) = requests_rx.recv().await {
-            let _ = span.enter();
-            this.on_request(request);
+        let watchdog = Timer::repeating(Duration::from_secs(5), Duration::from_secs(5));
+
+        let mut merged = StreamExt::merge(
+            UnboundedReceiverStream::new(requests_rx)
+                .map(|(span, req)| (span, Tick::Request(req))),
+            watchdog.map(|()| (Span::none(), Tick::Watchdog)),
+        );
+
+        while let Some((span, tick)) = merged.next().await {
+            let _guard = span.enter();
+            match tick {
+                Tick::Request(request) => this.on_request(request),
+                Tick::Watchdog => {
+                    if let Some(tap) = this.tap.borrow().as_ref() {
+                        tap.set_enabled(true);
+                    }
+                    // Full modifier reconciliation: prune any pressed_keys not
+                    // reflected in the last known flags.
+                    let mut state = this.state.borrow_mut();
+                    state.reconcile_modifier_keys();
+                    trace!(
+                        pressed_keys = state.pressed_keys.len(),
+                        disable_hotkey_active = state.disable_hotkey_active,
+                        event_processing = state.event_processing_enabled,
+                        "watchdog tick"
+                    );
+                }
+            }
         }
     }
 
-    fn on_request(self: &Rc<Self>, request: Request) {
+    fn on_request(self: &Arc<Self>, request: Request) {
         let mut should_rebuild_mask = false;
-        let mut should_update_gesture_handlers = false;
         let mut state = self.state.borrow_mut();
         match request {
             Request::Warp(point) => {
                 if let Err(e) = event::warp_mouse(point) {
                     warn!("Failed to warp mouse: {e:?}");
                 } else {
-                    state.above_window = (None, NSWindowLevel::MIN);
+                    state.above_window = None;
                 }
                 if state.mouse_hides_on_focus && !state.hidden {
                     debug!("Hiding mouse");
@@ -481,8 +356,6 @@ impl EventTap {
                     .filter_map(|(frame, maybe_space)| maybe_space.map(|space| (frame, space)))
                     .collect();
                 state.converter = converter;
-                state.window_level_cache.clear();
-                state.window_level_cache_last_prune_at = 0;
             }
             Request::SpaceChanged(spaces) => {
                 state.screen_spaces = state
@@ -552,7 +425,6 @@ impl EventTap {
                         state.hidden = false;
                     }
                 }
-                should_update_gesture_handlers = true;
                 should_rebuild_mask = true;
             }
             Request::LayoutModesChanged(modes) => {
@@ -576,9 +448,6 @@ impl EventTap {
         }
         drop(state);
 
-        if should_update_gesture_handlers {
-            self.update_gesture_handlers();
-        }
         if should_rebuild_mask {
             self.rebuild_event_tap_mask_if_needed();
         }
@@ -600,28 +469,20 @@ impl EventTap {
         }
     }
 
-    fn on_event(self: &Rc<Self>, event_type: CGEventType, event: &CGEvent) -> bool {
-        if event_type.0 == NSEventType::Gesture.0 as u32 {
-            let scroll_handler = self.scroll.borrow();
-            let swipe_handler = self.swipe.borrow();
-            if scroll_handler.is_none() && swipe_handler.is_none() {
-                return true;
+    fn on_event(self: &Arc<Self>, event_type: CGEventType, event: &CGEvent) -> bool {
+        // Check if the tap was re-enabled after being disabled by timeout or
+        // user input. If so, clear pressed_keys to avoid phantom modifiers
+        // from lost key-up events during the disabled period.
+        if let Some(tap) = self.tap.borrow().as_ref() {
+            if tap.take_reenabled_flag() {
+                let mut state = self.state.borrow_mut();
+                debug!("Event tap was re-enabled; clearing pressed_keys to prevent phantom modifiers");
+                state.pressed_keys.clear();
+                state.current_flags = CGEvent::flags(Some(event));
+                state.reconcile_modifier_keys();
+                drop(state);
+                self.refresh_disable_hotkey_state(&mut self.state.borrow_mut());
             }
-
-            let state = self.state.borrow_mut();
-            if let Some(nsevent) = NSEvent::eventWithCGEvent(event)
-                && nsevent.r#type() == NSEventType::Gesture
-            {
-                let cursor = CGEvent::location(Some(event));
-                let mode = state.layout_mode_at_point(cursor).unwrap_or(state.default_layout_mode);
-                let is_scrolling_mode = matches!(mode, LayoutMode::Scrolling);
-                if is_scrolling_mode && let Some(handler) = scroll_handler.as_ref() {
-                    self.handle_scroll_gesture_event(handler, &nsevent);
-                } else if let Some(handler) = swipe_handler.as_ref() {
-                    self.handle_gesture_event(handler, &nsevent);
-                }
-            }
-            return true;
         }
 
         let mut state = self.state.borrow_mut();
@@ -635,6 +496,7 @@ impl EventTap {
             let flags = CGEvent::flags(Some(event));
             if flags != state.current_flags {
                 state.current_flags = flags;
+                state.reconcile_modifier_keys();
                 self.refresh_disable_hotkey_state(&mut state);
             }
         }
@@ -655,7 +517,7 @@ impl EventTap {
                         .as_ref()
                         .map(|hit_rects| {
                             hit_rects
-                                .borrow()
+                                .load()
                                 .iter()
                                 .copied()
                                 .any(|frame| point_hits_indicator_frame(loc, frame))
@@ -715,7 +577,7 @@ impl EventTap {
                         .as_ref()
                         .map(|hit_rects| {
                             hit_rects
-                                .borrow()
+                                .load()
                                 .iter()
                                 .copied()
                                 .any(|frame| point_hits_indicator_frame(loc, frame))
@@ -728,15 +590,19 @@ impl EventTap {
                     });
                 }
 
-                // ffm
+                // ffm — forward deduped window-under-cursor changes to the
+                // reactor. All level-based filtering (popup suppression,
+                // menu-bar gap) happens in the reactor where SLS calls don't
+                // block the event tap.
                 if state.focus_follows_mouse_config_enabled
                     && state.focus_follows_mouse_enabled
                     && !state.disable_hotkey_active
                 {
-                    if let Some(wsid) =
-                        state.track_mouse_move(loc, window_from_mouse_event(event), ts)
-                    {
-                        _ = self.events_tx.send(Event::MouseMovedOverWindow(wsid));
+                    let wsid = window_from_mouse_event(event);
+                    if let Some(wsid) = wsid {
+                        if state.above_window_changed(wsid) {
+                            _ = self.events_tx.send(Event::MouseMovedOverWindow(wsid));
+                        }
                     }
                 }
             }
@@ -744,265 +610,6 @@ impl EventTap {
         }
 
         true
-    }
-
-    fn handle_gesture_event(&self, handler: &SwipeHandler, nsevent: &NSEvent) {
-        let cfg = &handler.cfg;
-        let state = &handler.state;
-        let Some(wm_sender) = self.wm_sender.as_ref() else {
-            state.borrow_mut().reset();
-            return;
-        };
-
-        let mut st = state.borrow_mut();
-
-        let phase = nsevent.phase();
-        if matches!(
-            phase,
-            NSEventPhase::Ended | NSEventPhase::Cancelled | NSEventPhase::Began
-        ) {
-            st.reset();
-            return;
-        }
-
-        let touches = nsevent.allTouches();
-        let mut sum_x = 0.0f64;
-        let mut sum_y = 0.0f64;
-        let mut touch_count = 0usize;
-        let mut active_count = 0usize;
-        let mut too_many_touches = false;
-
-        for t in touches.iter() {
-            let phase = t.phase();
-            if phase.contains(NSTouchPhase::Stationary) {
-                continue;
-            }
-
-            let ended =
-                phase.contains(NSTouchPhase::Ended) || phase.contains(NSTouchPhase::Cancelled);
-
-            touch_count += 1;
-            if touch_count > cfg.fingers {
-                too_many_touches = true;
-                break;
-            }
-
-            if !ended && let Some((x, y)) = touch_normalized_position(&t) {
-                sum_x += x;
-                sum_y += y;
-                active_count += 1;
-            }
-        }
-
-        if too_many_touches || touch_count != cfg.fingers || active_count == 0 {
-            st.reset();
-            return;
-        }
-
-        let avg_x = sum_x / active_count as f64;
-        let avg_y = sum_y / active_count as f64;
-
-        match st.phase {
-            GesturePhase::Idle => {
-                st.start_x = avg_x;
-                st.start_y = avg_y;
-                st.phase = GesturePhase::Armed;
-                trace!(
-                    "swipe armed: start_x={:.3} start_y={:.3}",
-                    st.start_x, st.start_y
-                );
-            }
-            GesturePhase::Armed => {
-                let dx = avg_x - st.start_x;
-                let dy = avg_y - st.start_y;
-                let horizontal = dx.abs();
-                let vertical = dy.abs();
-
-                if horizontal >= cfg.distance_pct && vertical <= cfg.vertical_tolerance {
-                    let mut dir_left = dx < 0.0;
-                    if cfg.invert_horizontal {
-                        dir_left = !dir_left;
-                    }
-                    let cmd = if dir_left {
-                        LC::NextWorkspace(cfg.skip_empty_workspaces)
-                    } else {
-                        LC::PrevWorkspace(cfg.skip_empty_workspaces)
-                    };
-
-                    if cfg.haptics_enabled {
-                        let _ = haptics::perform_haptic(cfg.haptic_pattern);
-                    }
-                    wm_sender.send(WmEvent::Command(WmCommand::ReactorCommand(
-                        reactor::Command::Layout(cmd),
-                    )));
-                    st.phase = GesturePhase::Committed;
-                }
-            }
-            GesturePhase::Committed => {
-                if active_count == 0 {
-                    st.reset();
-                }
-            }
-        }
-    }
-
-    fn handle_scroll_gesture_event(&self, handler: &ScrollHandler, nsevent: &NSEvent) {
-        let cfg = &handler.cfg;
-        let state = &handler.state;
-        let Some(wm_sender) = self.wm_sender.as_ref() else {
-            state.borrow_mut().reset();
-            return;
-        };
-
-        let mut st = state.borrow_mut();
-
-        let phase = nsevent.phase();
-        if matches!(
-            phase,
-            NSEventPhase::Ended | NSEventPhase::Cancelled | NSEventPhase::Began
-        ) {
-            st.reset();
-            return;
-        }
-
-        // let phase = nsevent.phase();
-        // if [NSEventPhase::Ended, NSEventPhase::Cancelled].contains(&phase) {
-        //     wm_sender.send(WmEvent::Command(WmCommand::ReactorCommand(
-        //         reactor::Command::Layout(LC::SnapStrip),
-        //     )));
-        //     st.reset();
-        //     return;
-        // }
-        // if phase == NSEventPhase::Began {
-        //     st.reset();
-        //     return;
-        // }
-
-        let touches = nsevent.allTouches();
-        let mut sum_x = 0.0f64;
-        let mut sum_y = 0.0f64;
-        let mut touch_count = 0usize;
-        let mut active_count = 0usize;
-        let mut too_many_touches = false;
-        let mut all_moved = true;
-
-        for t in touches.iter() {
-            let phase = t.phase();
-            if phase.contains(NSTouchPhase::Stationary) {
-                all_moved = false;
-                continue;
-            }
-
-            if !phase.contains(NSTouchPhase::Moved) {
-                all_moved = false;
-            }
-
-            let ended =
-                phase.contains(NSTouchPhase::Ended) || phase.contains(NSTouchPhase::Cancelled);
-
-            touch_count += 1;
-            if touch_count > cfg.fingers {
-                too_many_touches = true;
-                break;
-            }
-
-            if !ended && let Some((x, y)) = touch_normalized_position(&t) {
-                sum_x += x;
-                sum_y += y;
-                active_count += 1;
-            }
-        }
-
-        if too_many_touches || touch_count != cfg.fingers || active_count == 0 {
-            st.reset();
-            return;
-        }
-
-        let avg_x = sum_x / active_count as f64;
-        let avg_y = sum_y / active_count as f64;
-
-        match st.phase {
-            GesturePhase::Idle => {
-                st.start_x = avg_x;
-                st.start_y = avg_y;
-                st.last_x = avg_x;
-                st.last_y = avg_y;
-                st.accum_dx = 0.0;
-                st.phase = GesturePhase::Armed;
-                trace!(
-                    "scroll armed: start_x={:.3} start_y={:.3}",
-                    st.start_x, st.start_y
-                );
-            }
-            GesturePhase::Armed => {
-                if !all_moved {
-                    st.last_x = avg_x;
-                    st.last_y = avg_y;
-                    return;
-                }
-
-                let dx = avg_x - st.last_x;
-                let dy = avg_y - st.last_y;
-                let horizontal = dx.abs();
-                let vertical = dy.abs();
-
-                st.last_x = avg_x;
-                st.last_y = avg_y;
-
-                if vertical > cfg.vertical_tolerance || vertical >= horizontal {
-                    return;
-                }
-
-                st.accum_dx += dx;
-                let step = cfg.distance_pct;
-                if st.accum_dx.abs() >= step {
-                    let delta = if cfg.invert_horizontal {
-                        -st.accum_dx
-                    } else {
-                        st.accum_dx
-                    };
-                    let cmd = LC::ScrollStrip { delta };
-
-                    wm_sender.send(WmEvent::Command(WmCommand::ReactorCommand(
-                        reactor::Command::Layout(cmd),
-                    )));
-
-                    st.accum_dx = 0.0;
-                    st.phase = GesturePhase::Committed;
-                }
-            }
-            GesturePhase::Committed => {
-                if active_count == 0 {
-                    st.reset();
-                } else if all_moved {
-                    let dx = avg_x - st.last_x;
-                    let dy = avg_y - st.last_y;
-                    let horizontal = dx.abs();
-                    let vertical = dy.abs();
-                    st.last_x = avg_x;
-                    st.last_y = avg_y;
-                    if vertical > cfg.vertical_tolerance || vertical >= horizontal {
-                        return;
-                    }
-                    st.accum_dx += dx;
-                    let step = cfg.distance_pct;
-                    if st.accum_dx.abs() >= step {
-                        let delta = if cfg.invert_horizontal {
-                            -st.accum_dx
-                        } else {
-                            st.accum_dx
-                        };
-                        let cmd = LC::ScrollStrip { delta };
-
-                        wm_sender.send(WmEvent::Command(WmCommand::ReactorCommand(
-                            reactor::Command::Layout(cmd),
-                        )));
-
-                        st.accum_dx = 0.0;
-                    }
-                }
-            }
-        }
     }
 
     fn handle_keyboard_event(
@@ -1036,7 +643,7 @@ impl EventTap {
                     debug!(?hotkey, "Hotkey triggered but no WM sender available");
                     return true;
                 };
-                let bindings = self.hotkeys.borrow();
+                let bindings = self.hotkeys.load();
                 if let Some(commands) = bindings.get(&hotkey) {
                     for cmd in commands {
                         wm_sender.send(WmEvent::Command(cmd.clone()));
@@ -1051,8 +658,7 @@ impl EventTap {
 
     fn rebuild_hotkeys_for_current_layout(&self) {
         let specs = self.hotkey_specs.borrow();
-        let mut map = self.hotkeys.borrow_mut();
-        map.clear();
+        let mut map: HashMap<Hotkey, Vec<WmCommand>> = HashMap::default();
 
         for (spec, command) in specs.iter() {
             let Ok(hotkey) = Hotkey::from_str(spec) else {
@@ -1080,6 +686,7 @@ impl EventTap {
             "Updated hotkey bindings for current keyboard layout: {}",
             map.len()
         );
+        self.hotkeys.store(Arc::new(map));
     }
 }
 
@@ -1130,7 +737,9 @@ impl State {
         true
     }
 
+    #[cfg(test)]
     fn layout_mode_at_point(&self, loc: CGPoint) -> Option<crate::common::config::LayoutMode> {
+        use crate::sys::geometry::CGRectExt;
         self.screen_spaces
             .iter()
             .find(|(frame, _)| frame.contains(loc))
@@ -1142,9 +751,28 @@ impl State {
     fn note_key_up(&mut self, key_code: KeyCode) { self.pressed_keys.remove(&key_code); }
 
     fn note_flags_changed(&mut self, key_code: KeyCode) {
-        if is_modifier_key(key_code) {
-            self.pressed_keys.remove(&key_code);
+        if !is_modifier_key(key_code) {
+            return;
         }
+        // Determine whether this modifier is currently pressed by checking
+        // the authoritative CGEventFlags, not our tracked set.
+        if let Some(flag) = modifier_flag_for_key(key_code) {
+            if self.current_flags.contains(flag) {
+                self.pressed_keys.insert(key_code);
+            } else {
+                self.pressed_keys.remove(&key_code);
+            }
+        }
+    }
+
+    fn reconcile_modifier_keys(&mut self) {
+        self.pressed_keys.retain(|key| {
+            if let Some(flag) = modifier_flag_for_key(*key) {
+                self.current_flags.contains(flag)
+            } else {
+                true // non-modifier keys are not reconciled here
+            }
+        });
     }
 
     fn compute_disable_hotkey_active(&self, target: &Hotkey) -> bool {
@@ -1189,110 +817,21 @@ impl State {
         }
     }
 
-    fn track_mouse_move(
-        &mut self,
-        loc: CGPoint,
-        hinted_window: Option<WindowServerId>,
-        event_timestamp: u64,
-    ) -> Option<WindowServerId> {
-        let new_window = hinted_window.or_else(|| window_server::get_window_at_point(loc));
-        if self.above_window.0 == new_window {
-            return None;
+    /// Returns true if the window under the cursor changed.
+    fn above_window_changed(&mut self, wsid: WindowServerId) -> bool {
+        if self.above_window == Some(wsid) {
+            return false;
         }
-
-        let new_window_level = new_window
-            .map(|id| self.cached_window_level(id, event_timestamp))
-            .unwrap_or(NSWindowLevel::MIN);
-
-        debug!("Mouse is now above window {new_window:?} (level {new_window_level:?}) at {loc:?}");
-
-        // There is a gap between the menu bar and the actual menu pop-ups when
-        // a menu is opened. When the mouse goes over this gap, the system
-        // reports it to be over whatever window happens to be below the menu
-        // bar and behind the pop-up. Ignore anything in this gap so we don't
-        // dismiss the pop-up. Strangely, it only seems to happen when the mouse
-        // travels down from the menu bar and not when it travels back up.
-        // First observed on 13.5.2.
-        if self.above_window.1 == NSMainMenuWindowLevel {
-            const WITHIN: f64 = 1.0;
-            for screen in &self.screens {
-                if screen.contains(CGPoint::new(loc.x, loc.y + WITHIN))
-                    && loc.y < screen.min().y + WITHIN
-                {
-                    self.above_window = (new_window, new_window_level);
-                    return None;
-                }
-            }
-        }
-
-        let (old_window, old_window_level) =
-            replace(&mut self.above_window, (new_window, new_window_level));
-        debug!(?old_window, ?old_window_level, ?new_window, ?new_window_level);
-
-        if old_window_level >= NSPopUpMenuWindowLevel {
-            // Ignore one transition out of pop-up/menu-like windows to avoid
-            // stealing focus while transient UI is closing, but clear the
-            // latch so the next move over the same window can recover.
-            self.above_window = (None, NSWindowLevel::MIN);
-            return None;
-        }
-
-        if !(0..NSPopUpMenuWindowLevel).contains(&new_window_level)
-            && new_window_level != NSWindowLevel::MIN
-        {
-            return None;
-        }
-
-        new_window
+        self.above_window = Some(wsid);
+        true
     }
 
     fn reset(&mut self, enabled: bool) {
         if enabled {
-            self.above_window = (None, NSWindowLevel::MIN);
+            self.above_window = None;
             self.last_mouse_move_loc = None;
             self.last_mouse_move_timestamp = 0;
-            self.window_level_cache.clear();
-            self.window_level_cache_last_prune_at = 0;
         }
-    }
-
-    #[inline]
-    fn cached_window_level(&mut self, id: WindowServerId, event_timestamp: u64) -> NSWindowLevel {
-        if event_timestamp.saturating_sub(self.window_level_cache_last_prune_at)
-            >= WINDOW_LEVEL_CACHE_PRUNE_INTERVAL_NS
-        {
-            let cutoff = event_timestamp.saturating_sub(WINDOW_LEVEL_CACHE_TTL_NS);
-            self.window_level_cache.retain(|_, cached| cached.observed_at >= cutoff);
-            self.window_level_cache_last_prune_at = event_timestamp;
-
-            // Defensive bound for long sessions with heavy transient-window churn.
-            if self.window_level_cache.len() > WINDOW_LEVEL_CACHE_MAX_ENTRIES {
-                let mut items: Vec<(WindowServerId, u64)> = self
-                    .window_level_cache
-                    .iter()
-                    .map(|(wid, cached)| (*wid, cached.observed_at))
-                    .collect();
-                items.sort_unstable_by_key(|(_, observed_at)| *observed_at);
-                let drop_count = items.len() - WINDOW_LEVEL_CACHE_MAX_ENTRIES;
-                for (wid, _) in items.into_iter().take(drop_count) {
-                    self.window_level_cache.remove(&wid);
-                }
-            }
-        }
-
-        if let Some(cached) = self.window_level_cache.get(&id) {
-            if event_timestamp.saturating_sub(cached.observed_at) <= WINDOW_LEVEL_CACHE_TTL_NS {
-                return cached.level;
-            }
-        }
-
-        let level =
-            trace_misc("window_level", || window_level(id.into())).unwrap_or(NSWindowLevel::MIN);
-        self.window_level_cache.insert(id, CachedWindowLevel {
-            level,
-            observed_at: event_timestamp,
-        });
-        level
     }
 }
 
@@ -1319,24 +858,7 @@ fn mouse_move_sampling_profile(low_power_mode: bool) -> (u64, f64) {
     }
 }
 
-#[inline]
-fn touch_normalized_position(touch: &objc2_app_kit::NSTouch) -> Option<(f64, f64)> {
-    if touch.r#type() != NSTouchType::Indirect || touch.isResting() {
-        return None;
-    }
-
-    let position = std::panic::catch_unwind(AssertUnwindSafe(|| {
-        exception::catch(AssertUnwindSafe(|| touch.normalizedPosition())).ok()
-    }))
-    .ok()
-    .flatten()?;
-    let x = position.x.clamp(0.0, 1.0) as f64;
-    let y = position.y.clamp(0.0, 1.0) as f64;
-    Some((x, y))
-}
-
 fn build_event_mask(
-    gestures_enabled: bool,
     keyboard_enabled: bool,
     mouse_move_enabled: bool,
 ) -> CGEventMask {
@@ -1364,10 +886,6 @@ fn build_event_mask(
         ] {
             add(&mut m, ty);
         }
-    }
-    if gestures_enabled {
-        // NSEventType::Gesture is an NSEventType — it maps via .0
-        *&mut m |= 1u64 << (NSEventType::Gesture.0 as u64);
     }
     m
 }

--- a/src/actor/gesture_tap.rs
+++ b/src/actor/gesture_tap.rs
@@ -1,0 +1,633 @@
+//! Gesture handling via a dedicated ListenOnly CGEventTap.
+//!
+//! This actor runs on the main thread and handles trackpad swipe/scroll
+//! gestures for workspace switching. It uses a ListenOnly tap which is more
+//! resilient than a Default tap (macOS never disables listen-only taps via
+//! timeout).
+
+use std::cell::RefCell;
+use std::panic::AssertUnwindSafe;
+use std::rc::Rc;
+
+use objc2::exception;
+use objc2_app_kit::{NSEvent, NSEventPhase, NSEventType, NSTouchPhase, NSTouchType};
+use objc2_core_foundation::{CGPoint, CGRect};
+use objc2_core_graphics::{
+    CGEvent, CGEventMask, CGEventTapProxy, CGEventType,
+};
+use tracing::trace;
+
+use crate::actor;
+use crate::actor::wm_controller::{self, WmCommand, WmEvent};
+use crate::actor::reactor;
+use crate::common::collections::HashMap;
+use crate::common::config::{Config, HapticPattern, LayoutMode};
+use crate::layout_engine::LayoutCommand as LC;
+use crate::sys::screen::SpaceId;
+use crate::sys::{haptics};
+
+#[derive(Debug)]
+pub enum GestureRequest {
+    ConfigUpdated(Config),
+    LayoutModesChanged(Vec<(SpaceId, LayoutMode)>),
+    ScreenParametersChanged(Vec<(CGRect, Option<SpaceId>)>),
+    SpaceChanged(Vec<Option<SpaceId>>),
+}
+
+pub type Sender = actor::Sender<GestureRequest>;
+pub type Receiver = actor::Receiver<GestureRequest>;
+
+pub struct GestureTap {
+    config: RefCell<Config>,
+    wm_sender: wm_controller::Sender,
+    swipe: RefCell<Option<SwipeHandler>>,
+    scroll: RefCell<Option<ScrollHandler>>,
+    tap: RefCell<Option<crate::sys::event_tap::EventTap>>,
+    screen_spaces: RefCell<Vec<(CGRect, SpaceId)>>,
+    layout_mode_by_space: RefCell<HashMap<SpaceId, LayoutMode>>,
+    default_layout_mode: RefCell<LayoutMode>,
+    requests_rx: Option<Receiver>,
+}
+
+#[derive(Debug, Clone)]
+struct SwipeConfig {
+    enabled: bool,
+    invert_horizontal: bool,
+    vertical_tolerance: f64,
+    skip_empty_workspaces: Option<bool>,
+    fingers: usize,
+    distance_pct: f64,
+    haptics_enabled: bool,
+    haptic_pattern: HapticPattern,
+}
+
+impl SwipeConfig {
+    fn from_config(config: &Config) -> Self {
+        let g = &config.settings.gestures;
+        let vt_norm = if g.swipe_vertical_tolerance > 1.0 && g.swipe_vertical_tolerance <= 100.0 {
+            (g.swipe_vertical_tolerance / 100.0).clamp(0.0, 1.0)
+        } else if g.swipe_vertical_tolerance > 100.0 {
+            1.0
+        } else {
+            g.swipe_vertical_tolerance.max(0.0).min(1.0)
+        };
+        SwipeConfig {
+            enabled: g.enabled,
+            invert_horizontal: g.invert_horizontal_swipe,
+            vertical_tolerance: vt_norm,
+            skip_empty_workspaces: if g.skip_empty { Some(true) } else { None },
+            fingers: g.fingers.max(1),
+            distance_pct: g.distance_pct.clamp(0.01, 1.0),
+            haptics_enabled: g.haptics_enabled,
+            haptic_pattern: g.haptic_pattern,
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+struct SwipeState {
+    phase: GesturePhase,
+    start_x: f64,
+    start_y: f64,
+}
+
+impl SwipeState {
+    fn reset(&mut self) {
+        self.phase = GesturePhase::Idle;
+        self.start_x = 0.0;
+        self.start_y = 0.0;
+    }
+}
+
+#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+enum GesturePhase {
+    #[default]
+    Idle,
+    Armed,
+    Committed,
+}
+
+struct SwipeHandler {
+    cfg: SwipeConfig,
+    state: RefCell<SwipeState>,
+}
+
+#[derive(Debug, Clone)]
+struct ScrollConfig {
+    enabled: bool,
+    invert_horizontal: bool,
+    vertical_tolerance: f64,
+    fingers: usize,
+    distance_pct: f64,
+}
+
+impl ScrollConfig {
+    fn from_config(config: &Config) -> Self {
+        let g = &config.settings.layout.scrolling.gestures;
+        let vt_norm = if g.vertical_tolerance > 1.0 && g.vertical_tolerance <= 100.0 {
+            (g.vertical_tolerance / 100.0).clamp(0.0, 1.0)
+        } else if g.vertical_tolerance > 100.0 {
+            1.0
+        } else {
+            g.vertical_tolerance.max(0.0).min(1.0)
+        };
+        ScrollConfig {
+            enabled: g.enabled,
+            invert_horizontal: g.invert_horizontal,
+            vertical_tolerance: vt_norm,
+            fingers: g.fingers.max(1),
+            distance_pct: g.distance_pct.clamp(0.01, 1.0),
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+struct ScrollState {
+    phase: GesturePhase,
+    start_x: f64,
+    start_y: f64,
+    last_x: f64,
+    last_y: f64,
+    accum_dx: f64,
+}
+
+impl ScrollState {
+    fn reset(&mut self) {
+        self.phase = GesturePhase::Idle;
+        self.start_x = 0.0;
+        self.start_y = 0.0;
+        self.last_x = 0.0;
+        self.last_y = 0.0;
+        self.accum_dx = 0.0;
+    }
+}
+
+struct ScrollHandler {
+    cfg: ScrollConfig,
+    state: RefCell<ScrollState>,
+}
+
+struct CallbackCtx {
+    this: Rc<GestureTap>,
+}
+
+unsafe fn drop_gesture_ctx(ptr: *mut std::ffi::c_void) {
+    unsafe { drop(Box::from_raw(ptr as *mut CallbackCtx)) };
+}
+
+impl GestureTap {
+    pub fn new(
+        config: Config,
+        wm_sender: wm_controller::Sender,
+        requests_rx: Receiver,
+    ) -> Self {
+        let default_layout_mode = config.settings.layout.mode;
+        let (swipe, scroll) = Self::build_gesture_handlers(&config);
+        GestureTap {
+            config: RefCell::new(config),
+            wm_sender,
+            swipe: RefCell::new(swipe),
+            scroll: RefCell::new(scroll),
+            tap: RefCell::new(None),
+            screen_spaces: RefCell::new(Vec::new()),
+            layout_mode_by_space: RefCell::new(HashMap::default()),
+            default_layout_mode: RefCell::new(default_layout_mode),
+            requests_rx: Some(requests_rx),
+        }
+    }
+
+    pub async fn run(mut self) {
+        let mut requests_rx = self.requests_rx.take().unwrap();
+
+        let this = Rc::new(self);
+
+        if this.gesture_handlers_enabled() {
+            this.create_and_install_tap();
+        }
+
+        while let Some((span, request)) = requests_rx.recv().await {
+            let _guard = span.enter();
+            this.on_request(request);
+        }
+    }
+
+    fn on_request(self: &Rc<Self>, request: GestureRequest) {
+        match request {
+            GestureRequest::ConfigUpdated(new_config) => {
+                *self.default_layout_mode.borrow_mut() = new_config.settings.layout.mode;
+                *self.config.borrow_mut() = new_config;
+                self.update_gesture_handlers();
+            }
+            GestureRequest::LayoutModesChanged(modes) => {
+                let mut map = self.layout_mode_by_space.borrow_mut();
+                map.clear();
+                for (space, mode) in modes {
+                    map.insert(space, mode);
+                }
+            }
+            GestureRequest::ScreenParametersChanged(screens_with_spaces) => {
+                *self.screen_spaces.borrow_mut() = screens_with_spaces
+                    .into_iter()
+                    .filter_map(|(frame, maybe_space)| maybe_space.map(|space| (frame, space)))
+                    .collect();
+            }
+            GestureRequest::SpaceChanged(spaces) => {
+                let screens: Vec<CGRect> = self
+                    .screen_spaces
+                    .borrow()
+                    .iter()
+                    .map(|(frame, _)| *frame)
+                    .collect();
+                *self.screen_spaces.borrow_mut() = screens
+                    .into_iter()
+                    .zip(spaces.into_iter())
+                    .filter_map(|(frame, maybe_space)| maybe_space.map(|space| (frame, space)))
+                    .collect();
+            }
+        }
+    }
+
+    fn build_gesture_handlers(config: &Config) -> (Option<SwipeHandler>, Option<ScrollHandler>) {
+        let swipe_cfg = SwipeConfig::from_config(config);
+        let swipe = if swipe_cfg.enabled {
+            Some(SwipeHandler {
+                cfg: swipe_cfg,
+                state: RefCell::new(SwipeState::default()),
+            })
+        } else {
+            None
+        };
+
+        let scroll_cfg = ScrollConfig::from_config(config);
+        let scroll = if scroll_cfg.enabled {
+            Some(ScrollHandler {
+                cfg: scroll_cfg,
+                state: RefCell::new(ScrollState::default()),
+            })
+        } else {
+            None
+        };
+
+        (swipe, scroll)
+    }
+
+    fn update_gesture_handlers(self: &Rc<Self>) {
+        let config = self.config.borrow();
+        let (swipe, scroll) = Self::build_gesture_handlers(&config);
+        let was_enabled = self.gesture_handlers_enabled();
+        *self.swipe.borrow_mut() = swipe;
+        *self.scroll.borrow_mut() = scroll;
+        let is_enabled = self.gesture_handlers_enabled();
+
+        if !was_enabled && is_enabled {
+            self.create_and_install_tap();
+        } else if was_enabled && !is_enabled {
+            *self.tap.borrow_mut() = None;
+        }
+    }
+
+    fn gesture_handlers_enabled(&self) -> bool {
+        self.swipe.borrow().is_some() || self.scroll.borrow().is_some()
+    }
+
+    fn create_and_install_tap(self: &Rc<Self>) {
+        let mask = gesture_event_mask();
+        let ctx = Box::new(CallbackCtx { this: Rc::clone(self) });
+        let ctx_ptr = Box::into_raw(ctx) as *mut std::ffi::c_void;
+
+        let tap = unsafe {
+            crate::sys::event_tap::EventTap::new_listen_only(
+                mask,
+                Some(gesture_callback),
+                ctx_ptr,
+                Some(drop_gesture_ctx),
+            )
+        };
+
+        if let Some(tap) = tap {
+            *self.tap.borrow_mut() = Some(tap);
+        } else {
+            unsafe { drop(Box::from_raw(ctx_ptr as *mut CallbackCtx)) };
+            tracing::warn!("Failed to create gesture ListenOnly tap");
+        }
+    }
+
+    fn on_event(self: &Rc<Self>, event_type: CGEventType, event: &CGEvent) {
+        if event_type.0 != NSEventType::Gesture.0 as u32 {
+            return;
+        }
+
+        let scroll_handler = self.scroll.borrow();
+        let swipe_handler = self.swipe.borrow();
+        if scroll_handler.is_none() && swipe_handler.is_none() {
+            return;
+        }
+
+        if let Some(nsevent) = NSEvent::eventWithCGEvent(event)
+            && nsevent.r#type() == NSEventType::Gesture
+        {
+            let cursor = CGEvent::location(Some(event));
+            let mode = self
+                .layout_mode_at_point(cursor)
+                .unwrap_or(*self.default_layout_mode.borrow());
+            let is_scrolling_mode = matches!(mode, LayoutMode::Scrolling);
+            if is_scrolling_mode && let Some(handler) = scroll_handler.as_ref() {
+                self.handle_scroll_gesture_event(handler, &nsevent);
+            } else if let Some(handler) = swipe_handler.as_ref() {
+                self.handle_gesture_event(handler, &nsevent);
+            }
+        }
+    }
+
+    fn layout_mode_at_point(&self, loc: CGPoint) -> Option<LayoutMode> {
+        let screen_spaces = self.screen_spaces.borrow();
+        let layout_modes = self.layout_mode_by_space.borrow();
+        screen_spaces
+            .iter()
+            .find(|(frame, _)| {
+                loc.x >= frame.origin.x
+                    && loc.x < frame.origin.x + frame.size.width
+                    && loc.y >= frame.origin.y
+                    && loc.y < frame.origin.y + frame.size.height
+            })
+            .and_then(|(_, space)| layout_modes.get(space).copied())
+    }
+
+    fn handle_gesture_event(&self, handler: &SwipeHandler, nsevent: &NSEvent) {
+        let cfg = &handler.cfg;
+        let state = &handler.state;
+
+        let mut st = state.borrow_mut();
+
+        let phase = nsevent.phase();
+        if matches!(
+            phase,
+            NSEventPhase::Ended | NSEventPhase::Cancelled | NSEventPhase::Began
+        ) {
+            st.reset();
+            return;
+        }
+
+        let touches = nsevent.allTouches();
+        let mut sum_x = 0.0f64;
+        let mut sum_y = 0.0f64;
+        let mut touch_count = 0usize;
+        let mut active_count = 0usize;
+        let mut too_many_touches = false;
+
+        for t in touches.iter() {
+            let phase = t.phase();
+            if phase.contains(NSTouchPhase::Stationary) {
+                continue;
+            }
+
+            let ended =
+                phase.contains(NSTouchPhase::Ended) || phase.contains(NSTouchPhase::Cancelled);
+
+            touch_count += 1;
+            if touch_count > cfg.fingers {
+                too_many_touches = true;
+                break;
+            }
+
+            if !ended && let Some((x, y)) = touch_normalized_position(&t) {
+                sum_x += x;
+                sum_y += y;
+                active_count += 1;
+            }
+        }
+
+        if too_many_touches || touch_count != cfg.fingers || active_count == 0 {
+            st.reset();
+            return;
+        }
+
+        let avg_x = sum_x / active_count as f64;
+        let avg_y = sum_y / active_count as f64;
+
+        match st.phase {
+            GesturePhase::Idle => {
+                st.start_x = avg_x;
+                st.start_y = avg_y;
+                st.phase = GesturePhase::Armed;
+                trace!(
+                    "swipe armed: start_x={:.3} start_y={:.3}",
+                    st.start_x, st.start_y
+                );
+            }
+            GesturePhase::Armed => {
+                let dx = avg_x - st.start_x;
+                let dy = avg_y - st.start_y;
+                let horizontal = dx.abs();
+                let vertical = dy.abs();
+
+                if horizontal >= cfg.distance_pct && vertical <= cfg.vertical_tolerance {
+                    let mut dir_left = dx < 0.0;
+                    if cfg.invert_horizontal {
+                        dir_left = !dir_left;
+                    }
+                    let cmd = if dir_left {
+                        LC::NextWorkspace(cfg.skip_empty_workspaces)
+                    } else {
+                        LC::PrevWorkspace(cfg.skip_empty_workspaces)
+                    };
+
+                    if cfg.haptics_enabled {
+                        let _ = haptics::perform_haptic(cfg.haptic_pattern);
+                    }
+                    self.wm_sender.send(WmEvent::Command(WmCommand::ReactorCommand(
+                        reactor::Command::Layout(cmd),
+                    )));
+                    st.phase = GesturePhase::Committed;
+                }
+            }
+            GesturePhase::Committed => {
+                if active_count == 0 {
+                    st.reset();
+                }
+            }
+        }
+    }
+
+    fn handle_scroll_gesture_event(&self, handler: &ScrollHandler, nsevent: &NSEvent) {
+        let cfg = &handler.cfg;
+        let state = &handler.state;
+
+        let mut st = state.borrow_mut();
+
+        let phase = nsevent.phase();
+        if matches!(
+            phase,
+            NSEventPhase::Ended | NSEventPhase::Cancelled | NSEventPhase::Began
+        ) {
+            st.reset();
+            return;
+        }
+
+        let touches = nsevent.allTouches();
+        let mut sum_x = 0.0f64;
+        let mut sum_y = 0.0f64;
+        let mut touch_count = 0usize;
+        let mut active_count = 0usize;
+        let mut too_many_touches = false;
+        let mut all_moved = true;
+
+        for t in touches.iter() {
+            let phase = t.phase();
+            if phase.contains(NSTouchPhase::Stationary) {
+                all_moved = false;
+                continue;
+            }
+
+            if !phase.contains(NSTouchPhase::Moved) {
+                all_moved = false;
+            }
+
+            let ended =
+                phase.contains(NSTouchPhase::Ended) || phase.contains(NSTouchPhase::Cancelled);
+
+            touch_count += 1;
+            if touch_count > cfg.fingers {
+                too_many_touches = true;
+                break;
+            }
+
+            if !ended && let Some((x, y)) = touch_normalized_position(&t) {
+                sum_x += x;
+                sum_y += y;
+                active_count += 1;
+            }
+        }
+
+        if too_many_touches || touch_count != cfg.fingers || active_count == 0 {
+            st.reset();
+            return;
+        }
+
+        let avg_x = sum_x / active_count as f64;
+        let avg_y = sum_y / active_count as f64;
+
+        match st.phase {
+            GesturePhase::Idle => {
+                st.start_x = avg_x;
+                st.start_y = avg_y;
+                st.last_x = avg_x;
+                st.last_y = avg_y;
+                st.accum_dx = 0.0;
+                st.phase = GesturePhase::Armed;
+                trace!(
+                    "scroll armed: start_x={:.3} start_y={:.3}",
+                    st.start_x, st.start_y
+                );
+            }
+            GesturePhase::Armed => {
+                if !all_moved {
+                    st.last_x = avg_x;
+                    st.last_y = avg_y;
+                    return;
+                }
+
+                let dx = avg_x - st.last_x;
+                let dy = avg_y - st.last_y;
+                let horizontal = dx.abs();
+                let vertical = dy.abs();
+
+                st.last_x = avg_x;
+                st.last_y = avg_y;
+
+                if vertical > cfg.vertical_tolerance || vertical >= horizontal {
+                    return;
+                }
+
+                st.accum_dx += dx;
+                let step = cfg.distance_pct;
+                if st.accum_dx.abs() >= step {
+                    let delta = if cfg.invert_horizontal {
+                        -st.accum_dx
+                    } else {
+                        st.accum_dx
+                    };
+                    let cmd = LC::ScrollStrip { delta };
+
+                    self.wm_sender.send(WmEvent::Command(WmCommand::ReactorCommand(
+                        reactor::Command::Layout(cmd),
+                    )));
+
+                    st.accum_dx = 0.0;
+                    st.phase = GesturePhase::Committed;
+                }
+            }
+            GesturePhase::Committed => {
+                if active_count == 0 {
+                    st.reset();
+                } else if all_moved {
+                    let dx = avg_x - st.last_x;
+                    let dy = avg_y - st.last_y;
+                    let horizontal = dx.abs();
+                    let vertical = dy.abs();
+                    st.last_x = avg_x;
+                    st.last_y = avg_y;
+                    if vertical > cfg.vertical_tolerance || vertical >= horizontal {
+                        return;
+                    }
+                    st.accum_dx += dx;
+                    let step = cfg.distance_pct;
+                    if st.accum_dx.abs() >= step {
+                        let delta = if cfg.invert_horizontal {
+                            -st.accum_dx
+                        } else {
+                            st.accum_dx
+                        };
+                        let cmd = LC::ScrollStrip { delta };
+
+                        self.wm_sender.send(WmEvent::Command(WmCommand::ReactorCommand(
+                            reactor::Command::Layout(cmd),
+                        )));
+
+                        st.accum_dx = 0.0;
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn gesture_event_mask() -> CGEventMask {
+    1u64 << (NSEventType::Gesture.0 as u64)
+}
+
+#[inline]
+fn touch_normalized_position(touch: &objc2_app_kit::NSTouch) -> Option<(f64, f64)> {
+    if touch.r#type() != NSTouchType::Indirect || touch.isResting() {
+        return None;
+    }
+
+    let position = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        exception::catch(AssertUnwindSafe(|| touch.normalizedPosition())).ok()
+    }))
+    .ok()
+    .flatten()?;
+    let x = position.x.clamp(0.0, 1.0) as f64;
+    let y = position.y.clamp(0.0, 1.0) as f64;
+    Some((x, y))
+}
+
+unsafe extern "C-unwind" fn gesture_callback(
+    _proxy: CGEventTapProxy,
+    event_type: CGEventType,
+    event_ref: core::ptr::NonNull<CGEvent>,
+    user_info: *mut std::ffi::c_void,
+) -> *mut CGEvent {
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        let ctx = unsafe { &*(user_info as *const CallbackCtx) };
+        let event = unsafe { event_ref.as_ref() };
+        ctx.this.on_event(event_type, event);
+    }));
+
+    if let Err(_) = result {
+        // Gesture callback panicked; pass event through.
+    }
+
+    // ListenOnly taps must always return the event pointer.
+    event_ref.as_ptr()
+}

--- a/src/actor/reactor.rs
+++ b/src/actor/reactor.rs
@@ -39,6 +39,7 @@ use tracing::{debug, info, instrument, trace, warn};
 use transaction_manager::TransactionId;
 
 use super::event_tap;
+use super::gesture_tap;
 use crate::actor::app::{AppInfo, AppThreadHandle, Quiet, Request, WindowId, WindowInfo, pid_t};
 use crate::actor::broadcast::{BroadcastEvent, BroadcastSender};
 use crate::actor::raise_manager::{self, RaiseManager, RaiseRequest};
@@ -266,6 +267,7 @@ impl Reactor {
         menu_tx: menu_bar::Sender,
         stack_line_tx: stack_line::Sender,
         window_notify: Option<(crate::actor::window_notify::Sender, WindowTxStore)>,
+        gesture_tap_tx: Option<gesture_tap::Sender>,
         one_space: bool,
     ) -> ReactorHandle {
         let (events_tx, events) = actor::channel();
@@ -281,6 +283,7 @@ impl Reactor {
         reactor.communication_manager.event_tap_tx = Some(event_tap_tx);
         reactor.menu_manager.menu_tx = Some(menu_tx);
         reactor.communication_manager.stack_line_tx = Some(stack_line_tx);
+        reactor.communication_manager.gesture_tap_tx = gesture_tap_tx;
         reactor.communication_manager.events_tx = Some(events_tx_clone.clone());
         let query_handle = ReactorQueryHandle::new(events_tx_clone.clone());
         thread::Builder::new()
@@ -345,6 +348,7 @@ impl Reactor {
             recording_manager: managers::RecordingManager { record },
             communication_manager: managers::CommunicationManager {
                 event_tap_tx: None,
+                gesture_tap_tx: None,
                 stack_line_tx: None,
                 raise_manager_tx,
                 event_broadcaster: broadcast_tx,
@@ -2717,6 +2721,9 @@ impl Reactor {
 
         let modes_by_space = modes.iter().copied().collect();
         self.notification_manager.last_layout_modes_by_space = modes_by_space;
+        if let Some(gesture_tap_tx) = self.communication_manager.gesture_tap_tx.as_ref() {
+            gesture_tap_tx.send(gesture_tap::GestureRequest::LayoutModesChanged(modes.clone()));
+        }
         event_tap_tx.send(crate::actor::event_tap::Request::LayoutModesChanged(modes));
     }
 

--- a/src/actor/reactor/animation.rs
+++ b/src/actor/reactor/animation.rs
@@ -11,7 +11,6 @@ use crate::common::config::AnimationEasing;
 use crate::sys::geometry::{Round, SameAs};
 use crate::sys::power;
 use crate::sys::screen::SpaceId;
-use crate::sys::timer::Timer;
 use crate::sys::window_server::WindowServerId;
 
 #[derive(Debug)]
@@ -88,7 +87,7 @@ impl<'a> Animation<'a> {
             if duration < Duration::ZERO {
                 continue;
             }
-            Timer::sleep(duration);
+            std::thread::sleep(duration);
 
             for (&(handle, wid, _, to, _, txid), rect) in self.windows.iter().zip(&next_frames) {
                 let mut rect = *rect;

--- a/src/actor/reactor/managers.rs
+++ b/src/actor/reactor/managers.rs
@@ -14,7 +14,7 @@ use crate::actor::broadcast::{BroadcastEvent, BroadcastSender, StackInfo};
 use crate::actor::drag_swap::DragManager as DragSwapManager;
 use crate::actor::reactor::Reactor;
 use crate::actor::reactor::animation::AnimationManager;
-use crate::actor::{event_tap, menu_bar, raise_manager, stack_line, window_notify, wm_controller};
+use crate::actor::{event_tap, gesture_tap, menu_bar, raise_manager, stack_line, window_notify, wm_controller};
 use crate::common::collections::{HashMap, HashSet};
 use crate::common::config::{LayoutMode, WindowSnappingSettings};
 use crate::layout_engine::LayoutEngine;
@@ -172,6 +172,7 @@ pub struct RefocusManager {
 /// Manages communication channels to other actors
 pub struct CommunicationManager {
     pub event_tap_tx: Option<event_tap::Sender>,
+    pub gesture_tap_tx: Option<gesture_tap::Sender>,
     pub stack_line_tx: Option<stack_line::Sender>,
     pub raise_manager_tx: raise_manager::Sender,
     pub event_broadcaster: BroadcastSender,

--- a/src/actor/stack_line.rs
+++ b/src/actor/stack_line.rs
@@ -1,7 +1,8 @@
-use std::cell::RefCell;
 use std::collections::hash_map::Entry;
 use std::rc::Rc;
+use std::sync::Arc;
 
+use arc_swap::ArcSwap;
 use objc2::MainThreadMarker;
 use objc2_app_kit::NSCursor;
 use objc2_core_foundation::{CGPoint, CGRect, CGSize};
@@ -20,9 +21,10 @@ use crate::ui::stack_line::{
 };
 
 /// Shared indicator hit-rect state readable from the event tap callback.
-pub type SharedHitRects = Rc<RefCell<Vec<CGRect>>>;
+/// Uses Arc<ArcSwap<...>> for lock-free reads from the input thread.
+pub type SharedHitRects = Arc<ArcSwap<Vec<CGRect>>>;
 
-pub fn new_shared_hit_rects() -> SharedHitRects { Rc::new(RefCell::new(Vec::new())) }
+pub fn new_shared_hit_rects() -> SharedHitRects { Arc::new(ArcSwap::from_pointee(Vec::new())) }
 
 #[derive(Debug, Clone)]
 pub struct GroupInfo {
@@ -112,14 +114,13 @@ impl StackLine {
     /// Publish the current indicator frames so the event tap can suppress
     /// clicks that land on a visible, non-occluded indicator.
     fn sync_shared_hit_rects(&self) {
-        let mut rects = self.shared_hit_rects.borrow_mut();
-        rects.clear();
-        if !self.is_enabled() {
-            return;
+        let mut rects = Vec::new();
+        if self.is_enabled() {
+            for indicator in self.indicators.values().filter(|i| i.is_visible()) {
+                rects.push(indicator.frame());
+            }
         }
-        for indicator in self.indicators.values().filter(|indicator| indicator.is_visible()) {
-            rects.push(indicator.frame());
-        }
+        self.shared_hit_rects.store(Arc::new(rects));
     }
 
     #[instrument(name = "stack_line::handle_event", skip(self))]

--- a/src/actor/wm_controller.rs
+++ b/src/actor/wm_controller.rs
@@ -16,6 +16,7 @@ use strum::VariantNames;
 use tracing::{debug, error, info, instrument, warn};
 
 use crate::common::config::WorkspaceSelector;
+use crate::actor::gesture_tap;
 use crate::sys::app::{NSRunningApplicationExt, pid_t};
 
 pub type Sender = actor::Sender<WmEvent>;
@@ -120,6 +121,7 @@ pub struct WmController {
     config: Config,
     events_tx: reactor::Sender,
     event_tap_tx: event_tap::Sender,
+    gesture_tap_tx: Option<gesture_tap::Sender>,
     stack_line_tx: Option<crate::actor::stack_line::Sender>,
     mission_control_tx: Option<mission_control::Sender>,
     window_tx_store: Option<WindowTxStore>,
@@ -135,6 +137,7 @@ impl WmController {
         event_tap_tx: event_tap::Sender,
         stack_line_tx: crate::actor::stack_line::Sender,
         mission_control_tx: crate::actor::mission_control::Sender,
+        gesture_tap_tx: Option<gesture_tap::Sender>,
         window_tx_store: Option<WindowTxStore>,
     ) -> (Self, actor::Sender<WmEvent>) {
         let (sender, receiver) = actor::channel();
@@ -150,6 +153,7 @@ impl WmController {
             config,
             events_tx,
             event_tap_tx,
+            gesture_tap_tx,
             stack_line_tx: Some(stack_line_tx),
             mission_control_tx: Some(mission_control_tx),
             window_tx_store,
@@ -242,6 +246,9 @@ impl WmController {
                 _ = self
                     .event_tap_tx
                     .send(event_tap::Request::ConfigUpdated(self.config.config.clone()));
+                if let Some(tx) = &self.gesture_tap_tx {
+                    tx.send(gesture_tap::GestureRequest::ConfigUpdated(self.config.config.clone()));
+                }
 
                 if !self.hotkeys_installed {
                     debug!(
@@ -271,9 +278,14 @@ impl WmController {
                 self.events_tx.send(Event::ScreenParametersChanged(screens));
 
                 _ = self.event_tap_tx.send(event_tap::Request::ScreenParametersChanged(
-                    frames_with_spaces,
+                    frames_with_spaces.clone(),
                     converter,
                 ));
+                if let Some(tx) = &self.gesture_tap_tx {
+                    tx.send(gesture_tap::GestureRequest::ScreenParametersChanged(
+                        frames_with_spaces,
+                    ));
+                }
                 if let Some(tx) = &self.stack_line_tx {
                     _ = tx.try_send(crate::actor::stack_line::Event::ScreenParametersChanged(
                         converter,
@@ -282,7 +294,10 @@ impl WmController {
             }
             SpaceChanged(spaces) => {
                 self.events_tx.send(reactor::Event::SpaceChanged(spaces.clone()));
-                _ = self.event_tap_tx.send(event_tap::Request::SpaceChanged(spaces));
+                _ = self.event_tap_tx.send(event_tap::Request::SpaceChanged(spaces.clone()));
+                if let Some(tx) = &self.gesture_tap_tx {
+                    tx.send(gesture_tap::GestureRequest::SpaceChanged(spaces));
+                }
             }
             PowerStateChanged(is_low_power_mode) => {
                 info!("Power state changed: low power mode = {}", is_low_power_mode);

--- a/src/bin/rift.rs
+++ b/src/bin/rift.rs
@@ -8,6 +8,7 @@ use objc2_application_services::AXUIElement;
 use rift_wm::actor::config::ConfigActor;
 use rift_wm::actor::config_watcher::ConfigWatcher;
 use rift_wm::actor::event_tap::EventTap;
+use rift_wm::actor::gesture_tap::GestureTap;
 use rift_wm::actor::menu_bar::Menu;
 use rift_wm::actor::mission_control::MissionControlActor;
 use rift_wm::actor::mission_control_observer::NativeMissionControl;
@@ -161,6 +162,7 @@ Enable it in System Settings > Desktop & Dock (Mission Control) and restart Rift
     let (stack_line_tx, stack_line_rx) = rift_wm::actor::channel();
     let (wnd_tx, wnd_rx) = rift_wm::actor::channel();
     let window_tx_store = WindowTxStore::new();
+    let (gesture_tap_tx, gesture_tap_rx) = rift_wm::actor::channel();
     let reactor = Reactor::spawn(
         config.clone(),
         layout,
@@ -170,6 +172,7 @@ Enable it in System Settings > Desktop & Dock (Mission Control) and restart Rift
         menu_tx.clone(),
         stack_line_tx.clone(),
         Some((wnd_tx.clone(), window_tx_store.clone())),
+        Some(gesture_tap_tx.clone()),
         opt.one,
     );
     let events_tx = reactor.sender();
@@ -232,6 +235,7 @@ Enable it in System Settings > Desktop & Dock (Mission Control) and restart Rift
         event_tap_tx.clone(),
         stack_line_tx.clone(),
         mc_tx.clone(),
+        Some(gesture_tap_tx.clone()),
         Some(window_tx_store.clone()),
     );
 
@@ -246,9 +250,14 @@ Enable it in System Settings > Desktop & Dock (Mission Control) and restart Rift
         config.clone(),
         events_tx.clone(),
         event_tap_rx,
-        Some(wm_controller_sender.clone()),
-        Some(stack_line_tx.clone()),
-        Some(stack_line_hit_rects.clone()),
+        wm_controller_sender.clone(),
+        stack_line_tx.clone(),
+        stack_line_hit_rects.clone(),
+    );
+    let gesture_tap = GestureTap::new(
+        config.clone(),
+        wm_controller_sender.clone(),
+        gesture_tap_rx,
     );
     let menu = Menu::new(
         config.clone(),
@@ -282,6 +291,16 @@ Enable it in System Settings > Desktop & Dock (Mission Control) and restart Rift
     CGSetLocalEventsSuppressionInterval(0.0);
     CGEnableEventStateCombining(false);
 
+    // The event tap runs on a dedicated thread with its own CFRunLoop,
+    // isolated from main-thread stalls (layout, animation, SLS IPC).
+    std::thread::Builder::new()
+        .name("input".into())
+        .spawn(move || {
+            rift_wm::sys::executor::Executor::run(event_tap.run());
+            panic!("input thread exited");
+        })
+        .expect("failed to spawn input thread");
+
     Executor::run_main(mtm, async move {
         join!(
             supervise("wm_controller", wm_controller.run()),
@@ -289,7 +308,7 @@ Enable it in System Settings > Desktop & Dock (Mission Control) and restart Rift
                 "notification_center",
                 notification_center.watch_for_notifications()
             ),
-            supervise("event_tap", event_tap.run()),
+            supervise("gesture_tap", gesture_tap.run()),
             supervise("menu", menu.run()),
             supervise("stack_line", stack_line.run()),
             supervise("window_notify", wn_actor.run()),

--- a/src/sys/event_tap.rs
+++ b/src/sys/event_tap.rs
@@ -1,4 +1,5 @@
 use std::ffi::c_void;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use objc2_core_foundation::{
     CFMachPort, CFRetained, CFRunLoop, CFRunLoopMode, CFRunLoopSource, kCFRunLoopCommonModes,
@@ -23,6 +24,7 @@ struct TrampolineCtx {
     original_user_info: *mut c_void,
     original_drop: Option<unsafe fn(*mut c_void)>,
     port_ptr: Option<core::ptr::NonNull<CFMachPort>>,
+    was_reenabled: AtomicBool,
 }
 
 extern "C-unwind" fn trampoline_callback(
@@ -42,6 +44,7 @@ extern "C-unwind" fn trampoline_callback(
     if ety == -1 || ety == -2 {
         if let Some(port_ptr) = ctx.port_ptr {
             unsafe { CGEvent::tap_enable(port_ptr.as_ref(), true) };
+            ctx.was_reenabled.store(true, Ordering::Release);
         }
 
         return event_ref.as_ptr();
@@ -87,6 +90,7 @@ impl EventTap {
             original_user_info: user_info,
             original_drop: drop_ctx,
             port_ptr: None,
+            was_reenabled: AtomicBool::new(false),
         });
         let tramp_ptr = Box::into_raw(tramp) as *mut c_void;
 
@@ -142,6 +146,16 @@ impl EventTap {
     }
 
     pub fn set_enabled(&self, enabled: bool) { CGEvent::tap_enable(&self.port, enabled); }
+
+    /// Returns `true` if the tap was re-enabled since the last call, and
+    /// atomically clears the flag. Used by the actor layer to detect that
+    /// key-up events may have been lost while the tap was disabled.
+    pub fn take_reenabled_flag(&self) -> bool {
+        // SAFETY: self.user_info was created by new_with_options and always
+        // points to a live TrampolineCtx as long as this EventTap exists.
+        let ctx = unsafe { &*(self.user_info as *const TrampolineCtx) };
+        ctx.was_reenabled.swap(false, Ordering::AcqRel)
+    }
 }
 
 impl Drop for EventTap {


### PR DESCRIPTION
Reactor stalls trip `kCGEventTapDisabledByTimeout`. Lost key-up events during the disabled window leave phantom modifiers that silently break all hotkey lookups.

  - Move CGEventTap to a dedicated thread, reactor stalls no longeraffect event delivery
  - Reconcile `pressed_keys` against `CGEventFlags` on re-enable + 5s  watchdog as belt-and-suspenders
  - Fix animation sleep bug (Timer::sleep future was dropped immediately)
  
  
 **Update (22/05/2026)**: Have been running the same instance of rift for 3 days without restart (no such issues so far)
 **Update (01/06/2026)**: Have been running the same instance of rift for 12 days without restart (no such issues so far)