### PR TITLE
feat: Implement easing functions

### DIFF
--- a/rift.default.toml
+++ b/rift.default.toml
@@ -6,10 +6,20 @@
 # - animate: master switch for all window animations
 # - animation_duration: seconds per animation (>= 0.0, typical 0.15–0.35)
 # - animation_fps: frames per second (0.0 = display refresh rate). 60–120 recommended.
+# - animation_easing: easing curve. One of:
+#   linear,
+#   ease_in_out,
+#   ease_in_sine, ease_out_sine, ease_in_out_sine,
+#   ease_in_quad, ease_out_quad, ease_in_out_quad,
+#   ease_in_cubic, ease_out_cubic, ease_in_out_cubic,
+#   ease_in_quart, ease_out_quart, ease_in_out_quart,
+#   ease_in_quint, ease_out_quint, ease_in_out_quint,
+#   ease_in_expo, ease_out_expo, ease_in_out_expo,
 #   ease_in_circ, ease_out_circ, ease_in_out_circ
 animate = false
 animation_duration = 0.3
 animation_fps = 100.0
+animation_easing = "linear"
 
 # Space activation behavior
 # - If true, spaces start inactive (rift does not manage windows there)

--- a/src/actor/reactor/animation.rs
+++ b/src/actor/reactor/animation.rs
@@ -21,6 +21,7 @@ pub struct Animation<'a> {
     start: Instant,
     interval: Duration,
     frames: u32,
+    easing: AnimationEasing,
 
     windows: Vec<(
         &'a AppThreadHandle,
@@ -33,13 +34,14 @@ pub struct Animation<'a> {
 }
 
 impl<'a> Animation<'a> {
-    pub fn new(fps: f64, duration: f64, _: AnimationEasing) -> Self {
+    pub fn new(fps: f64, duration: f64, easing: AnimationEasing) -> Self {
         let interval = Duration::from_secs_f64(1.0 / fps);
         // let now = unsafe { CFAbsoluteTimeGetCurrent() };
         let now = Instant::now();
         Animation {
             start: now, // + interval, // not necessary, provide one extra frame to get things going
             interval,
+            easing,
             frames: (duration * fps).round() as u32,
             windows: vec![],
         }
@@ -76,7 +78,8 @@ impl<'a> Animation<'a> {
 
         let mut next_frames = Vec::with_capacity(self.windows.len());
         for frame in 1..=self.frames {
-            let t: f64 = f64::from(frame) / f64::from(self.frames);
+            let p: f64 = f64::from(frame) / f64::from(self.frames);
+            let t: f64 = self.easing.apply(p);
 
             next_frames.clear();
             for (_, _, from, to, _, _) in &self.windows {
@@ -118,25 +121,15 @@ impl<'a> Animation<'a> {
 }
 
 fn get_frame(a: CGRect, b: CGRect, t: f64) -> CGRect {
-    let s = ease(t);
     CGRect {
         origin: CGPoint {
-            x: blend(a.origin.x, b.origin.x, s),
-            y: blend(a.origin.y, b.origin.y, s),
+            x: blend(a.origin.x, b.origin.x, t),
+            y: blend(a.origin.y, b.origin.y, t),
         },
         size: CGSize {
-            width: blend(a.size.width, b.size.width, s),
-            height: blend(a.size.height, b.size.height, s),
+            width: blend(a.size.width, b.size.width, t),
+            height: blend(a.size.height, b.size.height, t),
         },
-    }
-}
-
-// https://notes.yvt.jp/Graphics/Easing-Functions/
-fn ease(t: f64) -> f64 {
-    if t < 0.5 {
-        (1.0 - f64::sqrt(1.0 - f64::powi(2.0 * t, 2))) / 2.0
-    } else {
-        (f64::sqrt(1.0 - f64::powi(-2.0 * t + 2.0, 2)) + 1.0) / 2.0
     }
 }
 

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -1,3 +1,4 @@
+use std::f64::consts::PI;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
@@ -417,6 +418,62 @@ pub enum AnimationEasing {
     EaseInCirc,
     EaseOutCirc,
     EaseInOutCirc,
+}
+
+impl AnimationEasing {
+    pub fn apply(&self, t: f64) -> f64 {
+        // https://easings.net/
+        match self {
+            AnimationEasing::EaseInSine => 1.0 - (t * PI / 2.0).cos(),
+            AnimationEasing::EaseOutSine => (t * PI / 2.0).sin(),
+            AnimationEasing::EaseInOutSine => -((PI * t).cos() - 1.0) / 2.0,
+
+            AnimationEasing::EaseInQuad => ease_in(t, 2),
+            AnimationEasing::EaseOutQuad => ease_out(t, 2),
+            AnimationEasing::EaseInOut | AnimationEasing::EaseInOutQuad => ease_in_out(t, 2),
+
+            AnimationEasing::EaseInCubic => ease_in(t, 3),
+            AnimationEasing::EaseOutCubic => ease_out(t, 3),
+            AnimationEasing::EaseInOutCubic => ease_in_out(t, 3),
+
+            AnimationEasing::EaseInQuart => ease_in(t, 4),
+            AnimationEasing::EaseOutQuart => ease_out(t, 4),
+            AnimationEasing::EaseInOutQuart => ease_in_out(t, 4),
+
+            AnimationEasing::EaseInQuint => ease_in(t, 5),
+            AnimationEasing::EaseOutQuint => ease_out(t, 5),
+            AnimationEasing::EaseInOutQuint => ease_in_out(t, 5),
+
+            AnimationEasing::EaseInExpo => 10.0f64.mul_add(t.max(0.0), -10.0).exp2(),
+            AnimationEasing::EaseOutExpo => 1.0 - (-10.0 * t.min(1.0)).exp2(),
+            AnimationEasing::EaseInOutExpo => {
+                if t < 0.5 {
+                    20.0f64.mul_add(t.max(0.0), -10.0).exp2() / 2.0
+                } else {
+                    (2.0 - (-20.0f64).mul_add(t.min(1.0), 10.0).exp2()) / 2.0
+                }
+            }
+
+            AnimationEasing::EaseInCirc => 1.0 - t.mul_add(-t, 1.0).sqrt(),
+            AnimationEasing::EaseOutCirc => (t - 1.0).mul_add(-(t - 1.0), 1.0).sqrt(),
+            AnimationEasing::EaseInOutCirc => {
+                if t < 0.5 {
+                    (1.0 - (1.0 - (2.0 * t).powi(2)).sqrt()) / 2.0
+                } else {
+                    ((1.0 - (-2.0 * t + 2.0).powi(2)).sqrt() + 1.0) / 2.0
+                }
+            }
+
+            AnimationEasing::Linear => t,
+        }
+    }
+}
+
+fn ease_in(t: f64, exp: i32) -> f64 { t.powi(exp) }
+fn ease_out(t: f64, exp: i32) -> f64 { 1.0 - (1.0 - t).powi(exp) }
+fn ease_in_out(t: f64, exp: i32) -> f64 {
+    if t < 0.5 { 2.0f64.powi(exp - 1) * t.powi(exp) }
+    else { 1.0 - (-2.0f64).mul_add(t, 2.0).powi(exp) / 2.0 }
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]


### PR DESCRIPTION
I was trying to change the `animation_easing` to linear (because the default easing was a little sharp for my taste), but realized it wasn't implemented, so I did my best to implement it as simply as I could. I used easings.net as a reference for the code.

I tried implementing the bounce/elastic/back ones too for fun, but they really just looked awful unless the animation duration was set to insanely long.