### PR TITLE
bsp: center the lone tiled window on-screen

### DIFF
--- a/crates/rift-protocol/src/commands.rs
+++ b/crates/rift-protocol/src/commands.rs
@@ -81,6 +81,7 @@ pub enum LayoutCommand {
     },
     PromoteToMaster,
     SwapMasterStack,
+    ToggleCenterSingleWindow,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/rift.default.toml
+++ b/rift.default.toml
@@ -108,6 +108,17 @@ new_window_placement = "master"
 # If omitted, defaults to the direction perpendicular to master_side's split
 # stack_arrangement = "vertical"
 
+# these settings only apply when layout mode == "bsp"
+[settings.layout.bsp]
+# Center the lone tiled window when a workspace has exactly one window.
+# Can also be toggled at runtime via the `toggle_center_single_window` command;
+# reloading the config resets it to this value.
+center_single_window = false
+# Size of the centered lone window as fractions of the usable screen area
+# (0.1..1.0)
+center_single_window_width_ratio = 0.7
+center_single_window_height_ratio = 0.8
+
 # these settings only apply when layout mode == "scrolling"
 [settings.layout.scrolling]
 # width of the active column (0..1 of screen width)
@@ -422,6 +433,9 @@ comb1 = "Alt + Shift"
 # - adjust_master_ratio = 0.05 / adjust_master_count = 1
 # - promote_to_master / swap_master_stack
 
+# the following commands *only* work when the bsp layout is active
+# - toggle_center_single_window (centers the lone tiled window; see [settings.layout.bsp])
+
 # the following commands *only* work when the scrolling layout is active
 # - scroll_strip = { delta = 0.5 }
 # - snap_strip / center_selection
@@ -462,6 +476,7 @@ comb1 = "Alt + Shift"
 "Alt + Shift + Down" = { join_window = "down" }
 "Alt + Comma" = "toggle_stack"
 "Alt + Slash" = "toggle_orientation"
+"Alt + Ctrl + C" = "toggle_center_single_window"
 "Alt + Ctrl + E" = "unjoin_windows"
 
 "Alt + Shift + Space" = "toggle_window_floating"

--- a/src/bin/rift-cli.rs
+++ b/src/bin/rift-cli.rs
@@ -323,6 +323,8 @@ enum LayoutCommands {
     PromoteToMaster,
     /// Swap the first master with the first stack window (master/stack layout only)
     SwapMasterStack,
+    /// Toggle centering of the lone tiled window (BSP layout only)
+    ToggleCenterSingleWindow,
     /// Swap two windows by window id (`WindowId { pid: ..., idx: ... }`)
     SwapWindows { a: String, b: String },
     /// Scroll the strip by a normalized delta (scrolling layout only)
@@ -920,6 +922,9 @@ fn map_layout_command(cmd: LayoutCommands) -> Result<CliCommand, String> {
         LayoutCommands::SwapMasterStack => Ok(CliCommand::Reactor(reactor::Command::Layout(
             LC::SwapMasterStack,
         ))),
+        LayoutCommands::ToggleCenterSingleWindow => Ok(CliCommand::Reactor(
+            reactor::Command::Layout(LC::ToggleCenterSingleWindow),
+        )),
         LayoutCommands::SwapWindows { a, b } => Ok(CliCommand::Reactor(reactor::Command::Layout(
             LC::SwapWindows(parse_window_id(&a)?.into(), parse_window_id(&b)?.into()),
         ))),

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -707,11 +707,45 @@ impl Default for TraditionalLayoutSettings {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct BspLayoutSettings {
     #[serde(flatten)]
     pub base: BaseLayoutSettings,
+    /// Centers the lone tiled window; runtime toggles reset on config reload.
+    #[serde(default)]
+    pub center_single_window: bool,
+    /// Centered lone-window width as a fraction of usable width (0.1..1.0).
+    #[serde(default = "default_bsp_center_width_ratio")]
+    pub center_single_window_width_ratio: f64,
+    /// Centered lone-window height as a fraction of usable height (0.1..1.0).
+    #[serde(default = "default_bsp_center_height_ratio")]
+    pub center_single_window_height_ratio: f64,
+}
+
+fn default_bsp_center_width_ratio() -> f64 { 0.7 }
+
+fn default_bsp_center_height_ratio() -> f64 { 0.8 }
+
+impl BspLayoutSettings {
+    /// Returns ratios when lone-window centering is enabled.
+    pub fn center_single_window_ratios(&self) -> Option<(f64, f64)> {
+        self.center_single_window.then_some((
+            self.center_single_window_width_ratio,
+            self.center_single_window_height_ratio,
+        ))
+    }
+}
+
+impl Default for BspLayoutSettings {
+    fn default() -> Self {
+        Self {
+            base: BaseLayoutSettings::default(),
+            center_single_window: false,
+            center_single_window_width_ratio: default_bsp_center_width_ratio(),
+            center_single_window_height_ratio: default_bsp_center_height_ratio(),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]

--- a/src/layout_engine/engine.rs
+++ b/src/layout_engine/engine.rs
@@ -452,6 +452,7 @@ impl LayoutEngine {
                 }
                 LayoutSystemKind::Bsp(system) => {
                     system.set_window_insertion_point(insertion_point);
+                    system.set_center_single_window(settings.bsp.center_single_window_ratios());
                 }
                 LayoutSystemKind::Stack(system) => {
                     system.update_settings(settings.stack.default_orientation, insertion_point);
@@ -466,6 +467,15 @@ impl LayoutEngine {
                     mode_settings.base = settings.resolved_base_for(mode);
                     system.update_settings(&mode_settings);
                 }
+            }
+        }
+    }
+
+    fn sync_bsp_center_single_window(&mut self) {
+        let ratios = self.layout_settings.bsp.center_single_window_ratios();
+        for (_, workspace) in self.virtual_workspace_manager.workspaces.iter_mut() {
+            if let LayoutSystemKind::Bsp(system) = &mut workspace.layout_system {
+                system.set_center_single_window(ratios);
             }
         }
     }
@@ -2085,6 +2095,15 @@ impl LayoutEngine {
                     LayoutSystemKind::Scrolling(s) => {
                         Self::toggle_orientation_for_system(s, layout, default_orientation)
                     }
+                }
+            }
+            LayoutCommand::ToggleCenterSingleWindow => {
+                self.layout_settings.bsp.center_single_window =
+                    !self.layout_settings.bsp.center_single_window;
+                self.sync_bsp_center_single_window();
+                EventResponse {
+                    changed: true,
+                    ..EventResponse::default()
                 }
             }
             LayoutCommand::ResizeWindowGrow(orientation) => {

--- a/src/layout_engine/systems/bsp.rs
+++ b/src/layout_engine/systems/bsp.rs
@@ -38,6 +38,8 @@ pub struct BspLayoutSystem {
     window_to_node: HashMap<WindowId, NodeId>,
     #[serde(skip, default)]
     window_insertion_point: WindowInsertionPoint,
+    #[serde(default)]
+    center_single_window: Option<(f64, f64)>,
 }
 
 impl BspLayoutSystem {
@@ -187,6 +189,7 @@ impl Default for BspLayoutSystem {
             kind: Default::default(),
             window_to_node: Default::default(),
             window_insertion_point: WindowInsertionPoint::default(),
+            center_single_window: None,
         }
     }
 }
@@ -201,6 +204,10 @@ impl BspLayoutSystem {
 
     pub fn set_window_insertion_point(&mut self, value: WindowInsertionPoint) {
         self.window_insertion_point = value;
+    }
+
+    pub fn set_center_single_window(&mut self, ratios: Option<(f64, f64)>) {
+        self.center_single_window = ratios;
     }
 
     fn index_window(&mut self, wid: WindowId, node: NodeId) {
@@ -721,6 +728,29 @@ impl BspLayoutSystem {
             _ => None,
         }
     }
+
+    fn center_single_window_frame(
+        &self,
+        state: &LayoutState,
+        rect: CGRect,
+        width_ratio: f64,
+        height_ratio: f64,
+    ) -> Option<(WindowId, CGRect)> {
+        let mut windows = Vec::new();
+        self.collect_windows_under(state.root, &mut windows);
+        let [window] = windows.as_slice() else { return None };
+
+        let width = (rect.size.width * width_ratio.clamp(0.1, 1.0)).round();
+        let height = (rect.size.height * height_ratio.clamp(0.1, 1.0)).round();
+        let frame = CGRect {
+            origin: CGPoint {
+                x: rect.origin.x + ((rect.size.width - width) / 2.0).round(),
+                y: rect.origin.y + ((rect.size.height - height) / 2.0).round(),
+            },
+            size: CGSize { width, height },
+        };
+        Some((*window, frame))
+    }
 }
 
 #[derive(Default, Serialize, Deserialize, Debug)]
@@ -976,6 +1006,49 @@ mod tests {
             "orthogonal max-only constraint should not change the parent split allocation"
         );
     }
+
+    #[test]
+    fn center_single_window_centers_lone_leaf_only() {
+        let mut system = BspLayoutSystem::default();
+        system.set_center_single_window(Some((0.7, 0.8)));
+        let layout = system.create_layout();
+        system.add_window_after_selection(layout, w(1));
+
+        let screen = CGRect::new(CGPoint::new(0.0, 0.0), CGSize::new(1200.0, 900.0));
+        assert_eq!(
+            system.calculate_layout(
+                layout,
+                screen,
+                0.0,
+                &HashMap::default(),
+                &Default::default(),
+                0.0,
+                Default::default(),
+                Default::default(),
+            ),
+            vec![(
+                w(1),
+                CGRect::new(CGPoint::new(180.0, 90.0), CGSize::new(840.0, 720.0))
+            )]
+        );
+
+        system.add_window_after_selection(layout, w(2));
+        assert_eq!(
+            system
+                .calculate_layout(
+                    layout,
+                    screen,
+                    0.0,
+                    &HashMap::default(),
+                    &Default::default(),
+                    0.0,
+                    Default::default(),
+                    Default::default(),
+                )
+                .len(),
+            2
+        );
+    }
 }
 
 impl LayoutSystem for BspLayoutSystem {
@@ -1124,6 +1197,13 @@ impl LayoutSystem for BspLayoutSystem {
         let mut out = Vec::new();
         if let Some(state) = self.layouts.get(layout).copied() {
             let rect = Self::apply_outer_gaps(screen, gaps);
+            if let Some((width_ratio, height_ratio)) = self.center_single_window
+                && !self.has_fullscreen_in_subtree(state.root)
+                && let Some(frame) =
+                    self.center_single_window_frame(&state, rect, width_ratio, height_ratio)
+            {
+                return vec![frame];
+            }
             self.calculate_layout_recursive(state.root, rect, screen, constraints, gaps, &mut out);
         }
         out

--- a/src/model/virtual_workspace.rs
+++ b/src/model/virtual_workspace.rs
@@ -92,9 +92,11 @@ impl VirtualWorkspace {
                 ),
             ),
             LayoutMode::Bsp => {
-                LayoutSystemKind::Bsp(crate::layout_engine::systems::BspLayoutSystem::new(
+                let mut system = crate::layout_engine::systems::BspLayoutSystem::new(
                     settings.window_insertion_point_for(mode),
-                ))
+                );
+                system.set_center_single_window(settings.bsp.center_single_window_ratios());
+                LayoutSystemKind::Bsp(system)
             }
             LayoutMode::Stack => LayoutSystemKind::Stack(
                 crate::layout_engine::systems::StackLayoutSystem::new_with_insertion_point(


### PR DESCRIPTION
Centers the lone tiled window in BSP workspaces at a configurable size, Omarchy/Hyprland-style.

- `[layout.bsp]` gains `center_single_window` (default off) plus width/height ratios.
- When enabled and a workspace has exactly one tiled, non-fullscreen window, it is centered at those ratios. Fullscreen and fullscreen-within-gaps leaves are exempt; a second window resumes the normal split.
- New `toggle_center_single_window` layout command (keybind + CLI) flips it at runtime; config reload resets.
- Defaults preserve existing behavior (off, full area).

Hyprland's `dwindle:single_window_aspect_ratio` can only express a fixed width:height ratio, so "narrower width, full height" is not possible there; independent ratios cover it.

Closes https://github.com/acsandmann/rift/issues/458

*AI-assisted — Tool: Pi; model: opencode-go/deepseek-v4-flash.*