### PR TITLE
chore: add missing "scrolling" layout in default config

### DIFF
--- a/rift.default.toml
+++ b/rift.default.toml
@@ -66,10 +66,11 @@ hot_reload = true
 
 [settings.layout]
 # Layout Types:
-# 	- "traditional" (i3/sway-like containers)
-#	- "bsp" (binary space partitioning),
+#   - "traditional" (i3/sway-like containers)
+#   - "bsp" (binary space partitioning)
 #   - "stack" (single stacked container)
 #   - "master_stack" (master area + stack area)
+#   - "scrolling" (niri-like)
 # defaults to "traditional" if omitted
 #
 # This is the default layout mode if there is nothing else configured


### PR DESCRIPTION
Add the missing `scrolling` option for the top level `settings.layout` config.

Also, fix formatting inconsistencies in this layout type list.