### PR TITLE
fix(hotkey): handle device-dependent modifiers for remapped hyper keys

### DIFF
--- a/src/sys/hotkey.rs
+++ b/src/sys/hotkey.rs
@@ -129,6 +129,16 @@ struct ModFamily {
     right_key: KeyCode,
 
     mask: CGEventFlags,
+    left_mask: u64,
+    right_mask: u64,
+}
+
+impl ModFamily {
+    fn is_active(&self, flags: CGEventFlags) -> bool {
+        flags.contains(self.mask)
+            || (flags.bits() & self.left_mask) != 0
+            || (flags.bits() & self.right_mask) != 0
+    }
 }
 
 const MOD_FAMILIES: &[ModFamily] = &[
@@ -142,6 +152,8 @@ const MOD_FAMILIES: &[ModFamily] = &[
         left_key: KeyCode::ControlLeft,
         right_key: KeyCode::ControlRight,
         mask: CGEventFlags::MaskControl,
+        left_mask: 0x00000001,
+        right_mask: 0x00002000,
     },
     ModFamily {
         name: "Alt",
@@ -153,6 +165,8 @@ const MOD_FAMILIES: &[ModFamily] = &[
         left_key: KeyCode::AltLeft,
         right_key: KeyCode::AltRight,
         mask: CGEventFlags::MaskAlternate,
+        left_mask: 0x00000020,
+        right_mask: 0x00000040,
     },
     ModFamily {
         name: "Shift",
@@ -164,6 +178,8 @@ const MOD_FAMILIES: &[ModFamily] = &[
         left_key: KeyCode::ShiftLeft,
         right_key: KeyCode::ShiftRight,
         mask: CGEventFlags::MaskShift,
+        left_mask: 0x00000002,
+        right_mask: 0x00000004,
     },
     ModFamily {
         name: "Meta",
@@ -175,6 +191,8 @@ const MOD_FAMILIES: &[ModFamily] = &[
         left_key: KeyCode::MetaLeft,
         right_key: KeyCode::MetaRight,
         mask: CGEventFlags::MaskCommand,
+        left_mask: 0x00000008,
+        right_mask: 0x00000010,
     },
 ];
 
@@ -656,7 +674,7 @@ impl From<HotkeySpec> for Hotkey {
 pub fn modifiers_from_flags(flags: CGEventFlags) -> Modifiers {
     let mut mods = Modifiers::empty();
     for m in MOD_FAMILIES {
-        if flags.contains(m.mask) {
+        if m.is_active(flags) {
             mods.insert(m.generic);
         }
     }
@@ -670,7 +688,7 @@ pub fn modifiers_from_flags_with_keys<S: std::hash::BuildHasher>(
     let mut mods = Modifiers::empty();
 
     for m in MOD_FAMILIES {
-        if !flags.contains(m.mask) {
+        if !m.is_active(flags) {
             continue;
         }
 


### PR DESCRIPTION
Tackles https://github.com/acsandmann/rift/issues/244

### Problem
Global hotkeys triggered via a remapped Caps Lock key (such as Raycast or Karabiner-Elements "Hyper Key") were not recognized. This occurs because tools like Karabiner or Raycast may only set device-dependent modifier bits (or strip the device-independent ones) on events, which the current hotkey engine fails to match.

### Solution
This PR ports a fix similar to the one implemented in `livesplit-core` to resolve this issue:
- Updated the `ModFamily` struct and `MOD_FAMILIES` table in `src/sys/hotkey.rs` to define and check both device-independent and device-dependent modifier flags (e.g., LEFT/RIGHT masks for Ctrl, Alt, Shift, and Command).
- Introduced `ModFamily::is_active` to check whether any of the device-independent or device-dependent bits are set.
- Updated `modifiers_from_flags` and `modifiers_from_flags_with_keys` to check `m.is_active(flags)`, ensuring hotkeys are correctly matched even when only device-specific modifier bits are present.

### Verification
- Verified compilation with `cargo check` and `cargo build`.
- Ran unit tests sequentially with `cargo test -- --test-threads=1`, and all 231 tests passed successfully.
