### PR TITLE
feat: persistently disable configured spaces

### DIFF
--- a/rift.default.toml
+++ b/rift.default.toml
@@ -17,6 +17,10 @@ animation_fps = 100.0
 # - If false, spaces are managed by default and you can disable specific ones.
 # Default is true; uncomment to change.
 #default_disable = false
+# Native macOS Space IDs that Rift should never manage. These exclusions are
+# persistent across Rift restarts, unlike toggle_space_activated. Find IDs with
+# `rift-cli query displays`. IDs can change if a macOS Space is deleted/recreated.
+disabled_space_ids = []
 
 # Mouse/Focus behavior
 # - focus_follows_mouse: moving the mouse into a window focuses it

--- a/src/actor/reactor.rs
+++ b/src/actor/reactor.rs
@@ -377,6 +377,9 @@ impl Reactor {
             Some((tx, store)) => (Some(tx), store),
             None => (None, WindowTxStore::new()),
         };
+        let mut space_activation_policy = SpaceActivationPolicy::new();
+        space_activation_policy
+            .set_configured_disabled_spaces(&config.settings.disabled_space_ids);
         let reactor = Reactor {
             config: config.clone(),
             one_space,
@@ -384,7 +387,7 @@ impl Reactor {
             layout_manager: managers::LayoutManager { layout_engine },
             state: RiftState::default(),
             space_state: ForwardedSpaceState::default(),
-            space_activation_policy: SpaceActivationPolicy::new(),
+            space_activation_policy,
             main_window_tracker: MainWindowTracker::default(),
             drag_manager: managers::DragManager {
                 drag_state: DragState::Inactive,
@@ -1543,6 +1546,7 @@ impl Reactor {
             Event::ConfigUpdated(new_cfg) => {
                 return command_workflow::handle_config_updated(
                     &mut self.config,
+                    &mut self.space_activation_policy,
                     &mut self.layout_manager,
                     &self.state,
                     &mut self.drag_manager,

--- a/src/actor/reactor/events/command.rs
+++ b/src/actor/reactor/events/command.rs
@@ -187,12 +187,15 @@ pub fn handle_close_window(
 
 pub fn handle_config_updated(
     config: &mut Config,
+    space_activation_policy: &mut SpaceActivationPolicy,
     layout: &mut LayoutManager,
     state: &RiftState,
     drag: &mut DragManager,
     new_config: Config,
 ) -> anyhow::Result<EventOutcome> {
     *config = new_config;
+    space_activation_policy
+        .set_configured_disabled_spaces(&config.settings.disabled_space_ids);
     layout.layout_engine.set_layout_settings(&config.settings.layout);
 
     layout
@@ -201,7 +204,9 @@ pub fn handle_config_updated(
 
     drag.update_config(config.settings.window_snapping);
 
-    Ok(EventOutcome::layout_changed(false).with_service_config_update(config.clone()))
+    Ok(EventOutcome::layout_changed(false)
+        .with_active_space_recompute()
+        .with_service_config_update(config.clone()))
 }
 
 pub fn handle_command_reactor_debug(

--- a/src/actor/reactor/tests.rs
+++ b/src/actor/reactor/tests.rs
@@ -83,6 +83,26 @@ fn config_reload_propagates_non_keybinding_changes_to_wm_controller() {
 }
 
 #[test]
+fn config_reload_recomputes_persistently_disabled_spaces() {
+    let mut reactor = test_reactor();
+    let screen = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
+    let space = SpaceId::new(6);
+
+    reactor.handle_event(space_state_event(vec![screen], vec![Some(space)]));
+    assert!(reactor.is_space_active(space));
+
+    let mut updated = reactor.config.clone();
+    updated.settings.disabled_space_ids = vec![space.get()];
+    reactor.handle_event(Event::ConfigUpdated(updated));
+    assert!(!reactor.is_space_active(space));
+
+    let mut updated = reactor.config.clone();
+    updated.settings.disabled_space_ids.clear();
+    reactor.handle_event(Event::ConfigUpdated(updated));
+    assert!(reactor.is_space_active(space));
+}
+
+#[test]
 fn it_ignores_stale_resize_events() {
     let (mut apps, mut reactor) = test_context();
     reactor.handle_event(space_state_event(

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -6,7 +6,7 @@ use regex::RegexBuilder;
 pub use rift_protocol::{AnimationEasing, ConfigCommand, LayoutMode, WorkspaceSelector};
 use serde::{Deserialize, Serialize};
 
-use super::collections::HashMap;
+use super::collections::{HashMap, HashSet};
 use crate::actor::wm_controller::WmCommand;
 use crate::sys::hotkey::{Hotkey, HotkeySpec};
 
@@ -425,6 +425,10 @@ pub struct Settings {
     pub animation_easing: AnimationEasing,
     #[serde(default = "yes")]
     pub default_disable: bool,
+    /// Native macOS Space IDs that Rift must never manage. Unlike temporary
+    /// `toggle_space_activated` overrides, these exclusions survive restarts.
+    #[serde(default)]
+    pub disabled_space_ids: Vec<u64>,
     #[serde(default = "yes")]
     pub mouse_follows_focus: bool,
     #[serde(default = "yes")]
@@ -1015,6 +1019,16 @@ impl Settings {
                 "animation_fps must be positive, got {}",
                 self.animation_fps
             ));
+        }
+
+        if self.disabled_space_ids.contains(&0) {
+            issues.push("disabled_space_ids must contain only positive Space IDs".to_string());
+        }
+
+        let unique_disabled_space_ids: HashSet<u64> =
+            self.disabled_space_ids.iter().copied().collect();
+        if unique_disabled_space_ids.len() != self.disabled_space_ids.len() {
+            issues.push("disabled_space_ids must not contain duplicates".to_string());
         }
 
         issues.extend(self.layout.validate());
@@ -1619,6 +1633,23 @@ mod tests {
     use super::*;
     use crate::actor::reactor;
     use crate::layout_engine::{LayoutCommand, ResizeOrientation};
+
+    #[test]
+    fn disabled_space_ids_parse_and_validate() {
+        let settings: Settings = toml::from_str("disabled_space_ids = [3, 6]").unwrap();
+
+        assert_eq!(settings.disabled_space_ids, vec![3, 6]);
+        assert!(settings.validate().is_empty());
+    }
+
+    #[test]
+    fn disabled_space_ids_reject_zero_and_duplicates() {
+        let settings: Settings = toml::from_str("disabled_space_ids = [0, 6, 6]").unwrap();
+        let issues = settings.validate();
+
+        assert!(issues.iter().any(|issue| issue.contains("positive Space IDs")));
+        assert!(issues.iter().any(|issue| issue.contains("duplicates")));
+    }
 
     #[test]
     fn layout_insertion_point_supports_global_default_and_per_mode_override() {

--- a/src/model/space_activation.rs
+++ b/src/model/space_activation.rs
@@ -10,6 +10,7 @@ use crate::sys::screen::{ScreenId, ScreenInfo, SpaceId};
 /// - user "toggle" commands (target space/display context)
 #[derive(Debug, Default)]
 pub struct SpaceActivationPolicy {
+    configured_disabled_spaces: HashSet<SpaceId>,
     disabled_spaces: HashSet<SpaceId>,
     enabled_spaces: HashSet<SpaceId>,
 
@@ -41,6 +42,7 @@ pub struct ToggleSpaceContext {
 impl SpaceActivationPolicy {
     pub fn new() -> Self {
         Self {
+            configured_disabled_spaces: HashSet::default(),
             disabled_spaces: HashSet::default(),
             enabled_spaces: HashSet::default(),
             disabled_displays: HashSet::default(),
@@ -51,6 +53,11 @@ impl SpaceActivationPolicy {
             last_known_display_by_screen: HashMap::default(),
             login_window_active: false,
         }
+    }
+
+    pub fn set_configured_disabled_spaces(&mut self, space_ids: &[u64]) {
+        self.configured_disabled_spaces =
+            space_ids.iter().copied().map(SpaceId::new).collect();
     }
 
     pub fn set_login_window_active(&mut self, active: bool) { self.login_window_active = active; }
@@ -157,6 +164,10 @@ impl SpaceActivationPolicy {
     /// This mutates the policy state only; Reactor is responsible for recomputing
     /// active spaces and performing any follow-up actions.
     pub fn toggle_space_activated(&mut self, cfg: SpaceActivationConfig, ctx: ToggleSpaceContext) {
+        if self.configured_disabled_spaces.contains(&ctx.space) {
+            return;
+        }
+
         let space_currently_enabled = if cfg.default_disable {
             self.enabled_spaces.contains(&ctx.space)
         } else {
@@ -205,6 +216,7 @@ impl SpaceActivationPolicy {
             let enabled = match *space_opt {
                 _ if self.login_window_active => false,
                 Some(space) if cfg.one_space && Some(space) != self.starting_space => false,
+                Some(space) if self.configured_disabled_spaces.contains(&space) => false,
                 Some(space) if self.disabled_spaces.contains(&space) => false,
                 _ if display_disabled => false,
                 Some(space) if self.enabled_spaces.contains(&space) => true,
@@ -476,6 +488,75 @@ mod tests {
         let active = policy
             .compute_active_spaces(cfg, &[Some(SpaceId::new(1))], &[Some("display-a".to_string())]);
         assert_eq!(active, vec![None]);
+    }
+
+    #[test]
+    fn configured_disabled_space_is_inactive_after_policy_recreation() {
+        let cfg = SpaceActivationConfig {
+            default_disable: false,
+            one_space: false,
+        };
+        let mut policy = SpaceActivationPolicy::new();
+        policy.set_configured_disabled_spaces(&[4]);
+
+        let active =
+            policy.compute_active_spaces(cfg, &[Some(SpaceId::new(3)), Some(SpaceId::new(4))], &[
+                Some("display-a".to_string()),
+                Some("display-a".to_string()),
+            ]);
+        assert_eq!(active, vec![Some(SpaceId::new(3)), None]);
+
+        let mut restarted_policy = SpaceActivationPolicy::new();
+        restarted_policy.set_configured_disabled_spaces(&[4]);
+        let restarted_active = restarted_policy.compute_active_spaces(
+            cfg,
+            &[Some(SpaceId::new(3)), Some(SpaceId::new(4))],
+            &[Some("display-a".to_string()), Some("display-a".to_string())],
+        );
+        assert_eq!(restarted_active, vec![Some(SpaceId::new(3)), None]);
+    }
+
+    #[test]
+    fn configured_disabled_space_cannot_be_enabled_by_toggle() {
+        let cfg = SpaceActivationConfig {
+            default_disable: false,
+            one_space: false,
+        };
+        let mut policy = SpaceActivationPolicy::new();
+        policy.set_configured_disabled_spaces(&[4]);
+
+        policy.toggle_space_activated(cfg, ToggleSpaceContext {
+            space: SpaceId::new(4),
+            display_uuid: Some("display-a".to_string()),
+        });
+
+        let active = policy.compute_active_spaces(
+            cfg,
+            &[Some(SpaceId::new(4))],
+            &[Some("display-a".to_string())],
+        );
+        assert_eq!(active, vec![None]);
+    }
+
+    #[test]
+    fn configured_disabled_space_overrides_default_disable_display_enable() {
+        let cfg = SpaceActivationConfig {
+            default_disable: true,
+            one_space: false,
+        };
+        let mut policy = SpaceActivationPolicy::new();
+        policy.set_configured_disabled_spaces(&[4]);
+        policy.toggle_space_activated(cfg, ToggleSpaceContext {
+            space: SpaceId::new(3),
+            display_uuid: Some("display-a".to_string()),
+        });
+
+        let active = policy.compute_active_spaces(
+            cfg,
+            &[Some(SpaceId::new(3)), Some(SpaceId::new(4))],
+            &[Some("display-a".to_string()), Some("display-a".to_string())],
+        );
+        assert_eq!(active, vec![Some(SpaceId::new(3)), None]);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- Add a `disabled_space_ids` configuration setting for native macOS Space IDs that Rift should never tile.
- Apply the configured exclusions during startup and configuration reloads.
- Keep runtime toggles from re-enabling a persistently disabled Space.
- Document the option in the default configuration.

## Why

Rift's existing space toggle is runtime-only. After restarting or rebooting, an intentionally untiled Space becomes active again and its windows can be rearranged. This provides a durable configuration-level exclusion.

## Validation

- `cargo test`: 543 library tests and 2 CLI tests passed.
- Rebooted macOS with native Space ID 6 configured (Desktop 4); it remained untiled and its windows were not rearranged.
- Other desktops continued tiling normally.
