### PR TITLE
ci(githooks): add pre-commit and pre-push hooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Run the Rust formatter on all files
+cargo +nightly fmt --all
+# Re-stage files that were modified by the formatter
+git add -u

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Run tests before pushing. If tests fail, the push is aborted.
+cargo test


### PR DESCRIPTION
### Summary
This PR adds local git hooks inside the `.githooks/` directory to help developers maintain strict code formatting and run tests automatically before committing or pushing changes.

### Key Changes
- **`.githooks/pre-commit`**: Automatically formats the codebase using the nightly toolchain (`cargo +nightly fmt --all`) and stages the formatted changes.
- **`.githooks/pre-push`**: Automatically runs `cargo test` prior to a push and prevents the push if any tests fail.
- **Executable Permissions**: Preserves `chmod +x` file permissions for both hook scripts in the repository.

### Developer Setup
Once this is merged, developers can enable these local hooks in their client by running:
```bash
git config core.hooksPath .githooks
```