### PR TITLE
fix: prevent window oscillation when moving windows between displays

### DIFF
--- a/src/actor/reactor/events/space.rs
+++ b/src/actor/reactor/events/space.rs
@@ -233,7 +233,19 @@ impl SpaceEventHandler {
                                 reactor, wsid, sid, wid,
                             )
                             .unwrap_or_else(|| {
-                                reactor.reassign_window_to_authoritative_space(wid, sid)
+                                // `SpaceWindowCreated` (this event) also fires as a side
+                                // effect of our own SetWindowFrame dragging a window across
+                                // a display seam. If a Rift frame transaction is still in
+                                // flight for this window, this appearance is our own echo —
+                                // chasing it reassigns the window back and forth, which makes
+                                // frame-resisting apps (e.g. Zen, Outlook) oscillate between
+                                // displays. The authoritative space record is still updated
+                                // above; only the layout reassignment is suppressed here.
+                                if reactor.transaction_manager.get_target_frame(wsid).is_some() {
+                                    false
+                                } else {
+                                    reactor.reassign_window_to_authoritative_space(wid, sid)
+                                }
                             });
                             if layout_changed {
                                 let _ = reactor.update_layout_or_warn(false, false);

--- a/src/actor/reactor/tests.rs
+++ b/src/actor/reactor/tests.rs
@@ -465,6 +465,126 @@ fn known_window_server_appearance_updates_authoritative_space() {
     assert_eq!(reactor.window_manager.window_server_space(wsid), Some(space2));
 }
 
+/// Builds a reactor with `space1` active on a screen and a single tiled window
+/// (`wid`/`wsid`) assigned to `space1`. `space2` exists with workspaces so it can
+/// be a reassignment target. Returns the pieces the `appeared` tests need.
+fn reactor_with_window_on_space1() -> (Reactor, WindowId, WindowServerId, SpaceId, SpaceId, CGRect) {
+    let mut reactor = Reactor::new_for_test(LayoutEngine::new(
+        &crate::common::config::VirtualWorkspaceSettings::default(),
+        &crate::common::config::LayoutSettings::default(),
+        None,
+    ));
+    let pid = 1;
+    let frame = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1440., 900.));
+    let space1 = SpaceId::new(1);
+    let space2 = SpaceId::new(2);
+    let wid = WindowId::new(pid, 1);
+    let wsid = WindowServerId::new(101);
+
+    reactor.handle_event(space_state_event(vec![frame], vec![Some(space1)], vec![]));
+
+    let (app_tx, _app_rx) = crate::actor::channel();
+    reactor.app_manager.apps.insert(pid, AppState {
+        info: AppInfo {
+            bundle_id: Some("com.test.app".to_string()),
+            localized_name: Some("Test App".to_string()),
+        },
+        handle: AppThreadHandle::new_for_test(app_tx),
+    });
+
+    let space1_workspace = reactor
+        .layout_manager
+        .layout_engine
+        .virtual_workspace_manager_mut()
+        .list_workspaces(space1)
+        .first()
+        .map(|(id, _)| *id)
+        .expect("space1 workspace");
+    // Ensure space2 has workspaces so a reassignment can resolve a target.
+    reactor.layout_manager.layout_engine.virtual_workspace_manager_mut().list_workspaces(space2);
+
+    reactor.window_manager.track_window_server_id(wsid, wid);
+    reactor.window_manager.track_window_server_info(crate::sys::window_server::WindowServerInfo {
+        id: wsid,
+        pid,
+        layer: 0,
+        frame,
+        min_frame: frame.size,
+        max_frame: frame.size,
+    });
+    reactor.window_manager.set_window_server_space(wsid, Some(space1));
+    reactor.window_manager.mark_window_visible(wsid);
+    reactor.window_manager.insert_window(wid, WindowState {
+        info: WindowInfo {
+            is_standard: true,
+            is_root: true,
+            is_minimized: false,
+            is_resizable: true,
+            min_size: None,
+            max_size: None,
+            title: "Window".to_string(),
+            frame,
+            sys_id: Some(wsid),
+            bundle_id: None,
+            path: None,
+            ax_role: None,
+            ax_subrole: None,
+        },
+        frame_monotonic: frame,
+        is_manageable: true,
+        ignore_app_rule: false,
+    });
+
+    assert!(reactor
+        .layout_manager
+        .layout_engine
+        .virtual_workspace_manager_mut()
+        .assign_window_to_workspace(space1, wid, space1_workspace));
+    assert_eq!(reactor.assigned_space_for_window_id(wid), Some(space1));
+
+    (reactor, wid, wsid, space1, space2, frame)
+}
+
+#[test]
+fn appeared_does_not_reassign_window_while_rift_move_is_in_flight() {
+    let (mut reactor, wid, wsid, space1, space2, frame) = reactor_with_window_on_space1();
+
+    // Simulate Rift having just sent a frame move for this window: a pending target
+    // is registered in the transaction store, exactly like the tiling/apply path does.
+    // The `appeared` event below is the echo of that move dragging the window across a
+    // display seam, not a genuine external space change.
+    reactor.transaction_manager.store_txid(
+        wsid,
+        crate::actor::reactor::transaction_manager::TransactionId::default(),
+        frame,
+    );
+
+    SpaceEventHandler::handle_window_server_appeared(&mut reactor, wsid, space2, SpaceEventKind::User);
+
+    assert_eq!(
+        reactor.assigned_space_for_window_id(wid),
+        Some(space1),
+        "window with an in-flight Rift move must not be reassigned by its own appearance echo"
+    );
+}
+
+#[test]
+fn appeared_reassigns_window_without_pending_rift_move() {
+    let (mut reactor, wid, wsid, space1, space2, _frame) = reactor_with_window_on_space1();
+
+    // No pending transaction: this is a genuine external space change, so Rift should
+    // follow it and reassign the window to the reported space.
+    assert_eq!(reactor.assigned_space_for_window_id(wid), Some(space1));
+
+    SpaceEventHandler::handle_window_server_appeared(&mut reactor, wsid, space2, SpaceEventKind::User);
+
+    assert_eq!(
+        reactor.assigned_space_for_window_id(wid),
+        Some(space2),
+        "window without an in-flight Rift move must follow a genuine external space change"
+    );
+}
+
 #[test]
 fn known_fullscreen_window_appearance_removes_window_from_layout() {
     let mut apps = Apps::new();


### PR DESCRIPTION
## Summary

Fixes a regression introduced by #392 (`feat: space actor`, this PR's base) where moving a window between displays makes some apps oscillate rapidly between the two displays instead of settling. It reproduces with both the `move_window_to_display` shortcut and a manual mouse drag, and is most visible with frame-resisting apps like **Zen** and **Outlook**.

**Root cause:** #392 changed `handle_window_server_appeared` to call `reassign_window_to_authoritative_space` for any known window on every `WindowServerAppeared` event, re-tiling it onto the WindowServer-reported space. Before #392, this event was ignored for known windows.

`WindowServerAppeared` is the CGS/SkyLight `SpaceWindowCreated` event (`actor/window_notify.rs`), which **also fires as a side effect of Rift's own `SetWindowFrame` dragging a window across a display seam** — and fires for *both* spaces while the window straddles the boundary. So Rift treated the echo of its own move as authoritative, reassigned the window, re-tiled it (moving it again), and chased it indefinitely.

Unlike the parallel `WindowFrameChanged` path (`actor/reactor/events/window.rs`), which suppresses self-induced moves via the pending-transaction (txid) check, the new `appeared → reassign` path had **no self-move guard**. Apps that accept the frame change settle after one event; frame-resisting apps never settle, so they oscillate.

This is not a removed guard — the existing oscillation protections (#342 two-tree desync, floating ping-pong, churn/sleep quarantine) are all intact; they simply don't cover this newly-added path.

**Diagnosis from live logs:** a 12 s capture of one repro showed the Zen window (`WindowServerId(54951)`) generating 121 `WindowServerAppeared` events split almost evenly across both displays (60 on one space, 61 on the other), driving ~52 reassign re-tiles — the window's frame alternating between two origins roughly every 170 ms with no `MoveWindowToDisplay` command in between.

**Fix:** in `handle_window_server_appeared`, skip the `reassign_window_to_authoritative_space` fallback when a Rift frame transaction is still in flight for the window (`transaction_manager.get_target_frame(wsid).is_some()`) — i.e. when the appearance is an echo of Rift's own move. The authoritative-space record is still updated, so #392's tested bookkeeping contract is unchanged. Genuine external moves (manual drag with no pending transaction) still reassign and follow the window.

**Tests:**
- `appeared_does_not_reassign_window_while_rift_move_is_in_flight` — the regression guard; fails before the fix (the window is reassigned to the echo space), passes after.
- `appeared_reassigns_window_without_pending_rift_move` — ensures genuine external space changes are still followed (guards against over-suppression).

> **Disclaimer:** The root cause analysis and fix were produced by Claude Code (Opus 4.8), guided and verified by the PR author.

> **Base note:** This targets the still-draft #392 branch (`feat/space-actor`), since the regression originates there. It will need retargeting if #392's approach changes before merge.

## Test plan

- [x] `cargo test` passes (284 tests, including 2 new tests)
- [x] New guard test fails without the fix, passes with it
- [x] Live verification with the debug build: shortcut moves no longer storm (~6× fewer WindowServer events, 0 reassign re-tiles from the appeared path); frame-resisting apps show only a sub-frame commit flash and settle; manual mouse-drag across displays is followed correctly and settles
