### PR TITLE
fix(cli): return error instead of panicking on invalid move-node/join-window direction

### DIFF
--- a/src/bin/rift-cli.rs
+++ b/src/bin/rift-cli.rs
@@ -877,15 +877,24 @@ fn map_layout_command(cmd: LayoutCommands) -> Result<CliCommand, String> {
     match cmd {
         LayoutCommands::Ascend => Ok(CliCommand::Reactor(reactor::Command::Layout(LC::Ascend))),
         LayoutCommands::Descend => Ok(CliCommand::Reactor(reactor::Command::Layout(LC::Descend))),
-        LayoutCommands::MoveNode { direction } => Ok(CliCommand::Reactor(
-            reactor::Command::Layout(LC::MoveNode(direction.into())),
-        )),
-        LayoutCommands::JoinWindow { direction } => Ok(CliCommand::Reactor(
-            reactor::Command::Layout(LC::JoinWindow(direction.into())),
-        )),
-        LayoutCommands::ConsumeOrExpelWindow { direction } => Ok(CliCommand::Reactor(
-            reactor::Command::Layout(LC::ConsumeOrExpelWindow(direction.into())),
-        )),
+        LayoutCommands::MoveNode { direction } => {
+            let direction = parse_focus_direction(&direction)?;
+            Ok(CliCommand::Reactor(reactor::Command::Layout(LC::MoveNode(
+                direction,
+            ))))
+        }
+        LayoutCommands::JoinWindow { direction } => {
+            let direction = parse_focus_direction(&direction)?;
+            Ok(CliCommand::Reactor(reactor::Command::Layout(LC::JoinWindow(
+                direction,
+            ))))
+        }
+        LayoutCommands::ConsumeOrExpelWindow { direction } => {
+            let direction = parse_focus_direction(&direction)?;
+            Ok(CliCommand::Reactor(reactor::Command::Layout(
+                LC::ConsumeOrExpelWindow(direction),
+            )))
+        }
         LayoutCommands::ToggleStack => {
             Ok(CliCommand::Reactor(reactor::Command::Layout(LC::ToggleStack)))
         }
@@ -1169,6 +1178,70 @@ mod tests {
             serde_json::json!({
                 "execute_command": { "command": { "config": { "set_animate": true } } }
             })
+        );
+    }
+
+    #[test]
+    fn invalid_move_node_direction_returns_error_not_panic() {
+        let result = build_execute_request(ExecuteCommands::Layout {
+            layout_cmd: LayoutCommands::MoveNode { direction: "foo".into() },
+        });
+
+        assert!(
+            result.is_err(),
+            "expected an error for an invalid direction, got Ok: {result:?}"
+        );
+        assert!(
+            result.unwrap_err().contains("Invalid focus direction"),
+            "expected the error to mention 'Invalid focus direction'"
+        );
+    }
+
+    #[test]
+    fn invalid_join_window_direction_returns_error_not_panic() {
+        let result = build_execute_request(ExecuteCommands::Layout {
+            layout_cmd: LayoutCommands::JoinWindow { direction: "foo".into() },
+        });
+
+        assert!(
+            result.is_err(),
+            "expected an error for an invalid direction, got Ok: {result:?}"
+        );
+        assert!(
+            result.unwrap_err().contains("Invalid focus direction"),
+            "expected the error to mention 'Invalid focus direction'"
+        );
+    }
+
+    #[test]
+    fn invalid_consume_or_expel_window_direction_returns_error_not_panic() {
+        let result = build_execute_request(ExecuteCommands::Layout {
+            layout_cmd: LayoutCommands::ConsumeOrExpelWindow { direction: "foo".into() },
+        });
+
+        assert!(
+            result.is_err(),
+            "expected an error for an invalid direction, got Ok: {result:?}"
+        );
+        assert!(
+            result.unwrap_err().contains("Invalid focus direction"),
+            "expected the error to mention 'Invalid focus direction'"
+        );
+    }
+
+    #[test]
+    fn valid_layout_direction_is_accepted_and_normalized() {
+        // Mixed-case / surrounding-whitespace input must be accepted and normalized to
+        // the canonical lowercase value, matching the existing focus/switch path.
+        let request = build_execute_request(ExecuteCommands::Layout {
+            layout_cmd: LayoutCommands::MoveNode { direction: " Left ".into() },
+        })
+        .expect("a valid direction should be accepted");
+
+        let rendered = serde_json::to_string(&request).unwrap();
+        assert!(
+            rendered.contains("\"left\""),
+            "expected the normalized direction 'left' in the request, got: {rendered}"
         );
     }
 }


### PR DESCRIPTION
## Problem

A typo in the direction argument of `rift-cli execute layout
move-node|join-window|consume-or-expel-window` (e.g. `move-node rignt`)
panicked with exit code 101 instead of returning a clean error:

    $ rift-cli execute layout move-node rignt
    thread 'main' panicked at crates/rift-protocol/src/layout.rs:58:18:
    Invalid direction string: rignt

The three commands fed the raw clap `direction: String` straight into
`From<String> for Direction`, which `panic!`s on any token outside
`left`/`right`/`up`/`down`. The sibling `focus` commands already validate
this input through `parse_focus_direction` and print
`Error: Invalid focus direction '…'` with exit 1.

## Changes

- Route `MoveNode`, `JoinWindow`, and `ConsumeOrExpelWindow` through
  `parse_focus_direction(&direction)?` in `map_layout_command`
  (`src/bin/rift-cli.rs`), matching the existing `focus`/`switch` path and
  the neighbouring `SetLayout` arm. Invalid directions now yield
  `Error: Invalid focus direction 'foo'; must be left, right, up, or down`
  with exit 1; valid directions are unchanged.
- Add regression test `invalid_move_node_direction_returns_error_not_panic`
  asserting the invalid path is an `Err` containing `"Invalid focus
  direction"` (pre-fix this panicked).

The `From<String> for Direction` impl in `crates/rift-protocol/src/layout.rs`
is intentionally left untouched; it is simply no longer reached from CLI
input.

## How I tested this

- `cargo nextest run -E 'test(invalid_move_node_direction_returns_error_not_panic)'`
  → PASS (was a panic before the fix).
- Manual: `rift-cli execute layout move-node|join-window|consume-or-expel-window <bad>`
  → exit 1 with the one-line `Invalid focus direction` error (previously
  exit 101 panic).
- Parity: `rift-cli execute layout move-node left` still parses correctly and
  reaches the IPC layer (no false rejection of valid directions).
- Gate: `cargo +nightly fmt --all --check --verbose` ✅,
  `cargo check --locked` ✅,
  `cargo nextest run -E 'not test(/actor::reactor::tests/)'` → 384 passed.
  Full `cargo nextest run --no-fail-fast`: the only failures are the 12
  pre-existing `actor::reactor::tests` host-env baseline (multi-display
  topology), unrelated to this change.

Scope: CLI-input validation only — no changes to the layout engine, IPC,
config, or `Direction` semantics for valid values.