### PR TITLE
fix: remove stale dev bin from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,6 @@ build = "build.rs"
 name = "rift"
 test = false
 
-[[bin]]
-name = "dev"
-test = false
-
 [profile.dev]
 opt-level = 0
 debug = 1


### PR DESCRIPTION
Remove missing `dev` bin from Cargo.toml to fix build failure:

```bash
cargo run --bin rift
error: failed to parse manifest at `/Users/adam/Projects/oss/rift/Cargo.toml`

Caused by:
  can't find `dev` bin at `src/bin/dev.rs` or `src/bin/dev/main.rs`. Please specify bin.path if you want to use a non-default path.
```