### PR TITLE
fix(traditional): avoid panic when a join collapses the shared parent

### DIFF
--- a/src/layout_engine/systems/traditional.rs
+++ b/src/layout_engine/systems/traditional.rs
@@ -2168,12 +2168,20 @@ impl TraditionalLayoutSystem {
                 node2.detach(&mut self.tree).push_back(new_container).with(|child, tree| {
                     tree.data.layout.info[child].size = size2;
                 });
-                self.tree.data.layout.info[new_container].size = size1 + size2;
                 self.tree.data.layout.info[new_container].total = size1 + size2;
-                self.tree.data.layout.info[p1].total = p1
-                    .children(&self.tree.map)
-                    .map(|child| self.tree.data.layout.info[child].size.max(0.0))
-                    .sum();
+                // Detaching both children can leave `p1` with a single child, in which
+                // case the tree observer collapses `p1`: it hoists `new_container` into
+                // p1's slot (inheriting p1's size via assume_size_of) and removes `p1`
+                // from the forest. Touching `info[p1]` afterwards panics on a dead key.
+                // Only recompute p1 while it is still alive; when it was collapsed away,
+                // new_container already inherited the correct size.
+                if self.tree.map.contains(p1) {
+                    self.tree.data.layout.info[new_container].size = size1 + size2;
+                    self.tree.data.layout.info[p1].total = p1
+                        .children(&self.tree.map)
+                        .map(|child| self.tree.data.layout.info[child].size.max(0.0))
+                        .sum();
+                }
                 return new_container;
             }
         }
@@ -3555,6 +3563,41 @@ mod tests {
             (sum_children - total).abs() < 0.0001,
             "parent total should remain equal to the sum of child sizes after joining siblings"
         );
+    }
+
+    #[test]
+    fn consecutive_perpendicular_joins_do_not_panic() {
+        // Regression: two joins in quick succession where the second collapses the
+        // container built by the first. Moving both children out of `p1` leaves it
+        // with one child, so the tree observer collapses `p1` and removes it from the
+        // forest mid-join; the old code then indexed `info[p1]` on a dead key and
+        // panicked with "invalid SecondaryMap key used".
+        let mut system = TraditionalLayoutSystem::default();
+        let layout = system.create_layout();
+        let root = system.root(layout);
+        system.tree.data.layout.set_kind(root, LayoutKind::Horizontal);
+
+        let w1 = w(160);
+        let w2 = w(161);
+        let w3 = w(162);
+        system.add_window_after_selection(layout, w1);
+        system.add_window_after_selection(layout, w2);
+        system.add_window_after_selection(layout, w3);
+
+        // First join builds a vertical container holding exactly w1 and w2.
+        assert!(system.select_window(layout, w1));
+        system.join_selection_with_direction(layout, Direction::Down);
+
+        // Second join is perpendicular to that container. It merges the container's
+        // only two children, leaving the container with a single child, so the tree
+        // observer collapses it and removes it from the forest mid-join. Must not panic.
+        assert!(system.select_window(layout, w1));
+        system.join_selection_with_direction(layout, Direction::Right);
+
+        // Tree must remain internally consistent: every window still reachable.
+        let mut windows = system.all_windows_in_layout(layout);
+        windows.sort();
+        assert_eq!(windows, vec![w1, w2, w3], "{}", system.draw_tree(layout));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a reproducible crash where `join_window` panics the reactor thread with
`invalid SecondaryMap key used`, killing the window manager. It fires when two
joins happen in quick succession — the second join collapses the container the
first one built.

## Reproduction

1. Traditional layout, three tiled windows.
2. Select a window and `join_window` in one direction (e.g. Down) — this nests
   two windows under a new container.
3. Select the same window and `join_window` perpendicular to that container
   (e.g. Right).

rift panics and the service respawns (crash-looping under launchd). Observed on
0.5.3 and 0.5.5:

```
thread 'reactor' panicked at src/layout_engine/systems/traditional.rs:2173:43:
invalid SecondaryMap key used
```

## Root cause

In `find_or_create_common_parent_internal`, the `p1 == p2` sibling fast-path
creates `new_container` under the shared parent `p1`, moves both `node1` and
`node2` into it, then recomputes `info[p1].total`.

Each move fires the `removed_child` tree observer (`Drop for ReattachedNode`).
When `p1`'s only children were `node1` and `node2`, detaching the second one
leaves `p1` with a single child, so the observer **collapses `p1`**: it hoists
`new_container` into p1's slot (inheriting p1's size via `assume_size_of`) and
removes `p1` from the forest. The subsequent `info[p1].total = …` then indexes
the layout `SecondaryMap` with the now-dead key and panics.

## Fix

Guard the post-move `info[p1]` update behind `self.tree.map.contains(p1)`. When
`p1` was collapsed away, `new_container` has already inherited the correct size
from the observer, so nothing more is needed. This mirrors the liveness check
already used in `tree.rs` (`map.contains(...)` before touching a node).

## Tests

Added `consecutive_perpendicular_joins_do_not_panic`, which reproduces the exact
panic on unpatched code and passes with the fix, asserting the tree stays
consistent (all windows still reachable) afterward.

- `cargo +nightly fmt --all --check` — PASS
- `cargo check --locked` — PASS (no Cargo.lock change)
- `cargo test --lib layout_engine::systems::traditional::tests` — 62 passed, 0 failed

Also verified on a patched release build in daily use: 34 join commands, 0 panics.

> **AI assistance:** Root-cause analysis, fix, regression test, and this PR were
> produced with Claude Code, guided and verified by me. I supplied the crash
> logs and confirmed the patched build on macOS.
