### PR TITLE
fix: Some applications' (Microsoft Word) closing event not detected

### DIFF
--- a/src/actor/app.rs
+++ b/src/actor/app.rs
@@ -758,6 +758,7 @@ impl State {
             kAXMenuClosedNotification => self.send_event(Event::MenuClosed(self.pid)),
             kAXUIElementDestroyedNotification => {
                 let Ok(wid) = self.id(&elem) else {
+                    self.remove_stale_windows();
                     return;
                 };
                 self.remove_window(wid);


### PR DESCRIPTION
I have the great privilege (sarcasm) of using Microsoft Products at work, but when clicking X, Rift would leave empty space for them until the next time stale windows were cleared. This was happening for me in Microsoft Teams, Excel, Powerpoint and Word.

The issue seems to be that when these particular windows are closed, a WindowClosed event is not being fired, but only a `kAXUIElementDestroyedNotification` event. However in a `kAXUIElementDestroyedNotification` event, the window has already been destroyed, so trying to get the window/process id returns `AXError(-25202) kAXErrorInvalidUIElement`.

A few years ago, AeroSpace stopped removing windows on `kAXUIElementDestroyedNotification` events and instead just refreshing the window list. [Commit](https://github.com/nikitabobko/AeroSpace/commit/405dec8b7170cf0d9dc6ca1e7495fe7abbb20ff8#diff-a0d1a6f9d6cddcdfdf71ee0cfb26cb22030355a0fd8442b636f062ba03b3c7c3) | [Current status of main](https://github.com/nikitabobko/AeroSpace/blob/63e0976bf38ffd0849676b620db10bdf5b3af5eb/Sources/AppBundle/tree/MacApp.swift#L347)

This PR is a 1 line change to implement the same thing, and from my testing solves the issue.