### PR TITLE
fix: mouse_hides_on_focus doesn't update with hotreload

### DIFF
--- a/src/actor/event_tap.rs
+++ b/src/actor/event_tap.rs
@@ -80,6 +80,7 @@ pub struct EventTap {
 struct State {
     hidden: bool,
     above_window: (Option<WindowServerId>, NSWindowLevel),
+    mouse_hiding_enabled: bool,
     mouse_hides_on_focus: bool,
     focus_follows_mouse_config_enabled: bool,
     default_layout_mode: LayoutMode,
@@ -111,6 +112,7 @@ impl Default for State {
         Self {
             hidden: false,
             above_window: (None, NSWindowLevel::MIN),
+            mouse_hiding_enabled: false,
             mouse_hides_on_focus: false,
             focus_follows_mouse_config_enabled: false,
             default_layout_mode: LayoutMode::Traditional,
@@ -433,18 +435,30 @@ impl EventTap {
             return;
         }
 
-        if this.state.borrow().mouse_hides_on_focus {
+        let mut state = this.state.borrow_mut();
+        this.ensure_mouse_hiding_enabled(&mut state);
+        drop(state);
+
+        while let Some((span, request)) = requests_rx.recv().await {
+            let _ = span.enter();
+            this.on_request(request);
+        }
+    }
+
+    fn ensure_mouse_hiding_enabled(self: &Rc<Self>, state: &mut State) {
+        if state.mouse_hiding_enabled {
+            return;
+        }
+
+        if state.mouse_hides_on_focus {
+            // Even if it fails, we tried so no need to try every time
+            state.mouse_hiding_enabled = true;
             if let Err(e) = window_server::allow_hide_mouse() {
                 error!(
                     "Could not enable mouse hiding: {e:?}. \
                     mouse_hides_on_focus will have no effect."
                 );
             }
-        }
-
-        while let Some((span, request)) = requests_rx.recv().await {
-            let _ = span.enter();
-            this.on_request(request);
         }
     }
 
@@ -544,6 +558,9 @@ impl EventTap {
                     if prev_active && !state.disable_hotkey_active {
                         state.reset(true);
                     }
+
+                    self.ensure_mouse_hiding_enabled(&mut state);
+
                     if prev_mouse_hides_on_focus && !state.mouse_hides_on_focus && state.hidden {
                         debug!("Showing mouse after disabling mouse_hides_on_focus");
                         if let Err(e) = event::show_mouse() {

--- a/src/actor/reactor/events/command.rs
+++ b/src/actor/reactor/events/command.rs
@@ -125,8 +125,6 @@ impl CommandEventHandler {
     }
 
     pub fn handle_config_updated(reactor: &mut Reactor, new_cfg: Config) {
-        let old_keys = reactor.config.keys.clone();
-
         reactor.config = new_cfg;
         reactor
             .layout_manager
@@ -154,10 +152,8 @@ impl CommandEventHandler {
 
         let _ = reactor.update_layout_or_warn(false, true);
 
-        if old_keys != reactor.config.keys {
-            if let Some(wm) = &reactor.communication_manager.wm_sender {
-                wm.send(WmEvent::ConfigUpdated(reactor.config.clone()));
-            }
+        if let Some(wm) = &reactor.communication_manager.wm_sender {
+            wm.send(WmEvent::ConfigUpdated(reactor.config.clone()));
         }
     }
 


### PR DESCRIPTION
`mouse_hides_on_focus`, `focus_follows_mouse` and `mouse_follows_focus` along with anything gesture related in the config wouldn't update without fully restarting rift. (I actually thought the three finger sideways swipe was broken until today, because setting `settings.gestures.enabled=true` seemed to do nothing.)


This PR fixes the two causes:

### 1.  `EventTap` and `GestureTap` were not receiving config updates https://github.com/acsandmann/rift/commit/8dfd6191137d5df4e9e4af539805c59e7b8a0a34

It looks like config reloads are initiated by `ConfigActor` (either from a cli command, or via `ConfigWatcher`). Then the updated config values are passed along like so:
```mermaid
graph LR;
    ConfigActor-->Reactor;
    Reactor-->WMController;
    WMController-->EventTap;
    WMController-->GestureTap;
```

However, the Reactor was only passing along config updates when any keybinds had changed. Removing this condition allowed `EventTap` and `GestureTap` to receive config updates.

### 2. Mouse hiding is only enabled on startup https://github.com/acsandmann/rift/commit/adeaedc185f54f87c59f221566954bbf8ab9f83b

In order for mouse hiding to work, `window_server::allow_hide_mouse()` must be called. However, if rift is started with `mouse_hides_on_focus=false` then `allow_hide_mouse()` is never called even on subsequent config reloads. This commit calls `allow_hide_mouse()` the first time `mouse_hides_on_focus` is set to `true`, whether that's on application start or when the config is reloaded.