### PR TITLE
fix: move real window focus (and the cursor) on focus_display / move_mouse_to_display

### DIFF
--- a/src/actor/reactor.rs
+++ b/src/actor/reactor.rs
@@ -1563,6 +1563,7 @@ impl Reactor {
                         screen,
                         target_is_active,
                         focus_window,
+                        focus_window_center: None,
                     },
                 );
             }
@@ -1582,12 +1583,16 @@ impl Reactor {
                     .as_ref()
                     .and_then(|screen| screen.space)
                     .is_none_or(|space| self.is_space_active(space));
+                let focus_window_center = focus_window
+                    .and_then(|wid| self.state.windows.window(wid))
+                    .map(|window| window.frame_monotonic.mid());
                 return command_workflow::handle_focus_display(
                     &self.app_manager,
                     command_workflow::DisplayFocusPayload {
                         screen,
                         target_is_active,
                         focus_window,
+                        focus_window_center,
                     },
                 );
             }

--- a/src/actor/reactor.rs
+++ b/src/actor/reactor.rs
@@ -1558,6 +1558,7 @@ impl Reactor {
                     .and_then(|screen| screen.space)
                     .is_none_or(|space| self.is_space_active(space));
                 return command_workflow::handle_move_mouse_to_display(
+                    &self.app_manager,
                     command_workflow::DisplayFocusPayload {
                         screen,
                         target_is_active,
@@ -1582,6 +1583,7 @@ impl Reactor {
                     .and_then(|screen| screen.space)
                     .is_none_or(|space| self.is_space_active(space));
                 return command_workflow::handle_focus_display(
+                    &self.app_manager,
                     command_workflow::DisplayFocusPayload {
                         screen,
                         target_is_active,

--- a/src/actor/reactor/events/command.rs
+++ b/src/actor/reactor/events/command.rs
@@ -249,7 +249,27 @@ pub struct DisplayFocusPayload {
     pub focus_window: Option<WindowId>,
 }
 
-pub fn handle_move_mouse_to_display(payload: DisplayFocusPayload) -> anyhow::Result<EventOutcome> {
+/// Build a raise request that moves real (window server) focus to `window`,
+/// mirroring what `handle_command_reactor_focus_window` emits. Without this,
+/// display-focus commands only update the layout engine's internal selection
+/// and macOS keyboard focus stays on the previous display.
+fn display_focus_raise_request(apps: &AppManager, window: WindowId) -> raise_manager::Event {
+    let mut app_handles: HashMap<i32, AppThreadHandle> = HashMap::default();
+    if let Some(app) = apps.apps.get(&window.pid) {
+        app_handles.insert(window.pid, app.handle.clone());
+    }
+    raise_manager::Event::RaiseRequest(raise_manager::RaiseRequest {
+        raise_windows: Vec::new(),
+        focus_window: Some((window, None)),
+        app_handles,
+        focus_quiet: Quiet::No,
+    })
+}
+
+pub fn handle_move_mouse_to_display(
+    apps: &AppManager,
+    payload: DisplayFocusPayload,
+) -> anyhow::Result<EventOutcome> {
     let Some(screen) = payload.screen else {
         return Ok(EventOutcome::finalized_event(None, false, false, false));
     };
@@ -260,12 +280,17 @@ pub fn handle_move_mouse_to_display(payload: DisplayFocusPayload) -> anyhow::Res
     let mut outcome = EventOutcome::finalized_event(None, false, false, false)
         .with_mouse_warp(screen.frame.mid());
     if let (Some(space), Some(window)) = (screen.space, payload.focus_window) {
-        outcome = outcome.with_layout_event(LayoutEvent::WindowFocused(space, window));
+        outcome = outcome
+            .with_layout_event(LayoutEvent::WindowFocused(space, window))
+            .with_raise_request(display_focus_raise_request(apps, window));
     }
     Ok(outcome)
 }
 
-pub fn handle_focus_display(payload: DisplayFocusPayload) -> anyhow::Result<EventOutcome> {
+pub fn handle_focus_display(
+    apps: &AppManager,
+    payload: DisplayFocusPayload,
+) -> anyhow::Result<EventOutcome> {
     let Some(screen) = payload.screen else {
         return Ok(EventOutcome::finalized_event(None, false, false, false));
     };
@@ -275,7 +300,8 @@ pub fn handle_focus_display(payload: DisplayFocusPayload) -> anyhow::Result<Even
     }
     if let (Some(space), Some(window)) = (screen.space, payload.focus_window) {
         return Ok(EventOutcome::finalized_event(None, false, false, false)
-            .with_layout_event(LayoutEvent::WindowFocused(space, window)));
+            .with_layout_event(LayoutEvent::WindowFocused(space, window))
+            .with_raise_request(display_focus_raise_request(apps, window)));
     }
     Ok(
         EventOutcome::finalized_event(None, false, false, false)

--- a/src/actor/reactor/events/command.rs
+++ b/src/actor/reactor/events/command.rs
@@ -247,6 +247,9 @@ pub struct DisplayFocusPayload {
     pub screen: Option<ScreenInfo>,
     pub target_is_active: bool,
     pub focus_window: Option<WindowId>,
+    /// Center of `focus_window`'s frame, used to warp the cursor onto the
+    /// window that receives focus. Falls back to the screen center.
+    pub focus_window_center: Option<objc2_core_foundation::CGPoint>,
 }
 
 /// Build a raise request that moves real (window server) focus to `window`,
@@ -301,7 +304,8 @@ pub fn handle_focus_display(
     if let (Some(space), Some(window)) = (screen.space, payload.focus_window) {
         return Ok(EventOutcome::finalized_event(None, false, false, false)
             .with_layout_event(LayoutEvent::WindowFocused(space, window))
-            .with_raise_request(display_focus_raise_request(apps, window)));
+            .with_raise_request(display_focus_raise_request(apps, window))
+            .with_mouse_warp(payload.focus_window_center.unwrap_or_else(|| screen.frame.mid())));
     }
     Ok(
         EventOutcome::finalized_event(None, false, false, false)


### PR DESCRIPTION
Fixes #332

## Problem

`handle_focus_display` and `handle_move_mouse_to_display` only emitted the internal `LayoutEvent::WindowFocused`, so the layout engine's selection moved but macOS keyboard focus stayed on the previous display. The next directional display command then resolved relative to the stale display — which is why `focus_display` appeared to "work once and then stop".

On top of that, even with real focus moving, the cursor stayed on the previous display; with `focus_follows_mouse` enabled the next mouse move immediately stole focus back.

## Fix

- Emit the same `RaiseRequest` that `handle_command_reactor_focus_window` uses, so window-server focus actually follows the display change (both for `focus_display` and `move_mouse_to_display`).
- Warp the cursor to the focused window's center (falling back to screen center when the display has no windows), so `focus_follows_mouse` doesn't fight the command.

## Testing

- `cargo test`: 403 passed, 1 failed — the failure (`topology_change_clears_stale_pending_hide_target_before_next_workspace_layout`) is pre-existing and also fails on clean `main` at 72494bf.
- Manually verified on a two-display setup: repeated `focus_display left/right` now reliably alternates displays, keyboard focus lands on a real window, and the cursor follows.