### PR TITLE
fix: ignore screen capture helper windows

### DIFF
--- a/src/actor/reactor/events/window.rs
+++ b/src/actor/reactor/events/window.rs
@@ -129,16 +129,21 @@ pub fn handle_window_destroyed(
     payload: WindowDestroyedPayload,
 ) -> anyhow::Result<EventOutcome> {
     let wid = payload.window;
-    let window_server_id = match state.windows.record(wid) {
-        Some(record) => record.window_server_id(),
-        None => return Ok(EventOutcome::no_change()),
-    };
+    let record_exists = state.windows.record(wid).is_some();
+    let window_server_id =
+        state.windows.record(wid).and_then(|record| record.window_server_id());
 
     if let Some(ws_id) = window_server_id {
         transactions.remove_for_window(ws_id);
         state.windows.remove_window_server_state(ws_id);
+    } else if record_exists {
+        debug!(?wid, "Received WindowDestroyed without a WindowServer identity");
     } else {
-        debug!(?wid, "Received WindowDestroyed for unknown window - ignoring");
+        // Destruction can race with discovery or native-window cleanup. The store is
+        // authoritative, but layout membership is only a projection and may still contain
+        // this id. Always emit the idempotent removal event so a late notification repairs
+        // any stale tile instead of preserving a focusable ghost.
+        debug!(?wid, "Scrubbing layout state for an untracked destroyed window");
     }
     state.windows.remove_window(wid);
 

--- a/src/actor/reactor/events/window.rs
+++ b/src/actor/reactor/events/window.rs
@@ -129,21 +129,21 @@ pub fn handle_window_destroyed(
     payload: WindowDestroyedPayload,
 ) -> anyhow::Result<EventOutcome> {
     let wid = payload.window;
-    let record_exists = state.windows.record(wid).is_some();
-    let window_server_id =
-        state.windows.record(wid).and_then(|record| record.window_server_id());
-
-    if let Some(ws_id) = window_server_id {
-        transactions.remove_for_window(ws_id);
-        state.windows.remove_window_server_state(ws_id);
-    } else if record_exists {
-        debug!(?wid, "Received WindowDestroyed without a WindowServer identity");
-    } else {
-        // Destruction can race with discovery or native-window cleanup. The store is
-        // authoritative, but layout membership is only a projection and may still contain
-        // this id. Always emit the idempotent removal event so a late notification repairs
-        // any stale tile instead of preserving a focusable ghost.
-        debug!(?wid, "Scrubbing layout state for an untracked destroyed window");
+    match state.windows.record(wid).map(|record| record.window_server_id()) {
+        Some(Some(ws_id)) => {
+            transactions.remove_for_window(ws_id);
+            state.windows.remove_window_server_state(ws_id);
+        }
+        Some(None) => {
+            debug!(?wid, "Received WindowDestroyed without a WindowServer identity");
+        }
+        None => {
+            // Destruction can race with discovery or native-window cleanup. The store is
+            // authoritative, but layout membership is only a projection and may still contain
+            // this id. Always emit the idempotent removal event so a late notification repairs
+            // any stale tile instead of preserving a focusable ghost.
+            debug!(?wid, "Scrubbing layout state for an untracked destroyed window");
+        }
     }
     state.windows.remove_window(wid);
 

--- a/src/actor/reactor/utils.rs
+++ b/src/actor/reactor/utils.rs
@@ -20,8 +20,7 @@ fn is_tiny_window_server_frame(size: CGSize) -> bool {
     // discovery pass can reconcile the real frame instead of permanently losing the window.
     width > 0.0
         && height > 0.0
-        && (width < MIN_MANAGEABLE_WINDOW_DIMENSION
-            || height < MIN_MANAGEABLE_WINDOW_DIMENSION)
+        && (width < MIN_MANAGEABLE_WINDOW_DIMENSION || height < MIN_MANAGEABLE_WINDOW_DIMENSION)
 }
 
 /// Computes whether a window is manageable based on its properties and window server information.

--- a/src/actor/reactor/utils.rs
+++ b/src/actor/reactor/utils.rs
@@ -1,12 +1,35 @@
 use objc2_app_kit::NSNormalWindowLevel;
+use objc2_core_foundation::CGSize;
 
 use crate::sys::window_server::{WindowServerId, WindowServerInfo, window_is_sticky, window_level};
+
+/// Small WindowServer surfaces used by capture/streaming helpers can expose themselves as
+/// otherwise-normal AX windows. They are not useful tiling targets and can disappear without the
+/// same lifecycle guarantees as application windows.
+const MIN_MANAGEABLE_WINDOW_DIMENSION: f64 = 16.0;
+
+fn is_tiny_window_server_frame(size: CGSize) -> bool {
+    let width = size.width.abs();
+    let height = size.height.abs();
+
+    if !width.is_finite() || !height.is_finite() {
+        return true;
+    }
+
+    // A zero-sized frame can be a transient creation snapshot. Keep it eligible so a later
+    // discovery pass can reconcile the real frame instead of permanently losing the window.
+    width > 0.0
+        && height > 0.0
+        && (width < MIN_MANAGEABLE_WINDOW_DIMENSION
+            || height < MIN_MANAGEABLE_WINDOW_DIMENSION)
+}
 
 /// Computes whether a window is manageable based on its properties and window server information.
 ///
 /// A window is manageable if:
 /// - It is not minimized
 /// - Its layer is 0 (if info available)
+/// - Its nonzero WindowServer dimensions are large enough to represent a real app window
 /// - It is not sticky
 /// - Its level is normal (if available)
 /// - It is AX standard and AX root
@@ -23,7 +46,7 @@ pub fn compute_window_manageability(
 
     if let Some(wsid) = window_server_id {
         if let Some(info) = window_server_info(wsid) {
-            if info.layer != 0 {
+            if info.layer != 0 || is_tiny_window_server_frame(info.frame.size) {
                 return false;
             }
         }
@@ -38,4 +61,29 @@ pub fn compute_window_manageability(
         }
     }
     is_ax_standard && is_ax_root
+}
+
+#[cfg(test)]
+mod tests {
+    use objc2_core_foundation::CGSize;
+
+    use super::is_tiny_window_server_frame;
+
+    #[test]
+    fn rejects_tiny_capture_helper_frames() {
+        assert!(is_tiny_window_server_frame(CGSize::new(40.0, 11.0)));
+        assert!(is_tiny_window_server_frame(CGSize::new(11.0, 40.0)));
+    }
+
+    #[test]
+    fn accepts_ordinary_and_transitional_frames() {
+        assert!(!is_tiny_window_server_frame(CGSize::new(800.0, 600.0)));
+        assert!(!is_tiny_window_server_frame(CGSize::ZERO));
+    }
+
+    #[test]
+    fn rejects_invalid_frame_dimensions() {
+        assert!(is_tiny_window_server_frame(CGSize::new(f64::NAN, 100.0)));
+        assert!(is_tiny_window_server_frame(CGSize::new(100.0, f64::INFINITY)));
+    }
 }


### PR DESCRIPTION
Closed in favor of a structural fix. The size threshold was too heuristic; the replacement should reject non-root WindowServer surfaces and keep the idempotent stale-layout cleanup.