### PR TITLE
fix: restore app-level AX notifications dropped by observer refcon hints

### DIFF
--- a/src/actor/app.rs
+++ b/src/actor/app.rs
@@ -618,9 +618,16 @@ impl State {
             sleep_dur = Duration::min(sleep_dur * 2, Duration::from_secs(1));
             true
         };
-        for &(_kind, notif) in APP_NOTIFICATIONS {
+        for &(kind, notif) in APP_NOTIFICATIONS {
+            // App-level notifications are not tied to a specific window, but the
+            // observer callback still recovers the notification kind by decoding
+            // the refcon hint (see `decode_notification_data`). Registering with the
+            // plain `add_notification` would attach a zero hint, which decodes to an
+            // invalid tag and causes the notification to be silently dropped - so
+            // encode the kind here just like the per-window registrations do.
+            let data = encode_notification_data(kind, None);
             loop {
-                match self.observer.add_notification(&self.app, notif) {
+                match self.observer.add_notification_with_data(&self.app, notif, data) {
                     Ok(()) => break,
                     #[allow(non_upper_case_globals)]
                     Err(AxError::Ax(AXError::NotificationAlreadyRegistered)) => {


### PR DESCRIPTION
## Summary

Fixes a regression (since v0.4.2) where activating an app on another workspace no longer follows to that app's workspace. It shows up in several everyday flows:

- Switching to an app on another workspace via **Cmd-Tab**.
- **Clicking a web link** in one app when the browser lives on a different workspace.
- **Clicking a macOS notification** whose target app is on a different workspace.

In each case the app comes to the front but Rift stays on the current workspace instead of following.

**Root cause:** The observer refcon-hint optimization (ec8d197, "add event hints in observers refcons") encodes the notification *kind* and *window* into the AX observer refcon so the callback can recover them without a lookup. Per-**window** notifications were registered with the encoded hint, but per-**application** notifications kept using the plain `add_notification`, which attaches a **zero** refcon.

Kind tags start at `1`, so `AxNotificationKind::from_tag(0)` returns `None`, and `decode_notification_data` therefore discards the event. The net effect is that **every** app-level notification — `ApplicationActivated`, `ApplicationDeactivated`, `ApplicationHidden`, `ApplicationShown`, and `MainWindowChanged` on the app element — is silently dropped.

The user-visible symptom is the missing workspace switch: the auto-switch-on-activation is driven by `Event::ApplicationActivated`, which is emitted from `on_activation_changed()`. With the app-level `AXApplicationActivated` notification dropped, that handler only ever ran via the frontmost-polling fallback after Rift's *own* (quiet) raises — never for a genuine user activation (Cmd-Tab, link open, notification click) — so the reactor never saw the activation and never switched.

**Diagnosis from live logs:** clean single-action Cmd-Tab repros (with the mouse held still to rule out focus-follows-mouse) showed only `ApplicationGloballyActivated(pid)` reaching the reactor, with **no** `ApplicationActivated(pid, …)` and no `on_activation_changed` for the activated app — exactly matching the dropped-notification analysis.

**Fix:** register app-level notifications with their encoded kind hint (`encode_notification_data(kind, None)`), mirroring the per-window registration path, so the callback decodes them correctly again. The `kind` was already present in `APP_NOTIFICATIONS` and was simply being discarded as `_kind`. This keeps the optimization fully intact — it just completes it for the app-level case.

> **Disclaimer:** The root cause analysis and fix were produced by Claude Code (Opus 4.8), guided and verified by the PR author.

> **Scope note:** Because this un-drops a class of app-level notifications that have been silently absent since v0.4.2, it restores v0.4.1 behavior for those events (activate/deactivate/hide/show and the app-level `MainWindowChanged` fallback), not only workspace switching. A careful eye on whether re-enabling those introduces any unexpected activation-driven behavior would be appreciated.

## Test plan

- [x] `cargo build --release` succeeds
- [x] Root cause confirmed from live logs: a clean Cmd-Tab repro shows `ApplicationGloballyActivated` with no corresponding `ApplicationActivated`
- [x] Manual verification of the fix: with the patched release build, Cmd-Tab to Finder on another workspace now logs `on_activation_changed, pid=…, is_frontmost=true` → `ApplicationActivated(pid, No)` → `Auto-switching to workspace N for activated app`, and the WM switches workspaces. It stays put afterward (no ping-pong), and Rift's own quiet raises are still suppressed (`Skipping auto workspace switch for quiet app activation`).
