### PR TITLE
feat: warp cursor with the window on move_node

### DIFF
--- a/src/actor/reactor.rs
+++ b/src/actor/reactor.rs
@@ -1590,6 +1590,16 @@ impl Reactor {
                 );
             }
             Event::Command(Command::Layout(command)) => {
+                // Moving a window doesn't change focus, so mouse_follows_focus
+                // never fires and the cursor gets left behind on the window's
+                // old position. Defer a warp to the moved window's post-layout
+                // frame, reusing the workspace-switch deferred-warp hook.
+                if matches!(command, layout::LayoutCommand::MoveNode(_))
+                    && self.config.settings.mouse_follows_focus
+                    && let Some(wid) = self.main_window()
+                {
+                    self.workspace_switch_manager.pending_workspace_mouse_warp = Some(wid);
+                }
                 let command_space = self.command_context_space();
                 let (visible_spaces, visible_space_centers) = self.visible_spaces_for_layout(false);
                 return command_workflow::handle_command_layout(


### PR DESCRIPTION
## Problem

With `mouse_follows_focus` enabled, moving a window (`move_node`) keeps focus on the same window, so no focus change fires and the cursor is left behind at the window's old position. With `focus_follows_mouse` also enabled, the stale cursor position can then steal focus back to whatever window now occupies it.

## Fix

When a `MoveNode` layout command runs and `mouse_follows_focus` is enabled, defer a warp to the moved window's post-layout frame by reusing the existing workspace-switch deferred-warp hook (`pending_workspace_mouse_warp`). Deferring means the warp targets the window's frame *after* the layout pass, not its pre-move position.

## Testing

- `cargo test`: 403 passed, 1 failed — the failure (`topology_change_clears_stale_pending_hide_target_before_next_workspace_layout`) is pre-existing and also fails on clean `main` at 72494bf.
- Manually verified: `move_node left/right/up/down` now carries the cursor along with the window, matching AeroSpace's `move + move-mouse window-force-center` behavior.