### PR TITLE
fix: retry the reap when waitpid reports StillAlive

### DIFF
--- a/src/sys/dispatch.rs
+++ b/src/sys/dispatch.rs
@@ -213,8 +213,11 @@ pub fn reap_on_exit_proc(pid: pid_t) {
     let ctx = Box::into_raw(Box::new(pid)) as *mut c_void;
     extern "C" fn proc_event_handler(ctx: *mut c_void) {
         let pid = unsafe { *(ctx as *mut pid_t) };
-        match waitpid(Pid::from_raw(pid), Some(WaitPidFlag::WNOHANG)) {
-            Ok(WaitStatus::StillAlive) => {}
+        let status = match waitpid(Pid::from_raw(pid), Some(WaitPidFlag::WNOHANG)) {
+            Ok(WaitStatus::StillAlive) => waitpid(Pid::from_raw(pid), None),
+            other => other,
+        };
+        match status {
             Ok(WaitStatus::Exited(p, _)) | Ok(WaitStatus::Signaled(p, _, _)) => {
                 let raw = p.as_raw();
                 if let Some(_src) = sources_map().lock().remove(&raw) {


### PR DESCRIPTION
## Summary
Fixes `<defunct>` processes piling up under long-running rift (I had 208 after 3 days).

## Root cause
`reap_on_exit_proc` registers a `DISPATCH_PROC_EXIT` source and reaps with `waitpid(WNOHANG)`. The kernel delivers `NOTE_EXIT` during `proc_exit()`, sometimes before the child is reapable, so `WNOHANG` returns `StillAlive` and the handler does nothing. It only fires once per process, so nothing retries and that child is never reaped. Every CLI event subscription goes through this path.

## Changes
- `src/sys/dispatch.rs`: on `StillAlive`, retry with a blocking `waitpid`. The child is already exiting so it returns immediately, and this is a global concurrent queue, not serial.

## Test plan
Same test on both branches, 40k spawns through `reap_on_exit_proc`:
- `main`: 97 zombies left
- this branch: 0

(`SIGCHLD`/`SIG_IGN` would also fix, but would break the `Command::output()` calls in `util.rs` and `wm_controller.rs`)

Found and fixed with Claude Code. I verified the before/after numbers myself. (not a rust dev, so if you prefer a different approach let me know!)