### PR TITLE
fix: don't fold non-native fullscreen self-resizes into the layout

### DIFF
--- a/src/actor/reactor/events/window.rs
+++ b/src/actor/reactor/events/window.rs
@@ -384,13 +384,37 @@ pub fn handle_window_frame_changed(
             }
             outcome = outcome.with_arrange_passes(2);
         } else if !old_frame.size.same_as(new_frame.size) && old_space_active {
-            outcome.arrange.is_resize = true;
-            outcome = outcome.with_layout_event(LayoutEvent::WindowResized {
-                wid,
-                old_frame,
-                new_frame,
-                screens,
-            });
+            // Apps implementing non-native fullscreen (Firefox with
+            // full-screen-api.macos-native-full-screen=false, etc.) resize
+            // their own window to cover the screen with no mouse involved.
+            // Folding that transient frame into the layout rewrites the
+            // split ratios and wrecks the workspace arrangement. Like
+            // AeroSpace, never incorporate a programmatic full-screen-sized
+            // resize: leave the tree untouched while it covers the screen,
+            // and re-assert the stored layout once it shrinks back.
+            let covers = |frame: &objc2_core_foundation::CGRect| {
+                screens.iter().any(|(_, screen_frame, _)| {
+                    frame.origin.x <= screen_frame.origin.x + 1.0
+                        && frame.origin.y <= screen_frame.origin.y + 1.0
+                        && frame.size.width >= screen_frame.size.width - 2.0
+                        && frame.size.height >= screen_frame.size.height - 2.0
+                })
+            };
+            if covers(&new_frame) {
+                // Entering self-fullscreen: keep layout state pristine.
+            } else if covers(&old_frame) {
+                // Leaving self-fullscreen: snap the window back into its
+                // slot instead of deriving new ratios from the restored frame.
+                outcome = outcome.with_arrange_passes(1);
+            } else {
+                outcome.arrange.is_resize = true;
+                outcome = outcome.with_layout_event(LayoutEvent::WindowResized {
+                    wid,
+                    old_frame,
+                    new_frame,
+                    screens,
+                });
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

Apps that implement fullscreen without macOS native fullscreen (e.g. Firefox with `full-screen-api.macos-native-full-screen=false`) resize their own window over the whole screen with no mouse involved. `handle_window_frame_changed` treats that as a user resize and emits `LayoutEvent::WindowResized`, which rewrites the split ratios around the window — wrecking the workspace arrangement (a BSP tree collapses into everything horizontally tiled). The damage doesn't invert when the app restores its frame on exit.

## Fix

Following AeroSpace's model for non-native fullscreen: in the non-drag, same-space resize path, detect frames that cover a screen (within a ±1–2px tolerance):

- Window resizes itself to cover the screen → ignore it for layout purposes (no `WindowResized`).
- Window shrinks back from a screen-covering frame → don't fold the transition into the ratios either; instead schedule an arrange pass so the stored layout is re-asserted.
- All other resizes behave exactly as before.

## Testing

- `cargo test`: 403 passed, 1 failed — the failure (`topology_change_clears_stale_pending_hide_target_before_next_workspace_layout`) is pre-existing and also fails on clean `main` at 72494bf.
- Manually verified with Firefox non-native fullscreen: entering and leaving fullscreen now returns to the exact BSP arrangement from before, instead of a flattened horizontal tiling.