### PR TITLE
feat(cli): add offline config check

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ Get up and running via the wiki:
 [<kbd><br>quick start<br></kbd>][quick_start]
 <br>
 
+To check a configuration file without starting Rift, run:
+
+```sh
+rift config check --config ~/.config/rift/config.toml
+```
+
+The command parses the TOML and runs Rift's semantic checks before any
+Accessibility, WindowServer, or other runtime services are initialized.
+
 ## Status
 Rift is a stable, reliable, and performant window manager used by many. It is still in development and thus new features, optimizations, and general improvements are regularly released, but is more than good enough for daily use.
 

--- a/src/bin/rift.rs
+++ b/src/bin/rift.rs
@@ -20,8 +20,8 @@ use rift_wm::actor::stack_line::StackLine;
 use rift_wm::actor::window_notify as window_notify_actor;
 use rift_wm::actor::wm_controller::{self, WmController};
 use rift_wm::common::config::{Config, config_file, restore_file};
-use rift_wm::common::log;
 use rift_wm::common::util::execute_startup_commands;
+use rift_wm::common::{config_check, log};
 use rift_wm::ipc;
 use rift_wm::layout_engine::LayoutEngine;
 use rift_wm::model::tx_store::WindowTxStore;
@@ -68,7 +68,7 @@ struct Cli {
     record: Option<PathBuf>,
 
     /// Path to configuration file to use (overrides default).
-    #[arg(long, value_name = "PATH")]
+    #[arg(long, global = true, value_name = "PATH")]
     config: Option<PathBuf>,
 
     #[command(subcommand)]
@@ -77,11 +77,22 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Check a configuration file without starting Rift.
+    Config {
+        #[command(subcommand)]
+        config: ConfigCommands,
+    },
     /// Manage the launchd service for rift
     Service {
         #[command(subcommand)]
         service: ServiceCommands,
     },
+}
+
+#[derive(Subcommand)]
+enum ConfigCommands {
+    /// Parse and semantically validate the configuration at --config PATH.
+    Check,
 }
 
 /// this is okay because there is no recovery mechanism for actors
@@ -93,8 +104,22 @@ async fn supervise(name: &'static str, fut: impl Future<Output = ()>) {
 }
 
 fn main() {
-    sigpipe::reset();
     let opt = Cli::parse();
+
+    if let Some(Commands::Config { config: ConfigCommands::Check }) = &opt.command {
+        let Some(path) = opt.config.as_deref() else {
+            eprintln!("rift config check requires --config PATH");
+            process::exit(1);
+        };
+        if let Err(error) = config_check::check(path) {
+            eprintln!("rift config check: {error:#}");
+            process::exit(1);
+        }
+        println!("Configuration is valid: {}", path.display());
+        process::exit(0);
+    }
+
+    sigpipe::reset();
 
     if let Some(Commands::Service { service }) = &opt.command {
         match handle_service_command(service) {

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,4 +1,5 @@
 pub mod collections;
 pub mod config;
+pub mod config_check;
 pub mod log;
 pub mod util;

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -1312,6 +1312,14 @@ impl Config {
         Self::parse(&buf)
     }
 
+    /// Read a configuration without resolving hotkeys through the active
+    /// macOS keyboard layout. This is for offline validation only; runtime
+    /// startup still uses [`Config::read`] so hotkeys become key codes.
+    pub(crate) fn read_offline(path: &Path) -> anyhow::Result<Config> {
+        let buf = std::fs::read_to_string(path)?;
+        Self::parse_offline(&buf)
+    }
+
     pub fn default() -> Config { Self::parse(include_str!("../../rift.default.toml")).unwrap() }
 
     /// Save the current config to a file
@@ -1574,8 +1582,15 @@ impl Config {
                     let expanded_key =
                         Self::expand_modifier_combinations(&key, &c.modifier_combinations);
                     let normalized_key = Self::normalize_hotkey_string(&expanded_key);
-                    let Ok(hotkey) = Hotkey::from_str(&normalized_key) else {
-                        bail!("Could not parse hotkey: {key}");
+                    let hotkey = match Hotkey::from_str(&normalized_key) {
+                        Ok(hotkey) => hotkey,
+                        Err(error)
+                            if crate::sys::hotkey::offline_key_resolution_enabled()
+                                && error.to_string().contains("active keyboard layout") =>
+                        {
+                            bail!("{error}");
+                        }
+                        Err(_) => bail!("Could not parse hotkey: {key}"),
                     };
                     keys.push((hotkey, cmd.clone()));
                     key_specs.push((normalized_key, cmd));
@@ -1611,6 +1626,13 @@ impl Config {
                 }
             }
         }
+    }
+
+    /// Parse the config model without asking macOS to resolve character keys.
+    /// The normal parser still validates all hotkeys; the keyboard layout
+    /// lookup is replaced by a contained static fallback scope.
+    fn parse_offline(buf: &str) -> anyhow::Result<Config> {
+        crate::sys::hotkey::with_offline_key_resolution(|| Self::parse(buf))
     }
 }
 

--- a/src/common/config_check.rs
+++ b/src/common/config_check.rs
@@ -1,0 +1,130 @@
+//! Offline validation for a Rift configuration file.
+//!
+//! This module intentionally only reads and deserializes the configuration. It
+//! must remain safe to call before AppKit, Accessibility, WindowServer, or any
+//! of Rift's runtime actors are initialized.
+
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+
+use super::config::Config;
+
+/// Parse and semantically validate the configuration at `path` without
+/// starting Rift's runtime.
+pub fn check(path: &Path) -> Result<()> {
+    let config = Config::read_offline(path).with_context(|| {
+        format!("could not read or parse configuration file '{}'", path.display())
+    })?;
+    let issues = config.validate();
+
+    if issues.is_empty() {
+        return Ok(());
+    }
+
+    let details = issues.iter().map(|issue| format!("  - {issue}")).collect::<Vec<_>>().join("\n");
+    bail!(
+        "configuration validation failed for '{}':\n{details}",
+        path.display()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    fn config_file(contents: &str) -> NamedTempFile {
+        let file = NamedTempFile::new().unwrap();
+        fs::write(file.path(), contents).unwrap();
+        file
+    }
+
+    #[test]
+    fn accepts_a_valid_configuration_without_starting_runtime() {
+        let file = config_file(include_str!("../../rift.default.toml"));
+
+        check(file.path()).unwrap();
+    }
+
+    #[test]
+    fn rejects_layout_specific_character_hotkeys_without_tis_lookup() {
+        let contents =
+            include_str!("../../rift.default.toml").replace("\"Alt + Z\"", "\"Alt + €\"");
+        let file = config_file(&contents);
+        let lookups_before = crate::sys::hotkey::keyboard_layout_lookup_count_for_test();
+
+        let error = format!("{:#}", check(file.path()).unwrap_err());
+
+        assert_eq!(
+            crate::sys::hotkey::keyboard_layout_lookup_count_for_test(),
+            lookups_before
+        );
+        assert!(error.contains("Cannot resolve character key '€' offline"));
+        assert!(error.contains("active keyboard layout"));
+    }
+
+    #[test]
+    fn rejects_invalid_named_hotkeys_offline() {
+        let contents =
+            include_str!("../../rift.default.toml").replace("\"Alt + Z\"", "\"Alt + Banana\"");
+        let file = config_file(&contents);
+
+        let error = format!("{:#}", check(file.path()).unwrap_err());
+
+        assert!(error.contains("Could not parse hotkey: Alt + Banana"));
+    }
+
+    #[test]
+    fn keeps_focus_disable_hotkeys_in_the_offline_scope() {
+        let contents = include_str!("../../rift.default.toml").replace(
+            "focus_follows_mouse = true",
+            "focus_follows_mouse = true\nfocus_follows_mouse_disable_hotkey = \"Alt + Comma\"",
+        );
+        let file = config_file(&contents);
+        let lookups_before = crate::sys::hotkey::keyboard_layout_lookup_count_for_test();
+
+        check(file.path()).unwrap();
+
+        assert_eq!(
+            crate::sys::hotkey::keyboard_layout_lookup_count_for_test(),
+            lookups_before
+        );
+    }
+
+    #[test]
+    fn reports_missing_files_clearly() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("missing.toml");
+
+        let error = format!("{:#}", check(&path).unwrap_err());
+
+        assert!(error.contains("could not read or parse configuration file"));
+        assert!(error.contains("missing.toml"));
+    }
+
+    #[test]
+    fn reports_toml_parse_failures() {
+        let file = config_file("[settings\n");
+
+        let error = format!("{:#}", check(file.path()).unwrap_err());
+
+        assert!(error.contains("could not read or parse configuration file"));
+        assert!(error.contains("TOML parse error"));
+    }
+
+    #[test]
+    fn reports_semantic_validation_failures() {
+        let contents = include_str!("../../rift.default.toml")
+            .replace("animation_duration = 0.3", "animation_duration = -1.0");
+        let file = config_file(&contents);
+
+        let error = format!("{:#}", check(file.path()).unwrap_err());
+
+        assert!(error.contains("configuration validation failed"));
+        assert!(error.contains("animation_duration must be non-negative"));
+    }
+}

--- a/src/sys/hotkey.rs
+++ b/src/sys/hotkey.rs
@@ -1,3 +1,4 @@
+use std::cell::Cell;
 use std::collections::HashMap as StdHashMap;
 use std::ffi::c_void;
 use std::fmt;
@@ -10,6 +11,37 @@ use objc2_core_foundation::CFData;
 use objc2_core_graphics::{CGEvent, CGEventField, CGEventFlags};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
+
+thread_local! {
+    static OFFLINE_KEY_RESOLUTION: Cell<bool> = const { Cell::new(false) };
+    #[cfg(test)]
+    static KEYBOARD_LAYOUT_LOOKUPS: Cell<usize> = const { Cell::new(0) };
+}
+
+struct OfflineKeyResolutionGuard {
+    previous: bool,
+}
+
+impl Drop for OfflineKeyResolutionGuard {
+    fn drop(&mut self) { OFFLINE_KEY_RESOLUTION.with(|offline| offline.set(self.previous)); }
+}
+
+/// Run key parsing without consulting the active macOS keyboard layout.
+///
+/// Offline config checks still use the normal hotkey parser and reject invalid
+/// named keys. Character keys use only the static fallback map.
+pub(crate) fn with_offline_key_resolution<R>(f: impl FnOnce() -> R) -> R {
+    let previous = OFFLINE_KEY_RESOLUTION.with(|offline| offline.replace(true));
+    let _guard = OfflineKeyResolutionGuard { previous };
+    f()
+}
+
+#[cfg(test)]
+pub(crate) fn keyboard_layout_lookup_count_for_test() -> usize {
+    KEYBOARD_LAYOUT_LOOKUPS.with(Cell::get)
+}
+
+pub(crate) fn offline_key_resolution_enabled() -> bool { OFFLINE_KEY_RESOLUTION.with(Cell::get) }
 
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Modifiers(u8);
@@ -457,6 +489,13 @@ impl FromStr for KeyCode {
         if s.chars().count() == 1 {
             if let Some(k) = keycode_from_char(s) {
                 return Ok(k);
+            }
+
+            if offline_key_resolution_enabled() {
+                return Err(anyhow!(
+                    "Cannot resolve character key '{}' offline without the active keyboard layout",
+                    s
+                ));
             }
 
             return Err(anyhow!("carbon keymap failed"));
@@ -934,6 +973,9 @@ fn generate_virtual_keymap() -> StdHashMap<String, KeyCode> {
     let _guard = KEYMAP_GENERATION_LOCK.lock();
     let mut keymap = StdHashMap::new();
 
+    #[cfg(test)]
+    KEYBOARD_LAYOUT_LOOKUPS.with(|lookups| lookups.set(lookups.get() + 1));
+
     let keyboard = unsafe { TISCopyCurrentASCIICapableKeyboardLayoutInputSource() };
     if keyboard.is_null() {
         tracing::warn!("Could not get ASCII-capable keyboard layout input source");
@@ -1004,10 +1046,33 @@ fn generate_virtual_keymap() -> StdHashMap<String, KeyCode> {
 }
 
 pub fn keycode_from_char(ch: &str) -> Option<KeyCode> {
+    if offline_key_resolution_enabled() {
+        return offline_static_keycode_from_char(ch);
+    }
+
     generate_virtual_keymap()
         .get(&ch.to_lowercase())
         .copied()
         .or_else(|| fallback_keycode_from_char(ch))
+}
+
+fn offline_static_keycode_from_char(ch: &str) -> Option<KeyCode> {
+    fallback_keycode_from_char(ch).or_else(|| {
+        Some(match ch {
+            "-" => KeyCode::Minus,
+            "=" => KeyCode::Equal,
+            "," => KeyCode::Comma,
+            "." => KeyCode::Period,
+            "/" => KeyCode::Slash,
+            ";" => KeyCode::Semicolon,
+            "'" => KeyCode::Quote,
+            "`" => KeyCode::Backquote,
+            "\\" => KeyCode::Backslash,
+            "[" => KeyCode::BracketLeft,
+            "]" => KeyCode::BracketRight,
+            _ => return None,
+        })
+    })
 }
 
 fn fallback_keycode_from_char(ch: &str) -> Option<KeyCode> {


### PR DESCRIPTION
## Summary

- add `rift config check --config PATH`
- parse the full config and run semantic validation without starting Rift
- resolve hotkeys through a static offline map so the command never touches AppKit, Accessibility, WindowServer, Carbon keyboard-layout services, startup commands, or Rift services
- reject layout-specific character keys that cannot be proven valid offline with a clear error

## Tests

- `cargo test --locked common::config_check`
- `cargo test --locked sys::hotkey::tests`
- `cargo build --locked --bin rift`
- `target/debug/rift config check --config rift.default.toml`