### PR TITLE
fix: scrolling alignment

### DIFF
--- a/src/layout_engine/systems/scrolling.rs
+++ b/src/layout_engine/systems/scrolling.rs
@@ -630,7 +630,11 @@ impl LayoutSystem for ScrollingLayoutSystem {
         let mut column_widths = Vec::with_capacity(state.columns.len());
         let mut column_ratios = Vec::with_capacity(state.columns.len());
         for col in state.columns.iter() {
-            let ratio = self.clamp_ratio(base_ratio + col.width_offset);
+            let ratio = if state.columns.len() == 1 {
+                1.0
+            } else {
+                self.clamp_ratio(base_ratio + col.width_offset)
+            };
             let base_width = (tiling.size.width * ratio).max(1.0);
             let mut min_w: f64 = 1.0;
             let mut fixed_w: Option<f64> = None;
@@ -697,12 +701,32 @@ impl LayoutSystem for ScrollingLayoutSystem {
             tiling.origin.x
         } else {
             match self.settings.alignment {
-                crate::common::config::ScrollingAlignment::Left => tiling.origin.x,
+                crate::common::config::ScrollingAlignment::Left => {
+                    if !niri_navigation && state.center_override_window.is_none() && state.columns.len() > 1 && selected_col_idx == state.columns.len() - 1 {
+                        tiling.origin.x + tiling.size.width - selected_width
+                    } else {
+                        tiling.origin.x
+                    }
+                }
                 crate::common::config::ScrollingAlignment::Center => {
-                    tiling.origin.x + (tiling.size.width - selected_width) / 2.0
+                    if !niri_navigation && state.center_override_window.is_none() && state.columns.len() > 1 {
+                        if selected_col_idx == 0 {
+                            tiling.origin.x
+                        } else if selected_col_idx == state.columns.len() - 1 {
+                            tiling.origin.x + tiling.size.width - selected_width
+                        } else {
+                            tiling.origin.x + (tiling.size.width - selected_width) / 2.0
+                        }
+                    } else {
+                        tiling.origin.x + (tiling.size.width - selected_width) / 2.0
+                    }
                 }
                 crate::common::config::ScrollingAlignment::Right => {
-                    tiling.origin.x + tiling.size.width - selected_width
+                    if !niri_navigation && state.center_override_window.is_none() && state.columns.len() > 1 && selected_col_idx == 0 {
+                        tiling.origin.x
+                    } else {
+                        tiling.origin.x + tiling.size.width - selected_width
+                    }
                 }
             }
         };
@@ -2238,5 +2262,130 @@ mod tests {
         let w2_frame = frame_for(&frames, w2);
         assert!(w1_frame.origin.x >= 0.0);
         assert!(w2_frame.origin.x + w2_frame.size.width <= 1000.0);
+    }
+
+    #[test]
+    fn anchored_alignments_adjust_outer_columns() {
+        let screen = screen(1000.0, 800.0);
+        let gaps = GapSettings::default();
+
+        // Test Left Alignment: last column is anchored to the right.
+        {
+            let mut settings = ScrollingLayoutSettings::default();
+            settings.alignment = crate::common::config::ScrollingAlignment::Left;
+            settings.focus_navigation_style =
+                crate::common::config::ScrollingFocusNavigationStyle::Anchored;
+            settings.column_width_ratio = 0.4;
+            let mut system = ScrollingLayoutSystem::new(&settings);
+            let layout = system.create_layout();
+            let w1 = wid(1, 1);
+            let w2 = wid(1, 2);
+            let w3 = wid(1, 3);
+            system.add_window_after_selection(layout, w1);
+            system.add_window_after_selection(layout, w2);
+            system.add_window_after_selection(layout, w3);
+
+            assert!(system.select_window(layout, w1));
+            let w1_frame = frame_for(&render(&system, layout, screen, &gaps), w1);
+            assert!((w1_frame.origin.x - 0.0).abs() < 1.0); // left-aligned
+
+            assert!(system.select_window(layout, w2));
+            let w2_frame = frame_for(&render(&system, layout, screen, &gaps), w2);
+            assert!((w2_frame.origin.x - 0.0).abs() < 1.0); // left-aligned
+
+            assert!(system.select_window(layout, w3));
+            let w3_frame = frame_for(&render(&system, layout, screen, &gaps), w3);
+            assert!((w3_frame.origin.x - 600.0).abs() < 1.0); // right-aligned
+        }
+
+        // Test Right Alignment: first column is anchored to the left.
+        {
+            let mut settings = ScrollingLayoutSettings::default();
+            settings.alignment = crate::common::config::ScrollingAlignment::Right;
+            settings.focus_navigation_style =
+                crate::common::config::ScrollingFocusNavigationStyle::Anchored;
+            settings.column_width_ratio = 0.4;
+            let mut system = ScrollingLayoutSystem::new(&settings);
+            let layout = system.create_layout();
+            let w1 = wid(1, 1);
+            let w2 = wid(1, 2);
+            let w3 = wid(1, 3);
+            system.add_window_after_selection(layout, w1);
+            system.add_window_after_selection(layout, w2);
+            system.add_window_after_selection(layout, w3);
+
+            assert!(system.select_window(layout, w1));
+            let w1_frame = frame_for(&render(&system, layout, screen, &gaps), w1);
+            assert!((w1_frame.origin.x - 0.0).abs() < 1.0); // left-aligned
+
+            assert!(system.select_window(layout, w2));
+            let w2_frame = frame_for(&render(&system, layout, screen, &gaps), w2);
+            assert!((w2_frame.origin.x - 600.0).abs() < 1.0); // right-aligned
+
+            assert!(system.select_window(layout, w3));
+            let w3_frame = frame_for(&render(&system, layout, screen, &gaps), w3);
+            assert!((w3_frame.origin.x - 600.0).abs() < 1.0); // right-aligned
+        }
+
+        // Test Center Alignment: first column is left-anchored, last is right-anchored, middle is centered.
+        {
+            let mut settings = ScrollingLayoutSettings::default();
+            settings.alignment = crate::common::config::ScrollingAlignment::Center;
+            settings.focus_navigation_style =
+                crate::common::config::ScrollingFocusNavigationStyle::Anchored;
+            settings.column_width_ratio = 0.4;
+            let mut system = ScrollingLayoutSystem::new(&settings);
+            let layout = system.create_layout();
+            let w1 = wid(1, 1);
+            let w2 = wid(1, 2);
+            let w3 = wid(1, 3);
+            system.add_window_after_selection(layout, w1);
+            system.add_window_after_selection(layout, w2);
+            system.add_window_after_selection(layout, w3);
+
+            assert!(system.select_window(layout, w1));
+            let w1_frame = frame_for(&render(&system, layout, screen, &gaps), w1);
+            assert!((w1_frame.origin.x - 0.0).abs() < 1.0); // left-aligned
+
+            assert!(system.select_window(layout, w2));
+            let w2_frame = frame_for(&render(&system, layout, screen, &gaps), w2);
+            assert!((w2_frame.origin.x - 300.0).abs() < 1.0); // centered
+
+            assert!(system.select_window(layout, w3));
+            let w3_frame = frame_for(&render(&system, layout, screen, &gaps), w3);
+            assert!((w3_frame.origin.x - 600.0).abs() < 1.0); // right-aligned
+        }
+    }
+
+    #[test]
+    fn single_column_fills_full_width() {
+        let mut settings = ScrollingLayoutSettings::default();
+        settings.column_width_ratio = 0.4;
+        let mut system = ScrollingLayoutSystem::new(&settings);
+        let layout = system.create_layout();
+        let w1 = wid(1, 1);
+
+        system.add_window_after_selection(layout, w1);
+
+        let screen = screen(1000.0, 800.0);
+        let gaps = GapSettings::default();
+        let frames1 = render(&system, layout, screen, &gaps);
+        let w1_frame1 = frame_for(&frames1, w1);
+
+        // With only 1 column, width should be 100% of tiling width (1000.0)
+        assert!((w1_frame1.size.width - 1000.0).abs() < 1.0);
+        assert!((w1_frame1.origin.x - 0.0).abs() < 1.0);
+
+        // Add a second window (w2)
+        let w2 = wid(1, 2);
+        system.add_window_after_selection(layout, w2);
+
+        let frames2 = render(&system, layout, screen, &gaps);
+        let w1_frame2 = frame_for(&frames2, w1);
+        let w2_frame2 = frame_for(&frames2, w2);
+
+        // With 2 columns, they should respect the configured column_width_ratio (0.4 * 1000 = 400.0)
+        assert!((w1_frame2.size.width - 400.0).abs() < 1.0);
+        assert!((w2_frame2.size.width - 400.0).abs() < 1.0);
     }
 }

--- a/src/layout_engine/systems/scrolling.rs
+++ b/src/layout_engine/systems/scrolling.rs
@@ -973,6 +973,10 @@ impl LayoutSystem for ScrollingLayoutSystem {
     }
 
     fn add_window_after_selection(&mut self, layout: LayoutId, wid: WindowId) {
+        let niri_navigation = matches!(
+            self.settings.focus_navigation_style,
+            ScrollingFocusNavigationStyle::Niri
+        );
         let Some(state) = self.layout_state_mut(layout) else {
             return;
         };
@@ -982,6 +986,9 @@ impl LayoutSystem for ScrollingLayoutSystem {
             state.insert_column_after(0, wid);
         } else {
             state.insert_column_at_end(wid);
+        }
+        if niri_navigation {
+            state.reveal_selected_without_direction();
         }
     }
 
@@ -1019,6 +1026,10 @@ impl LayoutSystem for ScrollingLayoutSystem {
     }
 
     fn set_windows_for_app(&mut self, layout: LayoutId, pid: pid_t, desired: Vec<WindowId>) {
+        let niri_navigation = matches!(
+            self.settings.focus_navigation_style,
+            ScrollingFocusNavigationStyle::Niri
+        );
         let Some(state) = self.layout_state_mut(layout) else {
             return;
         };
@@ -1054,6 +1065,9 @@ impl LayoutSystem for ScrollingLayoutSystem {
                 }
                 (None, None) => break,
             }
+        }
+        if niri_navigation {
+            state.reveal_selected_without_direction();
         }
     }
 
@@ -1243,12 +1257,20 @@ impl LayoutSystem for ScrollingLayoutSystem {
         from_layout: LayoutId,
         to_layout: LayoutId,
     ) {
+        let niri_navigation = matches!(
+            self.settings.focus_navigation_style,
+            ScrollingFocusNavigationStyle::Niri
+        );
         let Some(selected) = self.selected_window(from_layout) else {
             return;
         };
         if let Some(state) = self.layout_state_mut(from_layout) {
             state.remove_window(selected);
-            state.align_scroll_to_selected();
+            if niri_navigation {
+                state.reveal_selected_without_direction();
+            } else {
+                state.align_scroll_to_selected();
+            }
         }
         if let Some(state) = self.layout_state_mut(to_layout) {
             if let Some((col_idx, _)) = state.selected_location() {
@@ -1256,7 +1278,11 @@ impl LayoutSystem for ScrollingLayoutSystem {
             } else {
                 state.insert_column_at_end(selected);
             }
-            state.align_scroll_to_selected();
+            if niri_navigation {
+                state.reveal_selected_without_direction();
+            } else {
+                state.align_scroll_to_selected();
+            }
         }
     }
 
@@ -1405,6 +1431,10 @@ impl LayoutSystem for ScrollingLayoutSystem {
     }
 
     fn unjoin_selection(&mut self, layout: LayoutId) {
+        let niri_navigation = matches!(
+            self.settings.focus_navigation_style,
+            ScrollingFocusNavigationStyle::Niri
+        );
         let Some(state) = self.layout_state_mut(layout) else {
             return;
         };
@@ -1425,7 +1455,11 @@ impl LayoutSystem for ScrollingLayoutSystem {
             height_weights: vec![weight],
         });
         state.selected = Some(wid);
-        state.align_scroll_to_selected();
+        if niri_navigation {
+            state.reveal_selected_without_direction();
+        } else {
+            state.align_scroll_to_selected();
+        }
         state.clamp_scroll_offset();
     }
 
@@ -2167,5 +2201,42 @@ mod tests {
                 .abs()
                 < 2.0
         );
+    }
+
+    #[test]
+    fn niri_new_window_reveal_does_not_unnecessarily_push_offscreen() {
+        let mut settings = ScrollingLayoutSettings::default();
+        settings.alignment = crate::common::config::ScrollingAlignment::Center;
+        settings.focus_navigation_style =
+            crate::common::config::ScrollingFocusNavigationStyle::Niri;
+        settings.column_width_ratio = 0.4;
+        let mut system = ScrollingLayoutSystem::new(&settings);
+        let layout = system.create_layout();
+        let w1 = wid(1, 1);
+        let w2 = wid(1, 2);
+
+        // Add first window
+        system.add_window_after_selection(layout, w1);
+        let screen = screen(1000.0, 800.0);
+        let gaps = GapSettings::default();
+        let _ = render(&system, layout, screen, &gaps);
+        assert_eq!(scroll_offset(&system, layout), 0.0);
+
+        // Add second window
+        system.add_window_after_selection(layout, w2);
+        let frames = render(&system, layout, screen, &gaps);
+        let offset = scroll_offset(&system, layout);
+
+        // Both windows fit on screen (0.4 * 1000 = 400 width each, total 800 width < 1000 screen width).
+        // Since we are in Niri mode, adding a new window w2 to the right of w1
+        // should reveal it, but since w2 already fits fully on screen at offset 0.0
+        // (starts at 400.0, ends at 800.0), the scroll offset should remain 0.0,
+        // keeping both windows on screen!
+        assert_eq!(offset, 0.0);
+
+        let w1_frame = frame_for(&frames, w1);
+        let w2_frame = frame_for(&frames, w2);
+        assert!(w1_frame.origin.x >= 0.0);
+        assert!(w2_frame.origin.x + w2_frame.size.width <= 1000.0);
     }
 }

--- a/src/layout_engine/systems/scrolling.rs
+++ b/src/layout_engine/systems/scrolling.rs
@@ -702,14 +702,21 @@ impl LayoutSystem for ScrollingLayoutSystem {
         } else {
             match self.settings.alignment {
                 crate::common::config::ScrollingAlignment::Left => {
-                    if !niri_navigation && state.center_override_window.is_none() && state.columns.len() > 1 && selected_col_idx == state.columns.len() - 1 {
+                    if !niri_navigation
+                        && state.center_override_window.is_none()
+                        && state.columns.len() > 1
+                        && selected_col_idx == state.columns.len() - 1
+                    {
                         tiling.origin.x + tiling.size.width - selected_width
                     } else {
                         tiling.origin.x
                     }
                 }
                 crate::common::config::ScrollingAlignment::Center => {
-                    if !niri_navigation && state.center_override_window.is_none() && state.columns.len() > 1 {
+                    if !niri_navigation
+                        && state.center_override_window.is_none()
+                        && state.columns.len() > 1
+                    {
                         if selected_col_idx == 0 {
                             tiling.origin.x
                         } else if selected_col_idx == state.columns.len() - 1 {
@@ -722,7 +729,11 @@ impl LayoutSystem for ScrollingLayoutSystem {
                     }
                 }
                 crate::common::config::ScrollingAlignment::Right => {
-                    if !niri_navigation && state.center_override_window.is_none() && state.columns.len() > 1 && selected_col_idx == 0 {
+                    if !niri_navigation
+                        && state.center_override_window.is_none()
+                        && state.columns.len() > 1
+                        && selected_col_idx == 0
+                    {
                         tiling.origin.x
                     } else {
                         tiling.origin.x + tiling.size.width - selected_width


### PR DESCRIPTION
# Scrolling Layout Alignment, Anchoring & Single-Window Improvements

Improves https://github.com/acsandmann/rift/pull/265 a bit and adjusts to current code base.

## Summary of Changes
This PR addresses several visual and behavioral papercuts in the `scrolling` layout mode relating to scrolling offsets, edge-anchoring of outer columns, and single-window width utilization.

---

## What Was Done & Why

### 1. Fix Niri Scrolling Offset Jump on New Window Open
* **Why**: When a new window opened or was attached under `niri` focus style navigation, the layout engine used to force a complete viewport alignment snap. This caused the new window to align to the left edge of the screen, pushing the previous window(s) completely off-screen, even when they could easily fit together side-by-side.
* **What**: Updated column insertion and window state syncing methods (`add_window_after_selection`, `move_selection_to_layout_after_selection`, `set_windows_for_app`, and `unjoin_selection`) to respect Niri-style focus rules. In Niri navigation mode, we now perform a neutral focus reveal (`state.reveal_selected_without_direction()`), meaning the view will only scroll if the new window is clipped or falls off-screen.

### 2. Outer Column Anchoring in Anchored Mode (Left, Center, Right)
* **Why**: In Anchored focus style navigation, centering or aligning the very first and last columns strictly based on alignment ratio would leave unnecessary empty gutters on the outer screen edges (e.g., centering the first column on a 1000px screen with a 70% width ratio left a 150px gap on the left, even though there were columns to the right that could be shown).
* **What**: Updated `calculate_layout` anchor logic to automatically adjust viewport anchors for outer columns when multiple columns are present:
  * **Left Alignment**: Anchors the very last column to the right edge of the screen when focused.
  * **Right Alignment**: Anchors the very first column to the left edge of the screen when focused.
  * **Center Alignment**: Anchors the first column to the left edge and the last column to the right edge of the screen when focused.

### 3. Fullscreen/Full-width single column
* **Why**: If only a single window/column is active on the workspace, retaining a fractional width ratio (like 70% centered) left blank side space on the desktop unnecessarily.
* **What**: If `state.columns.len() == 1`, the layout engine now overrides the column ratio to `1.0` to let the single column occupy the full tiling width. Once a second column is introduced, the layout dynamically shrinks columns back to their configured fractional ratios.

---

## Verification & Tests
All tests are implemented and passing:
* Added `niri_new_window_reveal_does_not_unnecessarily_push_offscreen` verifying the neutral reveal on window addition.
* Added `anchored_alignments_adjust_outer_columns` verifying edge-snapping for Left, Right, and Center alignment modes.
* Added `single_column_fills_full_width` verifying the single column full-width behavior.

**Test Run Output:**
```text
running 24 tests
...
test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 211 filtered out; finished in 0.01s
```