### PR TITLE
fix: preserve BSP layout through native fullscreen

### DIFF
--- a/src/actor/app.rs
+++ b/src/actor/app.rs
@@ -1136,6 +1136,9 @@ impl State {
                     Requested(false),
                     event::get_mouse_state(),
                 ));
+                if let Ok(is_fullscreen) = elem.fullscreen() {
+                    self.send_event(Event::WindowNativeFullscreenChanged(wid, is_fullscreen));
+                }
             }
             AxNotificationKind::WindowMiniaturized => {
                 let Ok(wid) = self.wid_for_notification(&elem, hinted_wid) else {

--- a/src/actor/reactor.rs
+++ b/src/actor/reactor.rs
@@ -97,6 +97,7 @@ use crate::model::broadcast::{
 };
 use crate::model::space_activation::{SpaceActivationConfig, SpaceActivationPolicy};
 use crate::model::tx_store::WindowTxStore;
+use crate::model::window_store::NativeFullscreenTransition;
 use crate::model::{AppRuleResult, RiftState};
 use crate::sys::event::MouseState;
 use crate::sys::executor::Executor;
@@ -231,6 +232,9 @@ pub enum Event {
         Requested,
         Option<MouseState>,
     ),
+    /// The native Accessibility fullscreen attribute observed alongside an unsolicited window
+    /// move/resize notification.
+    WindowNativeFullscreenChanged(WindowId, bool),
     WindowTitleChanged(WindowId, String),
     MenuOpened(pid_t),
     MenuClosed(pid_t),
@@ -321,6 +325,10 @@ pub struct Reactor {
     refresh_quarantine_manager: managers::RefreshQuarantineManager,
     pending_space_change_manager: managers::PendingSpaceChangeManager,
     active_spaces: HashSet<SpaceId>,
+    /// Newly appeared native Spaces that are absent from the user-Desktop inventory. macOS can
+    /// expose browser video fullscreen this way while both its fullscreen type and per-window
+    /// Space membership are temporarily stale.
+    transient_fullscreen_space_candidates: HashSet<SpaceId>,
     pub animation_tx: Option<AnimationSender>,
 }
 
@@ -441,6 +449,7 @@ impl Reactor {
                 pending_space_change: None,
             },
             active_spaces: HashSet::default(),
+            transient_fullscreen_space_candidates: HashSet::default(),
             animation_tx: None,
         };
         reactor
@@ -662,6 +671,62 @@ impl Reactor {
             }
             self.state.windows.mark_window_visible(wsid);
             self.state.windows.clear_window_server_observed(wsid);
+            if let Some(space) = space {
+                self.restore_native_fullscreen_from_active_membership(wsid, space);
+            }
+        }
+    }
+
+    fn restore_native_fullscreen_from_active_membership(
+        &mut self,
+        window_server_id: WindowServerId,
+        space: SpaceId,
+    ) {
+        let Some(record) = self
+            .state
+            .windows
+            .native_fullscreen_record_for_window_server_id(window_server_id)
+        else {
+            return;
+        };
+        let target_space = record
+            .workspace
+            .map(|workspace| workspace.space)
+            .or(record.last_known_user_space);
+        if target_space != Some(space) {
+            return;
+        }
+
+        let Some(restored) = self
+            .state
+            .windows
+            .restore_window_from_native_fullscreen_by_window_server_id(window_server_id)
+        else {
+            return;
+        };
+        let owner = self
+            .state
+            .windows
+            .contains_window(restored.current_window_id)
+            .then_some(restored.current_window_id)
+            .or_else(|| self.state.windows.tracked_window_id(window_server_id));
+        let Some(owner) = owner else { return };
+
+        tracing::info!(
+            ?owner,
+            ?window_server_id,
+            ?space,
+            "Restored native-fullscreen window from active-Space membership"
+        );
+        self.send_layout_event(LayoutEvent::WindowNativeFullscreenRestored(owner));
+        if self.is_space_active(space)
+            && self
+                .state
+                .windows
+                .window(owner)
+                .is_some_and(WindowState::is_admitted)
+        {
+            self.send_layout_event(LayoutEvent::WindowAdded(space, owner));
         }
     }
 
@@ -681,6 +746,88 @@ impl Reactor {
                 continue;
             };
             if !self.is_space_active(space) {
+                continue;
+            }
+
+            let direct_spaces = window_server::window_spaces(wsid);
+            if let Some(fullscreen_space) = direct_spaces
+                .iter()
+                .copied()
+                .find(|candidate| Self::is_direct_fullscreen_space(*candidate))
+            {
+                let _ = self.state.windows.suspend_window_to_native_fullscreen(
+                    wid,
+                    Some(wsid),
+                    Some(space),
+                    fullscreen_space,
+                    NativeFullscreenTransition::Suspended,
+                );
+                tracing::info!(
+                    ?wid,
+                    ?wsid,
+                    ?space,
+                    ?fullscreen_space,
+                    "Suspended missing active-Space window on direct fullscreen Space"
+                );
+                self.send_layout_event(LayoutEvent::WindowNativeFullscreenSuspended(wid));
+                continue;
+            }
+
+            // YouTube/browser fullscreen can add a managed Space and remove the focused window
+            // from the active Desktop before SLSCopySpacesForWindows reports that new Space. The
+            // simultaneous inventory delta plus the focused BSP leaf is the only coherent signal
+            // in that snapshot, and is stronger than the stale direct membership.
+            let was_focused = self.main_window() == Some(wid)
+                || self.last_focused_window_in_space(space) == Some(wid);
+            if was_focused
+                && let Some(fullscreen_space) =
+                    self.transient_fullscreen_space_candidates.iter().copied().next()
+            {
+                let _ = self.state.windows.suspend_window_to_native_fullscreen(
+                    wid,
+                    Some(wsid),
+                    Some(space),
+                    fullscreen_space,
+                    NativeFullscreenTransition::Suspended,
+                );
+                tracing::info!(
+                    ?wid,
+                    ?wsid,
+                    ?space,
+                    ?fullscreen_space,
+                    ?direct_spaces,
+                    "Suspended focused window on newly appeared transient Space"
+                );
+                self.send_layout_event(LayoutEvent::WindowNativeFullscreenSuspended(wid));
+                continue;
+            }
+
+            // Native fullscreen exit is asynchronous. The direct membership can already point
+            // back at the original Desktop while the per-Space window list still omits the
+            // window. Keep the suspended leaf until an active-Space membership observation
+            // restores it; otherwise this lagging snapshot collapses the leaf and a later AX
+            // discovery inserts it again with default BSP weights.
+            if self.state.windows.is_window_native_fullscreen_suspended(wid) {
+                debug!(
+                    ?wid,
+                    ?wsid,
+                    ?space,
+                    ?direct_spaces,
+                    "Preserving native-fullscreen leaf while active-Space membership catches up"
+                );
+                continue;
+            }
+
+            // A direct same-Space membership is stronger than a temporarily incomplete
+            // per-Space window-list sample. This also avoids collapsing ordinary windows during
+            // the short WindowServer visibility gap around minimize and animation transitions.
+            if direct_spaces.contains(&space) {
+                debug!(
+                    ?wid,
+                    ?wsid,
+                    ?space,
+                    "Preserving window confirmed on active Space by direct membership"
+                );
                 continue;
             }
 
@@ -884,6 +1031,7 @@ impl Reactor {
     fn note_windowserver_activity(event: &Event) {
         let wsid = match event {
             Event::WindowFrameChanged(wid, ..) => Some(wid.idx.get()),
+            Event::WindowNativeFullscreenChanged(wid, ..) => Some(wid.idx.get()),
             Event::WindowCreated(wid, ..) => Some(wid.idx.get()),
             Event::WindowDestroyed(wid) => Some(wid.idx.get()),
             Event::WindowMinimized(wid) => Some(wid.idx.get()),
@@ -934,6 +1082,7 @@ impl Reactor {
                 | Event::WindowServerDestroyed(..)
                 | Event::WindowServerAppeared(..)
                 | Event::WindowFrameChanged(..)
+                | Event::WindowNativeFullscreenChanged(..)
                 | Event::WindowMinimized(..)
                 | Event::WindowDeminiaturized(..)
                 | Event::WindowTitleChanged(..)
@@ -1341,6 +1490,11 @@ impl Reactor {
                     .window(wid)
                     .map(|window| (window.info.sys_id, window.frame_monotonic))
                     .unwrap_or((None, new_frame));
+                if let Some(outcome) = server_id.and_then(|server_id| {
+                    self.handle_native_fullscreen_frame_transition(wid, server_id)
+                }) {
+                    return Ok(outcome);
+                }
                 let old_space = self.geometry_space_for_window(&old_frame, server_id);
                 let new_space = self.geometry_space_for_window(&new_frame, server_id);
                 let old_space_active = old_space.is_some_and(|space| self.is_space_active(space));
@@ -1403,6 +1557,57 @@ impl Reactor {
                     outcome.dispatch_mouse_up = true;
                 }
                 outcome.focused_window = raised_window;
+                return Ok(outcome);
+            }
+            Event::WindowNativeFullscreenChanged(wid, is_fullscreen) => {
+                if is_fullscreen {
+                    self.state.windows.mark_window_native_fullscreen_ax_observed(wid);
+                    return Ok(EventOutcome::no_change());
+                }
+
+                let Some(record) = self.state.windows.native_fullscreen_record_for_window(wid)
+                else {
+                    return Ok(EventOutcome::no_change());
+                };
+                // A regular browser window often remains AX-non-fullscreen while a separate
+                // video projection occupies the transient Space. Do not let that unrelated
+                // `false` value bypass the stricter active-membership exit path.
+                if !record.ax_fullscreen_observed {
+                    return Ok(EventOutcome::no_change());
+                }
+
+                let target_space = record
+                    .workspace
+                    .map(|workspace| workspace.space)
+                    .or(record.last_known_user_space);
+                let Some(target_space) = target_space else {
+                    return Ok(EventOutcome::no_change());
+                };
+                let Some(window_server_id) = record.window_server_id else {
+                    return Ok(EventOutcome::no_change());
+                };
+                let direct_spaces = window_server::window_spaces(window_server_id);
+                if direct_spaces.iter().copied().any(Self::is_direct_fullscreen_space) {
+                    return Ok(EventOutcome::no_change());
+                }
+
+                let mut outcome = EventOutcome::no_change();
+                if self
+                    .restore_fullscreen_window_to_user_space(
+                        window_server_id,
+                        target_space,
+                        wid,
+                        &mut outcome,
+                    )
+                    .is_some()
+                {
+                    tracing::info!(
+                        ?wid,
+                        ?window_server_id,
+                        ?target_space,
+                        "Restored native-fullscreen window from AXFullscreen exit"
+                    );
+                }
                 return Ok(outcome);
             }
             Event::WindowTitleChanged(wid, new_title) => {
@@ -2226,6 +2431,33 @@ impl Reactor {
             }
 
             for record in records {
+                let target_space = record
+                    .workspace
+                    .map(|workspace| workspace.space)
+                    .or(record.last_known_user_space);
+
+                // The display can report the original Desktop before the fullscreen window has
+                // actually rejoined that Desktop. Do not clear the suspension based on display
+                // state alone: wait until both direct and active-Space memberships confirm the
+                // return. Frame and membership handlers provide the same confirmation path.
+                if let (Some(window_server_id), Some(target_space)) =
+                    (record.window_server_id, target_space)
+                {
+                    let direct_spaces = window_server::window_spaces(window_server_id);
+                    let still_on_transient_space = direct_spaces
+                        .iter()
+                        .copied()
+                        .any(Self::is_direct_fullscreen_space);
+                    let active_membership_confirmed = self
+                        .space_state
+                        .active_window_spaces
+                        .get(&window_server_id)
+                        .is_some_and(|space| *space == target_space);
+                    if still_on_transient_space || !active_membership_confirmed {
+                        continue;
+                    }
+                }
+
                 let _ = self
                     .state
                     .windows
@@ -2250,10 +2482,9 @@ impl Reactor {
                             .then_some(record.current_window_id)
                     });
 
-                let target_space = record
-                    .workspace
-                    .map(|workspace| workspace.space)
-                    .or(record.last_known_user_space);
+                if let Some(window_id) = live_window_id {
+                    self.send_layout_event(LayoutEvent::WindowNativeFullscreenRestored(window_id));
+                }
 
                 if let (Some(window_id), Some(target_space)) = (live_window_id, target_space)
                     && let Some(source_space) =
@@ -2432,6 +2663,7 @@ impl Reactor {
         &mut self,
         space_state: ForwardedSpaceState,
     ) -> anyhow::Result<EventOutcome> {
+        self.update_transient_fullscreen_space_candidates(&space_state);
         let mut outcome = EventOutcome::window_membership_changed(false, true);
         let analysis = topology_workflow::analyze_space_snapshot(
             &self.space_state,
@@ -2561,6 +2793,37 @@ impl Reactor {
         Ok(outcome)
     }
 
+    fn update_transient_fullscreen_space_candidates(&mut self, incoming: &ForwardedSpaceState) {
+        // The first snapshot after startup contains the complete Desktop inventory, not a
+        // transition. It cannot identify newly created transient Spaces safely.
+        if self.space_state.display_space_ids.is_empty() {
+            self.transient_fullscreen_space_candidates.clear();
+            return;
+        }
+
+        let previous: HashSet<SpaceId> = self
+            .space_state
+            .display_space_ids
+            .values()
+            .flatten()
+            .copied()
+            .collect();
+        let current_user_spaces: HashSet<SpaceId> = incoming
+            .active_spaces
+            .iter()
+            .copied()
+            .chain(incoming.last_user_space_by_display.values().copied())
+            .collect();
+        self.transient_fullscreen_space_candidates = incoming
+            .display_space_ids
+            .values()
+            .flatten()
+            .copied()
+            .filter(|space| !previous.contains(space))
+            .filter(|space| !current_user_spaces.contains(space))
+            .collect();
+    }
+
     fn try_apply_pending_space_change(&mut self) {
         if let Some(pending) = self.pending_space_change_manager.pending_space_change.take() {
             if pending.screens.len() == self.space_state.screens.len() {
@@ -2663,6 +2926,12 @@ impl Reactor {
             .map(|(wid, info)| {
                 let current_native_space =
                     info.sys_id.and_then(|wsid| self.resolve_native_space(wsid, None));
+                let active_membership_confirmed = info.sys_id.is_some_and(|wsid| {
+                    self.state.windows.is_window_visible(wsid)
+                        || current_native_space.is_some_and(|space| {
+                            self.space_state.active_window_spaces.get(&wsid) == Some(&space)
+                        })
+                });
                 let active_space = self
                     .best_space_for_window(&info.frame, info.sys_id)
                     .filter(|space| self.is_space_active(*space))
@@ -2673,6 +2942,7 @@ impl Reactor {
                     wid,
                     info,
                     current_native_space,
+                    active_membership_confirmed,
                     active_space,
                 }
             })
@@ -2923,6 +3193,8 @@ impl Reactor {
             .or_else(|| {
                 self.state.windows.contains_window(original_window).then_some(original_window)
             })?;
+        *outcome = std::mem::take(outcome)
+            .with_layout_event(LayoutEvent::WindowNativeFullscreenRestored(owner));
         if owner != original_window && self.assigned_space_for_window_id(original_window).is_some()
         {
             *outcome = std::mem::take(outcome)
@@ -3065,6 +3337,9 @@ impl Reactor {
         let mut layout_changed = false;
 
         for wid in windows {
+            if self.state.windows.is_window_native_fullscreen_suspended(wid) {
+                continue;
+            }
             let Some(authoritative_space) = self.authoritative_space_for_window_id(wid) else {
                 continue;
             };
@@ -3174,6 +3449,134 @@ impl Reactor {
 
     fn is_known_fullscreen_window(&self, wsid: WindowServerId) -> bool {
         self.state.windows.is_window_server_id_native_fullscreen_suspended(wsid)
+    }
+
+    fn is_direct_fullscreen_space(space: SpaceId) -> bool {
+        #[cfg(test)]
+        {
+            space.get() >= 0x400000000
+        }
+        #[cfg(not(test))]
+        {
+            // Some macOS/browser combinations expose video fullscreen Spaces with a transient
+            // non-user type instead of the documented fullscreen type (4). Rift cannot manage
+            // any non-user Space as a Desktop, so treat both forms as native fullscreen here.
+            window_server::space_is_fullscreen(space.get())
+                || !window_server::space_is_user(space.get())
+        }
+    }
+
+    /// WindowServer lifecycle notifications can lag behind AX frame notifications during native
+    /// fullscreen transitions. Detect the transition from the window's direct Space memberships
+    /// before the generic frame-change workflow can interpret the fullscreen frame as a resize or
+    /// cross-Space move and collapse its preserved BSP leaf.
+    fn handle_native_fullscreen_frame_transition(
+        &mut self,
+        wid: WindowId,
+        window_server_id: WindowServerId,
+    ) -> Option<EventOutcome> {
+        let spaces = window_server::window_spaces(window_server_id);
+        if let Some(fullscreen_space) = spaces
+            .iter()
+            .copied()
+            .find(|space| Self::is_direct_fullscreen_space(*space))
+        {
+            let last_known_user_space = self
+                .assigned_space_for_window_id(wid)
+                .or_else(|| {
+                    self.state
+                        .windows
+                        .native_fullscreen_record_for_window(wid)
+                        .and_then(|record| record.last_known_user_space)
+                })
+                .or_else(|| {
+                    self.state
+                        .windows
+                        .window_server_space(window_server_id)
+                        .filter(|space| !Self::is_direct_fullscreen_space(*space))
+                });
+            let _ = self.state.windows.suspend_window_to_native_fullscreen(
+                wid,
+                Some(window_server_id),
+                last_known_user_space,
+                fullscreen_space,
+                NativeFullscreenTransition::Suspended,
+            );
+            debug!(
+                ?wid,
+                ?window_server_id,
+                ?fullscreen_space,
+                ?last_known_user_space,
+                "Suspended native-fullscreen window from direct Space membership"
+            );
+            return Some(
+                EventOutcome::no_change()
+                    .with_layout_event(LayoutEvent::WindowNativeFullscreenSuspended(wid)),
+            );
+        }
+
+        let record = self
+            .state
+            .windows
+            .native_fullscreen_record_for_window_server_id(window_server_id)?;
+        let target_space = record
+            .workspace
+            .map(|workspace| workspace.space)
+            .or(record.last_known_user_space)?;
+        if !spaces.contains(&target_space) {
+            return None;
+        }
+
+        if self
+            .space_state
+            .active_window_spaces
+            .get(&window_server_id)
+            .is_none_or(|space| *space != target_space)
+        {
+            debug!(
+                ?wid,
+                ?window_server_id,
+                ?target_space,
+                "Deferring native-fullscreen restore until active-Space membership catches up"
+            );
+            return Some(EventOutcome::no_change());
+        }
+
+        let restored = self
+            .state
+            .windows
+            .restore_window_from_native_fullscreen_by_window_server_id(window_server_id)?;
+        let owner = self
+            .state
+            .windows
+            .contains_window(restored.current_window_id)
+            .then_some(restored.current_window_id)
+            .unwrap_or(wid);
+        self.state
+            .windows
+            .set_window_server_space(window_server_id, Some(target_space));
+        if self.is_space_active(target_space) {
+            self.state.windows.mark_window_visible(window_server_id);
+        }
+
+        debug!(
+            ?owner,
+            ?window_server_id,
+            ?target_space,
+            "Restored native-fullscreen window from direct Space membership"
+        );
+        let mut outcome = EventOutcome::no_change()
+            .with_layout_event(LayoutEvent::WindowNativeFullscreenRestored(owner));
+        if self.is_space_active(target_space)
+            && self
+                .state
+                .windows
+                .window(owner)
+                .is_some_and(WindowState::is_admitted)
+        {
+            outcome = outcome.with_layout_event(LayoutEvent::WindowAdded(target_space, owner));
+        }
+        Some(outcome)
     }
 
     fn window_center_on_known_screen(&self, wid: WindowId) -> Option<CGPoint> {

--- a/src/actor/reactor/events/space.rs
+++ b/src/actor/reactor/events/space.rs
@@ -143,7 +143,8 @@ pub fn handle_window_server_destroyed(
         if let (Some(wid), Some(user_space)) = (window_id, last_known_user_space)
             && assigned_space == Some(user_space)
         {
-            outcome = outcome.with_layout_event(LayoutEvent::WindowRemovedPreserveFloating(wid));
+            outcome = outcome
+                .with_layout_event(LayoutEvent::WindowNativeFullscreenSuspended(wid));
             layout_changed = active_spaces.contains(&user_space);
         }
         if layout_changed && !mission_control_active {
@@ -311,8 +312,9 @@ pub fn handle_window_server_appeared(
                         if let Some(user_space) = last_known_user_space
                             && assigned_space == Some(user_space)
                         {
-                            outcome = outcome
-                                .with_layout_event(LayoutEvent::WindowRemovedPreserveFloating(wid));
+                            outcome = outcome.with_layout_event(
+                                LayoutEvent::WindowNativeFullscreenSuspended(wid),
+                            );
                             layout_changed = active_spaces.contains(&user_space);
                         }
                     }

--- a/src/actor/reactor/events/window_discovery.rs
+++ b/src/actor/reactor/events/window_discovery.rs
@@ -100,6 +100,7 @@ fn sync_window_server_id_mapping(
     old_sys_id: Option<WindowServerId>,
     new_sys_id: Option<WindowServerId>,
     current_native_space: Option<SpaceId>,
+    active_membership_confirmed: bool,
 ) -> crate::actor::reactor::events::EventOutcome {
     let mut outcome = crate::actor::reactor::events::EventOutcome::default();
     if old_sys_id != new_sys_id
@@ -134,9 +135,14 @@ fn sync_window_server_id_mapping(
                 .workspace
                 .map(|workspace| workspace.space)
                 .or(record.last_known_user_space);
-            if current_space != record.fullscreen_space && Some(current_space) == target_user_space
+            if active_membership_confirmed
+                && current_space != record.fullscreen_space
+                && Some(current_space) == target_user_space
             {
-                let _ = state.windows.restore_window_from_native_fullscreen(wid);
+                if state.windows.restore_window_from_native_fullscreen(wid).is_some() {
+                    outcome = outcome
+                        .with_layout_event(LayoutEvent::WindowNativeFullscreenRestored(wid));
+                }
             }
         }
     }
@@ -281,6 +287,7 @@ pub(crate) struct ObservedWindow {
     pub(crate) wid: WindowId,
     pub(crate) info: WindowInfo,
     pub(crate) current_native_space: Option<SpaceId>,
+    pub(crate) active_membership_confirmed: bool,
     pub(crate) active_space: Option<SpaceId>,
 }
 
@@ -322,6 +329,7 @@ pub(crate) fn process_window_list(
                     old_sys_id,
                     info.sys_id,
                     window.current_native_space,
+                    window.active_membership_confirmed,
                 ));
                 if let Ok(existing_outcome) =
                     sync_existing_window_state(state, wid, info, window.active_space)
@@ -336,6 +344,7 @@ pub(crate) fn process_window_list(
                     None,
                     info.sys_id,
                     window.current_native_space,
+                    window.active_membership_confirmed,
                 ));
                 let window_state: WindowState = WindowState::from((*info).clone());
                 state.windows.insert_window(wid, window_state);
@@ -351,6 +360,7 @@ pub(crate) fn process_window_list(
             wid,
             info,
             current_native_space,
+            active_membership_confirmed,
             active_space,
         } = window;
         if state.windows.contains_window(wid) {
@@ -362,6 +372,7 @@ pub(crate) fn process_window_list(
                 old_sys_id,
                 info.sys_id,
                 current_native_space,
+                active_membership_confirmed,
             ));
             if let Ok(existing_outcome) =
                 sync_existing_window_state(state, wid, &info, active_space)
@@ -376,6 +387,7 @@ pub(crate) fn process_window_list(
                 None,
                 info.sys_id,
                 current_native_space,
+                active_membership_confirmed,
             ));
             new_windows.push((wid, info));
         }

--- a/src/actor/reactor/tests.rs
+++ b/src/actor/reactor/tests.rs
@@ -1585,20 +1585,201 @@ fn known_window_server_appearance_restores_same_workspace_after_fullscreen() {
     let frame = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
     let user_space = SpaceId::new(1);
     let fullscreen_space = SpaceId::new(0x400000000 + user_space.get());
-    let wid = WindowId::new(1, 1);
+    let windows = [WindowId::new(1, 1), WindowId::new(1, 2), WindowId::new(1, 3)];
+    let wid = windows[1];
 
     reactor.handle_event(space_state_event(vec![frame], vec![Some(user_space)]));
-    make_active_app(&mut apps, &mut reactor, 1, make_windows(1), Some(wid));
+    make_active_app(&mut apps, &mut reactor, 1, make_windows(3), Some(wid));
+    reactor.handle_test_layout_command(LayoutCommand::SetWorkspaceLayout {
+        workspace: None,
+        mode: LayoutMode::Bsp,
+    });
+    reactor.send_layout_event(LayoutEvent::WindowFocused(user_space, wid));
+    reactor.handle_test_layout_command(LayoutCommand::ResizeWindowBy { amount: 0.2 });
+
+    let topology_before = reactor
+        .query_layout_state(Some(user_space.get()), None)
+        .expect("BSP layout state before fullscreen")
+        .container_tree;
+    let layout_before = test_layout(&mut reactor, user_space, frame);
 
     let wsid = reactor.state.windows.window(wid).unwrap().info.sys_id.unwrap();
     window_server_appeared(&mut reactor, wsid, fullscreen_space, SpaceEventKind::Fullscreen);
     assert!(!has_window_in_layout(&mut reactor, user_space, frame, wid));
+    assert_eq!(
+        reactor
+            .query_layout_state(Some(user_space.get()), None)
+            .expect("BSP layout state while fullscreen")
+            .container_tree,
+        topology_before,
+        "entering native fullscreen must preserve BSP topology and split weights"
+    );
+    let layout_while_fullscreen = test_layout(&mut reactor, user_space, frame);
+    for (other, expected_frame) in &layout_before {
+        if *other != wid {
+            assert_eq!(
+                layout_while_fullscreen
+                    .iter()
+                    .find(|(candidate, _)| candidate == other)
+                    .map(|(_, actual_frame)| actual_frame),
+                Some(expected_frame),
+                "the fullscreen leaf should continue reserving its original BSP slot"
+            );
+        }
+    }
 
     window_server_appeared(&mut reactor, wsid, user_space, SpaceEventKind::User);
 
     assert!(
         has_window_in_layout(&mut reactor, user_space, frame, wid),
         "managed window should return to layout when native fullscreen exits back to the same space"
+    );
+    assert_eq!(
+        reactor
+            .query_layout_state(Some(user_space.get()), None)
+            .expect("BSP layout state after fullscreen")
+            .container_tree,
+        topology_before,
+        "exiting native fullscreen must retain exact BSP topology"
+    );
+    assert_eq!(
+        test_layout(&mut reactor, user_space, frame),
+        layout_before,
+        "exiting native fullscreen must restore exact pre-fullscreen window frames"
+    );
+}
+
+#[test]
+fn frame_change_fullscreen_fallback_preserves_bsp_topology_and_split_weights() {
+    let (mut apps, mut reactor) = test_context();
+
+    let frame = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
+    let user_space = SpaceId::new(1);
+    let fullscreen_space = SpaceId::new(0x400000000 + user_space.get());
+    let windows = [WindowId::new(1, 1), WindowId::new(1, 2), WindowId::new(1, 3)];
+    let wid = windows[1];
+
+    reactor.handle_event(space_state_event(vec![frame], vec![Some(user_space)]));
+    make_active_app(&mut apps, &mut reactor, 1, make_windows(3), Some(wid));
+    reactor.handle_test_layout_command(LayoutCommand::SetWorkspaceLayout {
+        workspace: None,
+        mode: LayoutMode::Bsp,
+    });
+    reactor.send_layout_event(LayoutEvent::WindowFocused(user_space, wid));
+    reactor.handle_test_layout_command(LayoutCommand::ResizeWindowBy { amount: 0.2 });
+
+    let topology_before = reactor
+        .query_layout_state(Some(user_space.get()), None)
+        .expect("BSP layout state before fullscreen")
+        .container_tree;
+    let layout_before = test_layout(&mut reactor, user_space, frame);
+    let cached_frame_before = reactor.state.windows.window(wid).unwrap().frame_monotonic;
+    let wsid = reactor.state.windows.window(wid).unwrap().info.sys_id.unwrap();
+
+    // Reproduce the real browser transition: the direct WindowServer membership changes first,
+    // while Rift's forwarded fullscreen-space inventory has not observed the new Space yet.
+    assert!(reactor.space_state.fullscreen_spaces.is_empty());
+    crate::sys::window_server::set_window_spaces_override(
+        wsid,
+        Some(vec![fullscreen_space.get()]),
+    );
+    reactor.handle_event(Event::WindowFrameChanged(
+        wid,
+        frame,
+        None,
+        Requested(false),
+        Some(MouseState::Up),
+    ));
+
+    assert!(
+        reactor
+            .state
+            .windows
+            .is_window_server_id_native_fullscreen_suspended(wsid)
+    );
+    assert!(
+        reactor
+            .state
+            .windows
+            .window(wid)
+            .unwrap()
+            .frame_monotonic
+            .same_as(cached_frame_before),
+        "the fullscreen animation frame must not replace the cached tiled frame"
+    );
+    assert_eq!(
+        reactor
+            .query_layout_state(Some(user_space.get()), None)
+            .expect("BSP layout state while fullscreen")
+            .container_tree,
+        topology_before,
+        "frame-based fullscreen detection must preserve the exact BSP topology"
+    );
+    assert!(!has_window_in_layout(&mut reactor, user_space, frame, wid));
+
+    // Browser video fullscreen can leave the original AX window reporting false throughout the
+    // projection lifecycle. That uncorroborated value must not bypass the membership gate.
+    reactor.handle_event(Event::WindowNativeFullscreenChanged(wid, false));
+    assert!(
+        reactor
+            .state
+            .windows
+            .is_window_server_id_native_fullscreen_suspended(wsid)
+    );
+
+    // A regular AppKit fullscreen window reports true during entry. Its later false value is an
+    // authoritative exit signal even if the active-Space inventory has not caught up yet.
+    reactor.handle_event(Event::WindowNativeFullscreenChanged(wid, true));
+    assert!(
+        reactor
+            .state
+            .windows
+            .native_fullscreen_record_for_window(wid)
+            .is_some_and(|record| record.ax_fullscreen_observed)
+    );
+
+    crate::sys::window_server::set_window_spaces_override(wsid, Some(vec![user_space.get()]));
+    let misleading_return_frame = CGRect::new(
+        CGPoint::new(0., 0.),
+        CGSize::new(frame.size.width / 2.0, frame.size.height),
+    );
+    reactor.handle_event(Event::WindowFrameChanged(
+        wid,
+        misleading_return_frame,
+        None,
+        Requested(false),
+        Some(MouseState::Up),
+    ));
+
+    assert!(
+        reactor
+            .state
+            .windows
+            .is_window_server_id_native_fullscreen_suspended(wsid),
+        "direct membership alone should still wait for a trustworthy exit signal"
+    );
+    reactor.handle_event(Event::WindowNativeFullscreenChanged(wid, false));
+    crate::sys::window_server::set_window_spaces_override(wsid, None);
+
+    assert!(
+        reactor
+            .state
+            .windows
+            .native_fullscreen_record_for_window_server_id(wsid)
+            .is_none()
+    );
+    assert_eq!(
+        reactor
+            .query_layout_state(Some(user_space.get()), None)
+            .expect("BSP layout state after fullscreen")
+            .container_tree,
+        topology_before,
+        "the return animation must not rebalance or reinsert the preserved BSP leaf"
+    );
+    assert_eq!(
+        test_layout(&mut reactor, user_space, frame),
+        layout_before,
+        "the exact pre-fullscreen split weights and frames must be restored"
     );
 }
 
@@ -3143,6 +3324,333 @@ fn authoritative_active_window_snapshot_removes_missing_window_from_active_layou
 }
 
 #[test]
+fn authoritative_snapshot_fullscreen_transition_preserves_bsp_split_weights() {
+    let (mut apps, mut reactor) = test_context();
+    let frame = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
+    let user_space = SpaceId::new(1);
+    let fullscreen_space = SpaceId::new(0x400000000 + user_space.get());
+    let windows = [WindowId::new(44, 1), WindowId::new(44, 2), WindowId::new(44, 3)];
+    let fullscreen_window = windows[1];
+
+    reactor.handle_event(space_state_event(vec![frame], vec![Some(user_space)]));
+    make_active_app(&mut apps, &mut reactor, 44, make_windows(3), Some(fullscreen_window));
+    reactor.handle_test_layout_command(LayoutCommand::SetWorkspaceLayout {
+        workspace: None,
+        mode: LayoutMode::Bsp,
+    });
+    reactor.send_layout_event(LayoutEvent::WindowFocused(user_space, fullscreen_window));
+    reactor.handle_test_layout_command(LayoutCommand::ResizeWindowBy { amount: 0.2 });
+
+    let window_servers: Vec<_> = windows
+        .iter()
+        .map(|wid| reactor.state.windows.window(*wid).unwrap().info.sys_id.unwrap())
+        .collect();
+    for wsid in &window_servers {
+        reactor.mark_test_window_visible_in_space(*wsid, user_space);
+    }
+    let fullscreen_wsid = window_servers[1];
+    let topology_before = reactor
+        .query_layout_state(Some(user_space.get()), None)
+        .expect("BSP layout state before authoritative fullscreen transition")
+        .container_tree;
+    let layout_before = test_layout(&mut reactor, user_space, frame);
+
+    crate::sys::window_server::set_window_spaces_override(
+        fullscreen_wsid,
+        Some(vec![fullscreen_space.get()]),
+    );
+    reactor.reconcile_authoritative_active_window_snapshot(
+        window_servers
+            .iter()
+            .copied()
+            .filter(|wsid| *wsid != fullscreen_wsid)
+            .map(|wsid| (wsid, Some(user_space)))
+            .collect(),
+        false,
+    );
+
+    assert!(
+        reactor
+            .state
+            .windows
+            .is_window_server_id_native_fullscreen_suspended(fullscreen_wsid)
+    );
+    assert_eq!(
+        reactor.assigned_space_for_window_id(fullscreen_window),
+        Some(user_space),
+        "native fullscreen must retain the original workspace assignment"
+    );
+    assert_eq!(
+        reactor
+            .query_layout_state(Some(user_space.get()), None)
+            .expect("BSP layout state while fullscreen")
+            .container_tree,
+        topology_before,
+        "authoritative membership refresh must not collapse the fullscreen BSP leaf"
+    );
+    assert!(!has_window_in_layout(
+        &mut reactor,
+        user_space,
+        frame,
+        fullscreen_window
+    ));
+
+    crate::sys::window_server::set_window_spaces_override(
+        fullscreen_wsid,
+        Some(vec![user_space.get()]),
+    );
+    reactor.reconcile_authoritative_active_window_snapshot(
+        window_servers
+            .iter()
+            .copied()
+            .filter(|wsid| *wsid != fullscreen_wsid)
+            .map(|wsid| (wsid, Some(user_space)))
+            .collect(),
+        false,
+    );
+
+    assert!(
+        reactor
+            .state
+            .windows
+            .is_window_server_id_native_fullscreen_suspended(fullscreen_wsid),
+        "direct Desktop membership alone must not restore before the active-Space list catches up"
+    );
+    assert_eq!(
+        reactor
+            .query_layout_state(Some(user_space.get()), None)
+            .expect("BSP layout state during lagging fullscreen exit")
+            .container_tree,
+        topology_before,
+        "a lagging exit snapshot must not collapse the preserved BSP leaf"
+    );
+
+    reactor.reconcile_authoritative_active_window_snapshot(
+        window_servers
+            .iter()
+            .copied()
+            .map(|wsid| (wsid, Some(user_space)))
+            .collect(),
+        false,
+    );
+    crate::sys::window_server::set_window_spaces_override(fullscreen_wsid, None);
+
+    assert!(
+        reactor
+            .state
+            .windows
+            .native_fullscreen_record_for_window_server_id(fullscreen_wsid)
+            .is_none()
+    );
+    assert_eq!(
+        reactor
+            .query_layout_state(Some(user_space.get()), None)
+            .expect("BSP layout state after authoritative fullscreen transition")
+            .container_tree,
+        topology_before
+    );
+    assert_eq!(
+        test_layout(&mut reactor, user_space, frame),
+        layout_before,
+        "returning from fullscreen must restore the exact pre-fullscreen split weights"
+    );
+}
+
+#[test]
+fn new_transient_space_with_stale_window_membership_preserves_focused_bsp_leaf() {
+    let (mut apps, mut reactor) = test_context();
+    let frame = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
+    let user_space = SpaceId::new(1);
+    let transient_space = SpaceId::new(182);
+    let windows = [WindowId::new(45, 1), WindowId::new(45, 2), WindowId::new(45, 3)];
+    let fullscreen_window = windows[1];
+
+    reactor.handle_event(space_state_event(vec![frame], vec![Some(user_space)]));
+    make_active_app(&mut apps, &mut reactor, 45, make_windows(3), Some(fullscreen_window));
+    reactor.handle_test_layout_command(LayoutCommand::SetWorkspaceLayout {
+        workspace: None,
+        mode: LayoutMode::Bsp,
+    });
+    reactor.send_layout_event(LayoutEvent::WindowFocused(user_space, fullscreen_window));
+    reactor.handle_test_layout_command(LayoutCommand::ResizeWindowBy { amount: 0.2 });
+
+    let window_servers: Vec<_> = windows
+        .iter()
+        .map(|wid| reactor.state.windows.window(*wid).unwrap().info.sys_id.unwrap())
+        .collect();
+    for wsid in &window_servers {
+        reactor.mark_test_window_visible_in_space(*wsid, user_space);
+    }
+    let fullscreen_wsid = window_servers[1];
+    let topology_before = reactor
+        .query_layout_state(Some(user_space.get()), None)
+        .expect("BSP layout before stale-membership fullscreen transition")
+        .container_tree;
+    let layout_before = test_layout(&mut reactor, user_space, frame);
+
+    reactor
+        .space_state
+        .display_space_ids
+        .insert("display".to_string(), vec![user_space]);
+    let Event::SpaceStateChanged(mut entering) =
+        space_state_event(vec![frame], vec![Some(user_space)])
+    else {
+        unreachable!("space_state_event must produce a space-state event");
+    };
+    entering
+        .display_space_ids
+        .insert("display".to_string(), vec![user_space, transient_space]);
+    entering
+        .last_user_space_by_display
+        .insert("display".to_string(), user_space);
+    reactor.update_transient_fullscreen_space_candidates(&entering);
+
+    // This is the live browser failure: the display inventory already contains the temporary
+    // Space, but the direct per-window query still reports the original Desktop.
+    crate::sys::window_server::set_window_spaces_override(
+        fullscreen_wsid,
+        Some(vec![user_space.get()]),
+    );
+    reactor.reconcile_authoritative_active_window_snapshot(
+        window_servers
+            .iter()
+            .copied()
+            .filter(|wsid| *wsid != fullscreen_wsid)
+            .map(|wsid| (wsid, Some(user_space)))
+            .collect(),
+        false,
+    );
+
+    assert!(
+        reactor
+            .state
+            .windows
+            .is_window_server_id_native_fullscreen_suspended(fullscreen_wsid),
+        "new transient Space plus focused-window disappearance must suspend the BSP leaf"
+    );
+    assert_eq!(
+        reactor
+            .query_layout_state(Some(user_space.get()), None)
+            .expect("BSP layout while direct membership is stale")
+            .container_tree,
+        topology_before
+    );
+
+    // A lagging discovery/admission update can still emit its generic removal after the
+    // authoritative Space snapshot has suspended the live window. That late removal must not
+    // collapse the preserved BSP leaf and cause a default 50/50 reinsert on fullscreen exit.
+    reactor.send_layout_event(LayoutEvent::WindowRemoved(fullscreen_window));
+    assert_eq!(
+        reactor
+            .query_layout_state(Some(user_space.get()), None)
+            .expect("BSP layout after a late fullscreen removal")
+            .container_tree,
+        topology_before,
+        "late generic removal must preserve a live native-fullscreen leaf"
+    );
+
+    // Zen replaces its normal AX window with a separate fullscreen projection. Discovery then
+    // retires the original AX state and emits another removal plus an empty per-app layout sync.
+    // The suspended leaf and its saved workspace must survive until the original window returns.
+    let original_state = reactor
+        .state
+        .windows
+        .window(fullscreen_window)
+        .cloned()
+        .expect("the original browser window should still have live AX state");
+    let original_workspace = reactor
+        .state
+        .windows
+        .workspace_info_for_window(fullscreen_window)
+        .expect("the original browser window should have a workspace assignment");
+    reactor.state.windows.remove_window(fullscreen_window);
+    reactor.send_layout_event(LayoutEvent::WindowRemoved(fullscreen_window));
+    reactor.send_layout_event(LayoutEvent::WindowsOnScreenUpdated(
+        user_space,
+        fullscreen_window.pid,
+        Vec::new(),
+        None,
+    ));
+    assert_eq!(
+        reactor
+            .query_layout_state(Some(user_space.get()), None)
+            .expect("BSP layout while the original AX window is replaced")
+            .container_tree,
+        topology_before,
+        "fullscreen AX projection replacement must preserve the original BSP leaf"
+    );
+
+    reactor
+        .state
+        .windows
+        .insert_window(fullscreen_window, original_state);
+
+    let Event::SpaceStateChanged(mut exiting) =
+        space_state_event(vec![frame], vec![Some(user_space)])
+    else {
+        unreachable!("space_state_event must produce a space-state event");
+    };
+    exiting
+        .display_space_ids
+        .insert("display".to_string(), vec![user_space]);
+    exiting
+        .last_user_space_by_display
+        .insert("display".to_string(), user_space);
+    reactor.update_transient_fullscreen_space_candidates(&exiting);
+
+    // The active-Space list also lags during exit. Preserve the suspension through that gap.
+    reactor.reconcile_authoritative_active_window_snapshot(
+        window_servers
+            .iter()
+            .copied()
+            .filter(|wsid| *wsid != fullscreen_wsid)
+            .map(|wsid| (wsid, Some(user_space)))
+            .collect(),
+        false,
+    );
+    assert!(
+        reactor
+            .state
+            .windows
+            .is_window_server_id_native_fullscreen_suspended(fullscreen_wsid)
+    );
+
+    reactor.reconcile_authoritative_active_window_snapshot(
+        window_servers
+            .iter()
+            .copied()
+            .map(|wsid| (wsid, Some(user_space)))
+            .collect(),
+        false,
+    );
+    crate::sys::window_server::set_window_spaces_override(fullscreen_wsid, None);
+
+    assert!(
+        reactor
+            .state
+            .windows
+            .native_fullscreen_record_for_window_server_id(fullscreen_wsid)
+            .is_none()
+    );
+    assert_eq!(
+        reactor
+            .state
+            .windows
+            .workspace_info_for_window(fullscreen_window),
+        Some(original_workspace),
+        "fullscreen restoration must reinstate workspace ownership lost with the AX replacement"
+    );
+    assert_eq!(
+        reactor
+            .query_layout_state(Some(user_space.get()), None)
+            .expect("BSP layout after stale-membership fullscreen transition")
+            .container_tree,
+        topology_before
+    );
+    assert_eq!(test_layout(&mut reactor, user_space, frame), layout_before);
+}
+
+#[test]
 fn authoritative_active_window_snapshot_reassigns_missing_window_to_inactive_space() {
     let (mut apps, mut reactor) = test_context();
     let frame = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
@@ -3913,7 +4421,13 @@ fn unfullscreen_restores_window_tracking() {
     apps.simulate_until_quiet(&mut reactor);
 
     // Exit fullscreen (return to user space).
-    reactor.handle_event(space_state_event(vec![full_screen], vec![Some(user_space)]));
+    reactor.handle_event(space_state_event_with(
+        vec![full_screen],
+        vec![Some(user_space)],
+        |state| {
+            state.active_window_spaces.insert(WindowServerId::new(1), user_space);
+        },
+    ));
 
     // The reactor should trigger a GetVisibleWindows request.
     let mut saw_get_visible_windows = false;

--- a/src/actor/spaces.rs
+++ b/src/actor/spaces.rs
@@ -906,7 +906,10 @@ impl SpacesActor {
         }
         #[cfg(not(test))]
         {
+            // Native video fullscreen can be reported as a transient non-user Space rather than
+            // the documented fullscreen type. Both forms must be kept out of Desktop topology.
             window_server::space_is_fullscreen(space.get())
+                || !window_server::space_is_user(space.get())
         }
     }
 

--- a/src/layout_engine/engine.rs
+++ b/src/layout_engine/engine.rs
@@ -72,6 +72,11 @@ pub enum LayoutEvent {
     WindowAdded(SpaceId, WindowId),
     WindowRemoved(WindowId),
     WindowRemovedPreserveFloating(WindowId),
+    /// Temporarily stop emitting frames for a window that moved to a native macOS fullscreen
+    /// Space while preserving its exact layout-tree membership.
+    WindowNativeFullscreenSuspended(WindowId),
+    /// Resume frame emission after a native fullscreen window returns to a user Space.
+    WindowNativeFullscreenRestored(WindowId),
     WindowFocused(SpaceId, WindowId),
     WindowResized {
         wid: WindowId,
@@ -123,6 +128,10 @@ pub struct LayoutEngine {
     floating_positions: FloatingPositionStore,
     app_rules: AppRuleEngine,
     focused_window: Option<WindowId>,
+    /// Windows retain their layout-tree leaf while macOS hosts them on a temporary native
+    /// fullscreen Space. Keeping this state in the engine also lets identity rekeys transfer the
+    /// suspension atomically with the preserved leaf.
+    native_fullscreen_suspended: HashSet<WindowId>,
     window_layout_constraints: HashMap<WindowId, WindowLayoutConstraints>,
     virtual_workspace_manager: WorkspaceStore,
     layout_settings: LayoutSettings,
@@ -1199,12 +1208,20 @@ impl LayoutEngine {
 
             // AX/window-server discovery can temporarily omit windows. Keep windows that are
             // still assigned to this workspace so a partial snapshot does not tear them out
-            // of the tree and cause their sibling weights to be rebuilt.
+            // of the tree and cause their sibling weights to be rebuilt. A browser may replace
+            // its normal AX window with a fullscreen projection, temporarily removing even the
+            // saved workspace assignment; the native-fullscreen lifecycle is authoritative then.
             for wid in current.iter().copied() {
+                let preserve_suspended = self.native_fullscreen_suspended.contains(&wid)
+                    && window_store.is_window_native_fullscreen_suspended(wid);
+                let preserve_assigned = self.virtual_workspace_manager.workspace_for_window(
+                    window_store,
+                    space,
+                    wid,
+                ) == Some(ws_id);
                 if !desired.contains(&wid)
                     && !self.floating.is_floating(wid)
-                    && self.virtual_workspace_manager.workspace_for_window(window_store, space, wid)
-                        == Some(ws_id)
+                    && (preserve_suspended || preserve_assigned)
                 {
                     desired.push(wid);
                 }
@@ -1313,6 +1330,7 @@ impl LayoutEngine {
             floating_positions: FloatingPositionStore::default(),
             app_rules: AppRuleEngine::new(&virtual_workspace_config.app_rules),
             focused_window: None,
+            native_fullscreen_suspended: HashSet::default(),
             window_layout_constraints: HashMap::default(),
             virtual_workspace_manager,
             layout_settings: layout_settings.clone(),
@@ -1591,6 +1609,7 @@ impl LayoutEngine {
                     ws.layout_system.remove_windows_for_app(pid);
                 }
                 self.floating.remove_all_for_pid(pid);
+                self.native_fullscreen_suspended.retain(|wid| wid.pid != pid);
                 self.window_layout_constraints.retain(|wid, _| wid.pid != pid);
                 self.forget_persisted_app(pid);
 
@@ -1604,10 +1623,49 @@ impl LayoutEngine {
                 }
             }
             LayoutEvent::WindowRemoved(wid) => {
-                self.remove_window_internal(window_store, wid, false);
+                // Discovery, admission, and WindowServer visibility updates can emit an ordinary
+                // removal after native-fullscreen entry has already suspended the window. Some
+                // browsers also replace the normal AX window with a separate fullscreen
+                // projection, temporarily removing the original WindowState entirely. The native
+                // fullscreen record remains authoritative across that replacement, so neither
+                // form of late removal may collapse the preserved BSP leaf.
+                if self.native_fullscreen_suspended.contains(&wid)
+                    && window_store.is_window_native_fullscreen_suspended(wid)
+                {
+                    info!(?wid, "Preserving suspended native-fullscreen leaf from late removal");
+                    self.floating.remove_active_for_window(wid);
+                } else {
+                    self.native_fullscreen_suspended.remove(&wid);
+                    self.remove_window_internal(window_store, wid, false);
+                }
             }
             LayoutEvent::WindowRemovedPreserveFloating(wid) => {
-                self.remove_window_internal(window_store, wid, true);
+                // WindowServer sends a disappearance for the source user Space during native
+                // fullscreen entry. Once suspended, that disappearance must not collapse the
+                // preserved layout leaf.
+                if self.native_fullscreen_suspended.contains(&wid) {
+                    self.floating.remove_active_for_window(wid);
+                } else {
+                    self.remove_window_internal(window_store, wid, true);
+                }
+            }
+            LayoutEvent::WindowNativeFullscreenSuspended(wid) => {
+                let changed = self.native_fullscreen_suspended.insert(wid);
+                self.floating.remove_active_for_window(wid);
+                if self.focused_window == Some(wid) {
+                    self.focused_window = None;
+                }
+                return EventResponse {
+                    changed,
+                    ..EventResponse::default()
+                };
+            }
+            LayoutEvent::WindowNativeFullscreenRestored(wid) => {
+                let changed = self.native_fullscreen_suspended.remove(&wid);
+                return EventResponse {
+                    changed,
+                    ..EventResponse::default()
+                };
             }
             LayoutEvent::WindowFocused(space, wid) => {
                 if self.floating.is_floating(wid) {
@@ -1641,6 +1699,12 @@ impl LayoutEngine {
                 new_frame,
                 screens,
             } => {
+                // AX can deliver the fullscreen animation's frame before WindowServer delivers
+                // the matching Space lifecycle event. A suspended leaf keeps its pre-fullscreen
+                // split weight until the window returns to its user Space.
+                if self.native_fullscreen_suspended.contains(&wid) {
+                    return EventResponse::default();
+                }
                 for (space, screen_frame, display_uuid) in screens {
                     let Some((ws_id, layout)) = self.workspace_and_layout(space) else {
                         debug!(
@@ -2136,16 +2200,20 @@ impl LayoutEngine {
         let Some((ws_id, layout)) = self.workspace_and_layout(space) else {
             return Vec::new();
         };
-        self.workspace_tree(ws_id).calculate_layout(
-            layout,
-            screen,
-            self.layout_settings.stack.stack_offset,
-            &self.window_layout_constraints,
-            gaps,
-            stack_line_thickness,
-            stack_line_horiz,
-            stack_line_vert,
-        )
+        self.workspace_tree(ws_id)
+            .calculate_layout(
+                layout,
+                screen,
+                self.layout_settings.stack.stack_offset,
+                &self.window_layout_constraints,
+                gaps,
+                stack_line_thickness,
+                stack_line_horiz,
+                stack_line_vert,
+            )
+            .into_iter()
+            .filter(|(wid, _)| !self.native_fullscreen_suspended.contains(wid))
+            .collect()
     }
 
     pub fn calculate_layout_with_virtual_workspaces<F>(
@@ -2335,6 +2403,8 @@ impl LayoutEngine {
             positions.insert(wid, hidden_rect);
         }
 
+        positions.retain(|wid, _| !self.native_fullscreen_suspended.contains(wid));
+
         positions.into_iter().collect()
     }
 
@@ -2426,6 +2496,8 @@ impl LayoutEngine {
                 positions.insert(window_id, stored_position);
             }
         }
+
+        positions.retain(|wid, _| !self.native_fullscreen_suspended.contains(wid));
 
         positions.into_iter().collect()
     }
@@ -3026,6 +3098,9 @@ impl LayoutEngine {
         self.virtual_workspace_manager.transfer_window_identity(from, to);
         self.floating_positions.transfer_window_identity(from, to);
         self.floating.transfer_window_identity(from, to);
+        if self.native_fullscreen_suspended.remove(&from) {
+            self.native_fullscreen_suspended.insert(to);
+        }
         self.transfer_persisted_window_identity(from, to);
         if let Some(constraints) = self.window_layout_constraints.remove(&from) {
             self.window_layout_constraints.insert(to, constraints);
@@ -3512,6 +3587,228 @@ mod tests {
             Some(assigned_workspace),
             "window should reappear in the same workspace after a temporary hide"
         );
+    }
+
+    #[test]
+    fn native_fullscreen_suspension_preserves_bsp_topology_and_split_weights() {
+        let mut window_store = WindowStore::default();
+        let mut layout_settings = LayoutSettings::default();
+        layout_settings.mode = LayoutMode::Bsp;
+        let mut engine = LayoutEngine::new(
+            &VirtualWorkspaceSettings::default(),
+            &layout_settings,
+            None,
+        );
+        let space = SpaceId::new(304);
+        let screen = CGRect::new(CGPoint::new(0.0, 0.0), CGSize::new(1200.0, 900.0));
+        let windows = [WindowId::new(42, 1), WindowId::new(42, 2), WindowId::new(42, 3)];
+        let window_info = |wid| (wid, None, None, None, true, CGSize::new(0.0, 0.0), None, None);
+
+        let _ = engine.handle_event(
+            &mut window_store,
+            LayoutEvent::SpaceExposed(space, screen.size),
+        );
+        let _ = engine.handle_event(
+            &mut window_store,
+            LayoutEvent::windows_on_screen_updated(
+                space,
+                windows[0].pid,
+                windows.iter().copied().map(window_info).collect(),
+                None,
+            ),
+        );
+        let _ = engine.handle_event(
+            &mut window_store,
+            LayoutEvent::WindowFocused(space, windows[1]),
+        );
+        let _ = engine.handle_command(
+            &mut window_store,
+            Some(space),
+            &[space],
+            &HashMap::default(),
+            LayoutCommand::ResizeWindowBy { amount: 0.2 },
+        );
+
+        let topology_before = engine
+            .query_workspace_layout(space, None)
+            .expect("BSP workspace should be initialized")
+            .container_tree;
+        let frames_before = engine.calculate_layout(
+            space,
+            screen,
+            &layout_settings.gaps,
+            0.0,
+            Default::default(),
+            Default::default(),
+        );
+
+        let suspended = windows[1];
+        let _ = engine.handle_event(
+            &mut window_store,
+            LayoutEvent::WindowNativeFullscreenSuspended(suspended),
+        );
+        // macOS can report the old user-Space disappearance after the fullscreen appearance.
+        let _ = engine.handle_event(
+            &mut window_store,
+            LayoutEvent::WindowRemovedPreserveFloating(suspended),
+        );
+        let _ = engine.handle_event(
+            &mut window_store,
+            LayoutEvent::WindowResized {
+                wid: suspended,
+                old_frame: frames_before
+                    .iter()
+                    .find(|(wid, _)| *wid == suspended)
+                    .expect("suspended window should have a pre-fullscreen frame")
+                    .1,
+                new_frame: screen,
+                screens: vec![(space, screen, None)],
+            },
+        );
+
+        assert_eq!(
+            engine
+                .query_workspace_layout(space, None)
+                .expect("suspended BSP workspace should remain initialized")
+                .container_tree,
+            topology_before,
+            "native fullscreen must preserve the exact BSP leaf, nesting, selection, and weights"
+        );
+        let frames_while_suspended = engine.calculate_layout(
+            space,
+            screen,
+            &layout_settings.gaps,
+            0.0,
+            Default::default(),
+            Default::default(),
+        );
+        assert!(!frames_while_suspended.iter().any(|(wid, _)| *wid == suspended));
+        for (wid, frame) in &frames_before {
+            if *wid != suspended {
+                assert_eq!(
+                    frames_while_suspended.iter().find(|(other, _)| other == wid).map(|(_, f)| f),
+                    Some(frame),
+                    "the suspended leaf should continue reserving its original split"
+                );
+            }
+        }
+
+        let _ = engine.handle_event(
+            &mut window_store,
+            LayoutEvent::WindowNativeFullscreenRestored(suspended),
+        );
+        let _ = engine.handle_event(&mut window_store, LayoutEvent::WindowAdded(space, suspended));
+
+        assert_eq!(
+            engine
+                .query_workspace_layout(space, None)
+                .expect("restored BSP workspace should remain initialized")
+                .container_tree,
+            topology_before
+        );
+        assert_eq!(
+            engine.calculate_layout(
+                space,
+                screen,
+                &layout_settings.gaps,
+                0.0,
+                Default::default(),
+                Default::default(),
+            ),
+            frames_before,
+            "exiting native fullscreen must restore the exact pre-fullscreen frames"
+        );
+    }
+
+    #[test]
+    fn native_fullscreen_suspension_follows_window_identity_rekey() {
+        let mut window_store = WindowStore::default();
+        let mut layout_settings = LayoutSettings::default();
+        layout_settings.mode = LayoutMode::Bsp;
+        let mut engine = LayoutEngine::new(
+            &VirtualWorkspaceSettings::default(),
+            &layout_settings,
+            None,
+        );
+        let space = SpaceId::new(305);
+        let screen = CGRect::new(CGPoint::new(0.0, 0.0), CGSize::new(1200.0, 900.0));
+        let old = WindowId::new(43, 1);
+        let sibling = WindowId::new(43, 2);
+        let replacement = WindowId::new(43, 99);
+        let window_info = |wid| (wid, None, None, None, true, CGSize::new(0.0, 0.0), None, None);
+
+        let _ = engine.handle_event(
+            &mut window_store,
+            LayoutEvent::SpaceExposed(space, screen.size),
+        );
+        let _ = engine.handle_event(
+            &mut window_store,
+            LayoutEvent::windows_on_screen_updated(
+                space,
+                old.pid,
+                vec![window_info(old), window_info(sibling)],
+                None,
+            ),
+        );
+        let expected_frame = engine
+            .calculate_layout(
+                space,
+                screen,
+                &layout_settings.gaps,
+                0.0,
+                Default::default(),
+                Default::default(),
+            )
+            .into_iter()
+            .find(|(wid, _)| *wid == old)
+            .expect("old identity should have a BSP leaf")
+            .1;
+
+        let _ = engine.handle_event(
+            &mut window_store,
+            LayoutEvent::WindowNativeFullscreenSuspended(old),
+        );
+        engine.rekey_window_identity(&mut window_store, old, replacement);
+        assert!(
+            !engine
+                .calculate_layout(
+                    space,
+                    screen,
+                    &layout_settings.gaps,
+                    0.0,
+                    Default::default(),
+                    Default::default(),
+                )
+                .iter()
+                .any(|(wid, _)| *wid == old || *wid == replacement),
+            "the replacement identity must remain suspended"
+        );
+
+        let _ = engine.handle_event(
+            &mut window_store,
+            LayoutEvent::WindowNativeFullscreenRestored(replacement),
+        );
+        let _ = engine.handle_event(
+            &mut window_store,
+            LayoutEvent::WindowAdded(space, replacement),
+        );
+        let restored_frames = engine.calculate_layout(
+            space,
+            screen,
+            &layout_settings.gaps,
+            0.0,
+            Default::default(),
+            Default::default(),
+        );
+        assert_eq!(
+            restored_frames
+                .iter()
+                .find(|(wid, _)| *wid == replacement)
+                .map(|(_, frame)| *frame),
+            Some(expected_frame),
+            "a rekeyed fullscreen window must return to the original BSP slot"
+        );
+        assert!(!restored_frames.iter().any(|(wid, _)| *wid == old));
     }
 
     #[test]

--- a/src/layout_engine/engine/persistence/snapshot.rs
+++ b/src/layout_engine/engine/persistence/snapshot.rs
@@ -64,6 +64,7 @@ impl PersistedLayout {
             floating_positions: self.floating_positions,
             app_rules: AppRuleEngine::default(),
             focused_window: None,
+            native_fullscreen_suspended: HashSet::default(),
             window_layout_constraints: HashMap::default(),
             virtual_workspace_manager: self.virtual_workspace_manager,
             layout_settings: LayoutSettings::default(),

--- a/src/model/window_store.rs
+++ b/src/model/window_store.rs
@@ -98,6 +98,10 @@ pub struct NativeFullscreenRecord {
     pub last_known_user_space: Option<SpaceId>,
     pub fullscreen_space: SpaceId,
     pub transition: NativeFullscreenTransition,
+    /// The owning AX window explicitly reported `AXFullscreen = true`. This distinguishes
+    /// ordinary AppKit fullscreen from browser video projections, whose original AX window can
+    /// remain non-fullscreen while a separate transient projection owns the native Space.
+    pub ax_fullscreen_observed: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -532,6 +536,8 @@ impl WindowStore {
                 .or_else(|| existing.and_then(|record| record.last_known_user_space)),
             fullscreen_space,
             transition,
+            ax_fullscreen_observed: existing
+                .is_some_and(|record| record.ax_fullscreen_observed),
         };
         self.windows.entry(window_id).or_default().placement = WindowPlacement::NativeFullscreen;
         self.app_windows.entry(window_id.pid).or_default().insert(window_id);
@@ -612,12 +618,32 @@ impl WindowStore {
         self.native_fullscreen_records_by_original_window.values().copied()
     }
 
+    /// Remember that this lifecycle was corroborated by the window's native AX fullscreen
+    /// attribute. A later `false` value is then an authoritative exit signal even when the
+    /// active-Space window inventory is still lagging behind the animation.
+    pub fn mark_window_native_fullscreen_ax_observed(&mut self, window_id: WindowId) -> bool {
+        let Some(original_window_id) = self.native_fullscreen_original_window(window_id) else {
+            return false;
+        };
+        let Some(record) =
+            self.native_fullscreen_records_by_original_window.get_mut(&original_window_id)
+        else {
+            return false;
+        };
+        let changed = !record.ax_fullscreen_observed;
+        record.ax_fullscreen_observed = true;
+        changed
+    }
+
     pub fn restore_window_from_native_fullscreen(
         &mut self,
         window_id: WindowId,
     ) -> Option<NativeFullscreenRecord> {
         let original_window_id = self.native_fullscreen_original_window(window_id)?;
         let record = self.remove_native_fullscreen_record_by_original_window(original_window_id)?;
+        if let Some(workspace) = record.workspace {
+            self.assign_window_to_workspace(record.current_window_id, workspace);
+        }
         if let Some(window) = self.windows.get_mut(&record.current_window_id) {
             window.placement = if window.rule_floating {
                 WindowPlacement::Floating


### PR DESCRIPTION
## What changed

- Preserve a tiled window's BSP leaf, topology, and split weights while it is in native fullscreen.
- Correlate Accessibility fullscreen signals with WindowServer Space membership instead of treating the transition as an ordinary removal and re-add.
- Handle browser video fullscreen implementations that create a transient Space or temporarily replace the original AX window.
- Restore the saved workspace assignment and layout position when the window returns.

## Why

Native fullscreen temporarily removes a window from its user Desktop. Rift's normal disappearance handling could collapse its BSP leaf, so exiting fullscreen reinserted the window with default 50/50 weights. Some browser video players also expose a replacement projection window, while regular AppKit fullscreen follows a different AX lifecycle.

## Validation

- `cargo test`: 542 library tests and 2 CLI tests passed.
- YouTube/browser video fullscreen returned to the exact asymmetric tiled split.
- Standard macOS green-button fullscreen returned to the original tiled frame.
- Repeated fullscreen transitions and a full reboot completed without regressions.
