### PR TITLE
feat(gaps): support external display overrides

### DIFF
--- a/rift.default.toml
+++ b/rift.default.toml
@@ -156,6 +156,7 @@ default_orientation = "perpendicular"
 # Gap configuration
 # - outer: space between windows and screen edges
 # - inner: space between tiled windows
+# - external: optional overrides applied to every external display.
 # - per_display: optional display-specific overrides keyed by display UUID.
 #   When present, the values in a per-display override replace the defaults
 #   (you may override only `outer`, only `inner`, or both for a display).
@@ -170,6 +171,13 @@ right = 0
 [settings.layout.gaps.inner]
 horizontal = 0
 vertical = 0
+
+# Example external-display override:
+# [settings.layout.gaps.external.outer]
+# top = 48
+# left = 0
+# bottom = 0
+# right = 0
 
 # Example per-display overrides:
 # Replace the quoted key with your display's UUID. Only specify values you want to override.

--- a/src/actor/config.rs
+++ b/src/actor/config.rs
@@ -27,6 +27,34 @@ pub struct ConfigActor {
     config_path: PathBuf,
 }
 
+fn set_json_path(
+    root: &mut serde_json::Value,
+    key: &str,
+    value: serde_json::Value,
+) -> Result<(), String> {
+    let parts: Vec<&str> = key.split('.').collect();
+    if parts.is_empty() || parts.iter().any(|part| part.is_empty()) {
+        return Err("Empty config key provided".to_string());
+    }
+
+    let mut current = root;
+    for (index, part) in parts.iter().enumerate() {
+        if current.is_null() {
+            *current = serde_json::json!({});
+        }
+        let Some(object) = current.as_object_mut() else {
+            return Err(format!("Invalid config path: {key}"));
+        };
+        if index + 1 == parts.len() {
+            object.insert((*part).to_string(), value);
+            return Ok(());
+        }
+        current = object.entry((*part).to_string()).or_insert_with(|| serde_json::json!({}));
+    }
+
+    Ok(())
+}
+
 impl ConfigActor {
     pub fn spawn(config: Config, reactor_tx: reactor::Sender) -> Sender {
         Self::spawn_with_path(config, reactor_tx, crate::common::config::config_file())
@@ -182,50 +210,22 @@ impl ConfigActor {
             }
 
             ConfigCommand::Set { key, value } => match serde_json::to_value(&new_config) {
-                Ok(mut cfg_val) => {
-                    let parts: Vec<&str> = key.split('.').collect();
-                    if parts.is_empty() {
-                        errors.push("Empty config key provided".to_string());
-                    } else {
-                        let mut cur = &mut cfg_val;
-                        let mut failed = false;
-                        for (i, part) in parts.iter().enumerate() {
-                            if i + 1 == parts.len() {
-                                if let Some(obj) = cur.as_object_mut() {
-                                    obj.insert(part.to_string(), value.clone());
-                                } else {
-                                    errors.push(format!("Invalid config path: {}", key));
-                                    failed = true;
-                                }
-                            } else if let Some(obj) = cur.as_object_mut() {
-                                if !obj.contains_key(*part) {
-                                    obj.insert(part.to_string(), serde_json::json!({}));
-                                }
-                                cur = obj.get_mut(*part).unwrap();
-                            } else {
-                                errors.push(format!("Invalid config path: {}", key));
-                                failed = true;
-                                break;
-                            }
+                Ok(mut cfg_val) => match set_json_path(&mut cfg_val, &key, value.clone()) {
+                    Ok(()) => match serde_json::from_value::<Config>(cfg_val) {
+                        Ok(cfg2) => {
+                            new_config = cfg2;
+                            config_changed = true;
+                            info!("Updated {} to {}", key, value);
                         }
-
-                        if !failed {
-                            match serde_json::from_value::<Config>(cfg_val) {
-                                Ok(cfg2) => {
-                                    new_config = cfg2;
-                                    config_changed = true;
-                                    info!("Updated {} to {}", key, value);
-                                }
-                                Err(e) => {
-                                    errors.push(format!(
-                                        "Failed to deserialize config after setting '{}': {}",
-                                        key, e
-                                    ));
-                                }
-                            }
+                        Err(e) => {
+                            errors.push(format!(
+                                "Failed to deserialize config after setting '{}': {}",
+                                key, e
+                            ));
                         }
-                    }
-                }
+                    },
+                    Err(error) => errors.push(error),
+                },
                 Err(e) => {
                     errors.push(format!("Failed to serialize config for modification: {}", e))
                 }
@@ -294,5 +294,29 @@ impl ConfigActor {
         } else {
             Err("Config file not found".into())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::set_json_path;
+    use crate::common::config::Config;
+
+    #[test]
+    fn generic_set_initializes_optional_external_gap_objects() {
+        let mut value = serde_json::to_value(Config::default()).unwrap();
+
+        set_json_path(
+            &mut value,
+            "settings.layout.gaps.external.outer.top",
+            serde_json::json!(48.0),
+        )
+        .unwrap();
+
+        let config: Config = serde_json::from_value(value).unwrap();
+        assert_eq!(
+            config.settings.layout.gaps.external.unwrap().outer.unwrap().top,
+            48.0
+        );
     }
 }

--- a/src/actor/reactor.rs
+++ b/src/actor/reactor.rs
@@ -2758,9 +2758,11 @@ impl Reactor {
             else {
                 continue;
             };
-            self.layout_manager
-                .layout_engine
-                .update_space_display(space, Some(display_uuid.to_string()));
+            self.layout_manager.layout_engine.update_space_display(
+                space,
+                Some(display_uuid.to_string()),
+                !screen.is_builtin,
+            );
         }
         let current_screens = self.screens_for_current_spaces();
         self.space_activation_policy

--- a/src/actor/reactor/managers.rs
+++ b/src/actor/reactor/managers.rs
@@ -243,16 +243,18 @@ impl LayoutManager {
                 continue;
             }
             let display_uuid_opt = screen.display_uuid_owned();
+            let is_external = !screen.is_builtin;
             let gaps = reactor
                 .config
                 .settings
                 .layout
                 .gaps
-                .effective_for_display(display_uuid_opt.as_deref());
-            reactor
-                .layout_manager
-                .layout_engine
-                .update_space_display(space, display_uuid_opt.clone());
+                .effective_for_display(display_uuid_opt.as_deref(), is_external);
+            reactor.layout_manager.layout_engine.update_space_display(
+                space,
+                display_uuid_opt.clone(),
+                is_external,
+            );
             let mut layout =
                 reactor.layout_manager.layout_engine.calculate_layout_with_virtual_workspaces(
                     &reactor.state.windows,
@@ -308,12 +310,13 @@ impl LayoutManager {
             if let Some(screen) = reactor.space_state.screen_by_space(space) {
                 let screen_frame = screen.frame;
                 let display_uuid = screen.display_uuid_owned();
+                let is_external = !screen.is_builtin;
                 let gaps = reactor
                     .config
                     .settings
                     .layout
                     .gaps
-                    .effective_for_display(display_uuid.as_deref());
+                    .effective_for_display(display_uuid.as_deref(), is_external);
                 let active_workspace_for_space_has_fullscreen = active_space == Some(space)
                     && reactor
                         .layout_manager

--- a/src/actor/reactor/query.rs
+++ b/src/actor/reactor/query.rs
@@ -357,8 +357,12 @@ impl Reactor {
 
                     if let Some(screen) = screen_info {
                         let display_uuid = screen.display_uuid_opt();
-                        let gaps =
-                            self.config.settings.layout.gaps.effective_for_display(display_uuid);
+                        let gaps = self
+                            .config
+                            .settings
+                            .layout
+                            .gaps
+                            .effective_for_display(display_uuid, !screen.is_builtin);
                         self.layout_manager.layout_engine.calculate_layout_for_workspace(
                             &self.state.windows,
                             space,
@@ -596,7 +600,12 @@ impl Reactor {
             .query_workspace_layout(space_id, workspace_id)?;
         let screen = self.space_state.screen_by_space(space_id)?;
         let display_uuid = screen.display_uuid_owned();
-        let gaps = self.config.settings.layout.gaps.effective_for_display(display_uuid.as_deref());
+        let gaps = self
+            .config
+            .settings
+            .layout
+            .gaps
+            .effective_for_display(display_uuid.as_deref(), !screen.is_builtin);
         let target_frames = self.layout_manager.layout_engine.calculate_workspace_layout(
             space_id,
             snapshot.workspace_id,

--- a/src/actor/reactor/testing.rs
+++ b/src/actor/reactor/testing.rs
@@ -289,6 +289,7 @@ pub fn make_screen_snapshots(frames: Vec<CGRect>, spaces: Vec<Option<SpaceId>>) 
             frame,
             space,
             display_uuid: format!("test-display-{idx}"),
+            is_builtin: false,
             name: None,
         })
         .collect()
@@ -348,6 +349,7 @@ pub fn fullscreen_startup_space_state(
         frame: screen,
         space: None,
         display_uuid,
+        is_builtin: false,
         name: None,
     }]);
     state.fullscreen_spaces.insert(fullscreen_space);

--- a/src/actor/reactor/tests.rs
+++ b/src/actor/reactor/tests.rs
@@ -3666,6 +3666,7 @@ fn fullscreen_space_in_screen_params_does_not_trigger_topology_relayout() {
             frame,
             space: Some(space),
             display_uuid: display_uuid.clone(),
+            is_builtin: false,
             name: None,
         }]
     };
@@ -3787,6 +3788,7 @@ fn fullscreen_screen_params_preserves_window_layout() {
         frame: full_screen,
         space: None,
         display_uuid: "test-display-0".to_string(),
+        is_builtin: false,
         name: None,
     }]));
     apps.simulate_until_quiet(&mut reactor);

--- a/src/actor/spaces/tests.rs
+++ b/src/actor/spaces/tests.rs
@@ -9,6 +9,7 @@ fn make_screen(space: Option<SpaceId>) -> ScreenInfo {
         id: crate::sys::screen::ScreenId::new(1),
         frame: CGRect::new(CGPoint::new(0.0, 0.0), CGSize::new(1000.0, 800.0)),
         display_uuid: "display-1".to_string(),
+        is_builtin: false,
         name: Some("Display".to_string()),
         space,
     }
@@ -25,6 +26,7 @@ fn make_screen_with(
         id: crate::sys::screen::ScreenId::new(screen_id),
         frame: CGRect::new(CGPoint::new(origin_x, 0.0), CGSize::new(width, 800.0)),
         display_uuid: display_uuid.to_string(),
+        is_builtin: false,
         name: Some(display_uuid.to_string()),
         space,
     }

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -928,6 +928,9 @@ pub struct GapSettings {
     /// Inner gaps (space between windows)
     #[serde(default)]
     pub inner: InnerGaps,
+    /// Gap overrides applied to every external display
+    #[serde(default)]
+    pub external: Option<GapOverride>,
     /// Display-specific gap overrides keyed by display UUID
     #[serde(default)]
     pub per_display: HashMap<String, GapOverride>,
@@ -1165,6 +1168,19 @@ impl GapSettings {
         // Validate inner gaps
         issues.extend(self.inner.validate());
 
+        if let Some(overrides) = &self.external {
+            if let Some(outer) = &overrides.outer {
+                for issue in outer.validate() {
+                    issues.push(format!("external {issue}"));
+                }
+            }
+            if let Some(inner) = &overrides.inner {
+                for issue in inner.validate() {
+                    issues.push(format!("external {issue}"));
+                }
+            }
+        }
+
         for (uuid, overrides) in &self.per_display {
             if let Some(outer) = &overrides.outer {
                 for issue in outer.validate() {
@@ -1181,12 +1197,27 @@ impl GapSettings {
         issues
     }
 
-    pub fn effective_for_display(&self, display_uuid: Option<&str>) -> GapSettings {
+    pub fn effective_for_display(
+        &self,
+        display_uuid: Option<&str>,
+        is_external: bool,
+    ) -> GapSettings {
         let mut resolved = GapSettings {
             outer: self.outer.clone(),
             inner: self.inner.clone(),
+            external: None,
             per_display: HashMap::default(),
         };
+        if is_external {
+            if let Some(overrides) = &self.external {
+                if let Some(outer_override) = &overrides.outer {
+                    resolved.outer = outer_override.clone();
+                }
+                if let Some(inner_override) = &overrides.inner {
+                    resolved.inner = inner_override.clone();
+                }
+            }
+        }
         if let Some(uuid) = display_uuid {
             if let Some(overrides) = self.per_display.get(uuid) {
                 if let Some(outer_override) = &overrides.outer {
@@ -1619,6 +1650,71 @@ mod tests {
     use super::*;
     use crate::actor::reactor;
     use crate::layout_engine::{LayoutCommand, ResizeOrientation};
+
+    #[test]
+    fn external_gap_override_applies_only_to_external_displays() {
+        let gaps: GapSettings = toml::from_str(
+            r#"
+                [outer]
+                top = 10
+                left = 10
+                bottom = 10
+                right = 10
+
+                [external.outer]
+                top = 58
+                left = 10
+                bottom = 10
+                right = 10
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            gaps.effective_for_display(Some("built-in"), false).outer.top,
+            10.0
+        );
+        assert_eq!(
+            gaps.effective_for_display(Some("external"), true).outer.top,
+            58.0
+        );
+    }
+
+    #[test]
+    fn display_uuid_override_wins_over_external_override() {
+        let gaps: GapSettings = toml::from_str(
+            r#"
+                [outer]
+                top = 10
+
+                [external.outer]
+                top = 58
+
+                [per_display.special.outer]
+                top = 72
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(gaps.effective_for_display(Some("special"), true).outer.top, 72.0);
+    }
+
+    #[test]
+    fn external_gap_override_is_validated() {
+        let gaps: GapSettings = toml::from_str(
+            r#"
+                [external.outer]
+                top = -1
+            "#,
+        )
+        .unwrap();
+
+        assert!(
+            gaps.validate()
+                .iter()
+                .any(|issue| { issue.contains("external outer.top gap must be non-negative") })
+        );
+    }
 
     #[test]
     fn layout_insertion_point_supports_global_default_and_per_mode_override() {

--- a/src/layout_engine/engine.rs
+++ b/src/layout_engine/engine.rs
@@ -159,6 +159,7 @@ pub struct LayoutEngine {
     layout_settings: LayoutSettings,
     broadcast_tx: Option<BroadcastSender>,
     space_display_map: HashMap<SpaceId, Option<String>>,
+    space_display_external: HashMap<SpaceId, bool>,
     display_last_space: HashMap<String, SpaceId>,
     persistence: PersistenceState,
     /// Set only while a master-file startup restore is waiting for the first display snapshot.
@@ -1211,12 +1212,19 @@ impl LayoutEngine {
         Some((workspace_id, workspace_name))
     }
 
-    pub fn update_space_display(&mut self, space: SpaceId, display_uuid: Option<String>) {
+    pub fn update_space_display(
+        &mut self,
+        space: SpaceId,
+        display_uuid: Option<String>,
+        is_external: bool,
+    ) {
         if let Some(uuid) = display_uuid {
             self.space_display_map.insert(space, Some(uuid.clone()));
+            self.space_display_external.insert(space, is_external);
             self.display_last_space.insert(uuid, space);
         } else {
             self.space_display_map.remove(&space);
+            self.space_display_external.remove(&space);
         }
     }
 
@@ -1261,6 +1269,9 @@ impl LayoutEngine {
         if let Some(uuid) = self.space_display_map.remove(&old_space) {
             self.space_display_map.insert(new_space, uuid);
         }
+        if let Some(is_external) = self.space_display_external.remove(&old_space) {
+            self.space_display_external.insert(new_space, is_external);
+        }
 
         for (_uuid, space) in self.display_last_space.iter_mut() {
             if *space == old_space {
@@ -1277,6 +1288,8 @@ impl LayoutEngine {
         self.space_display_map.retain(|_, uuid_opt| {
             uuid_opt.as_ref().map(|uuid| active.contains(uuid.as_str())).unwrap_or(false)
         });
+        self.space_display_external
+            .retain(|space, _| self.space_display_map.contains_key(space));
     }
 
     pub fn new(
@@ -1298,6 +1311,7 @@ impl LayoutEngine {
             layout_settings: layout_settings.clone(),
             broadcast_tx,
             space_display_map: HashMap::default(),
+            space_display_external: HashMap::default(),
             display_last_space: HashMap::default(),
             persistence: PersistenceState::default(),
             startup_restore_pending: false,
@@ -1343,7 +1357,8 @@ impl LayoutEngine {
         let Some(layout) = self.workspace_layouts.active(resize.space, resize.workspace_id) else {
             return;
         };
-        let gaps = self.layout_settings.gaps.effective_for_display(display_uuid);
+        let is_external = self.space_display_external.get(&resize.space).copied().unwrap_or(false);
+        let gaps = self.layout_settings.gaps.effective_for_display(display_uuid, is_external);
         let previous_selection = self.workspace_tree(resize.workspace_id).selected_window(layout);
         let tree = self.workspace_tree_mut(resize.workspace_id);
         let _ = tree.select_window(layout, resize.window);
@@ -1651,8 +1666,12 @@ impl LayoutEngine {
                         );
                         continue;
                     };
-                    let gaps =
-                        self.layout_settings.gaps.effective_for_display(display_uuid.as_deref());
+                    let is_external =
+                        self.space_display_external.get(&space).copied().unwrap_or(false);
+                    let gaps = self
+                        .layout_settings
+                        .gaps
+                        .effective_for_display(display_uuid.as_deref(), is_external);
                     self.workspace_tree_mut(ws_id).on_window_resized(
                         layout,
                         wid,
@@ -3920,7 +3939,7 @@ mod tests {
             ),
         );
 
-        let gaps = engine.layout_settings.gaps.effective_for_display(None);
+        let gaps = engine.layout_settings.gaps.effective_for_display(None, false);
         let positions = engine.calculate_layout_with_virtual_workspaces(
             &window_store,
             space,

--- a/src/layout_engine/engine/persistence/snapshot.rs
+++ b/src/layout_engine/engine/persistence/snapshot.rs
@@ -69,6 +69,7 @@ impl PersistedLayout {
             layout_settings: LayoutSettings::default(),
             broadcast_tx: None,
             space_display_map: self.space_display_map,
+            space_display_external: HashMap::default(),
             display_last_space: self.display_last_space,
             persistence: self.persistence,
             startup_restore_pending: false,

--- a/src/layout_engine/engine/persistence/tests.rs
+++ b/src/layout_engine/engine/persistence/tests.rs
@@ -1395,7 +1395,7 @@ fn master_restore_resolves_old_space_id_by_display_identity() {
         (saved_b, "display-b", LayoutMode::Scrolling),
     ] {
         let _ = snapshot.handle_event(&mut snapshot_store, LayoutEvent::SpaceExposed(space, size));
-        snapshot.update_space_display(space, Some(display.into()));
+        snapshot.update_space_display(space, Some(display.into()), false);
         let workspace = snapshot.active_workspace(space).unwrap();
         assert!(snapshot.switch_workspace_layout_mode(&snapshot_store, space, workspace, mode,));
     }
@@ -1410,7 +1410,7 @@ fn master_restore_resolves_old_space_id_by_display_identity() {
     let mut engine = test_engine();
     let mut window_store = WindowStore::default();
     let _ = engine.handle_event(&mut window_store, LayoutEvent::SpaceExposed(current_a, size));
-    engine.update_space_display(current_a, Some("display-a".into()));
+    engine.update_space_display(current_a, Some("display-a".into()), false);
     engine
         .restore_layout(
             path.clone(),
@@ -1464,7 +1464,7 @@ fn startup_restore_remaps_saved_space_by_display_identity_once() {
     let mut snapshot_store = WindowStore::default();
     let _ =
         snapshot.handle_event(&mut snapshot_store, LayoutEvent::SpaceExposed(saved_space, size));
-    snapshot.update_space_display(saved_space, Some(display.clone()));
+    snapshot.update_space_display(saved_space, Some(display.clone()), false);
     let path = std::env::temp_dir().join(format!(
         "rift-startup-space-remap-test-{}-{}.ron",
         std::process::id(),
@@ -1497,7 +1497,7 @@ fn startup_restore_handles_space_id_swaps_between_displays() {
     let mut snapshot_store = WindowStore::default();
     for (space, display) in [(space_a, "display-a"), (space_b, "display-b")] {
         let _ = snapshot.handle_event(&mut snapshot_store, LayoutEvent::SpaceExposed(space, size));
-        snapshot.update_space_display(space, Some(display.into()));
+        snapshot.update_space_display(space, Some(display.into()), false);
         let workspace = snapshot.active_workspace(space).unwrap();
         assert!(snapshot.virtual_workspace_manager.rename_workspace(
             space,

--- a/src/model/server.rs
+++ b/src/model/server.rs
@@ -252,6 +252,7 @@ impl<'de> Deserialize<'de> for RuntimeDisplayData {
             id: ScreenId::new(helper.screen_id),
             frame: helper.frame,
             display_uuid: helper.uuid,
+            is_builtin: false,
             name: helper.name,
             space: helper.space.map(SpaceId::new),
         };
@@ -320,6 +321,7 @@ mod tests {
             id: ScreenId::new(7),
             frame: CGRect::new(CGPoint::new(10.0, 20.0), CGSize::new(300.0, 400.0)),
             display_uuid: "display-uuid".to_string(),
+            is_builtin: false,
             name: Some("Primary".to_string()),
             space: Some(SpaceId::new(42)),
         };

--- a/src/model/space_activation.rs
+++ b/src/model/space_activation.rs
@@ -267,6 +267,7 @@ mod tests {
             id: ScreenId::new(screen_id),
             frame: CGRect::new(CGPoint::new(0.0, 0.0), CGSize::new(0.0, 0.0)),
             display_uuid: display_uuid.unwrap_or_default().to_string(),
+            is_builtin: false,
             name: None,
             space: space.map(SpaceId::new),
         }

--- a/src/sys/screen.rs
+++ b/src/sys/screen.rs
@@ -64,6 +64,8 @@ pub struct ScreenInfo {
     #[serde(with = "CGRectDef")]
     pub frame: CGRect,
     pub display_uuid: String,
+    #[serde(skip)]
+    pub is_builtin: bool,
     pub name: Option<String>,
     pub space: Option<SpaceId>,
 }
@@ -210,6 +212,7 @@ impl<S: System> ScreenCache<S> {
                     id: cg_id,
                     frame,
                     display_uuid,
+                    is_builtin: self.system.is_builtin(cg_id.as_u32()),
                     name: ns_screens.iter().find(|s| s.cg_id == cg_id).and_then(|s| s.name.clone()),
                     space: None,
                 }
@@ -425,6 +428,7 @@ pub trait System {
     fn cg_screens(&self) -> Result<Vec<CGScreenInfo>, CGError>;
     fn display_uuid(&self, screen: &CGScreenInfo) -> CFRetained<CFString>;
     fn ns_screens(&self) -> Vec<NSScreenInfo>;
+    fn is_builtin(&self, _did: u32) -> bool { false }
     fn notch_height(&self, _did: u32) -> f64 { 0.0 }
 }
 
@@ -519,10 +523,11 @@ impl System for Actual {
             .collect()
     }
 
+    fn is_builtin(&self, did: u32) -> bool { unsafe { super::skylight::CGDisplayIsBuiltin(did) } }
+
     fn notch_height(&self, did: u32) -> f64 {
         let screens = NSScreen::screens(self.mtm);
-        let builtin = unsafe { super::skylight::CGDisplayIsBuiltin(did) };
-        if !builtin {
+        if !self.is_builtin(did) {
             return 0.0;
         }
 
@@ -754,6 +759,7 @@ mod test {
     struct Stub {
         cg_screens: Vec<CGScreenInfo>,
         ns_screens: Vec<NSScreenInfo>,
+        builtin_id: Option<u32>,
     }
     impl System for Stub {
         fn cg_screens(&self) -> Result<Vec<CGScreenInfo>, CGError> { Ok(self.cg_screens.clone()) }
@@ -763,6 +769,8 @@ mod test {
         }
 
         fn ns_screens(&self) -> Vec<NSScreenInfo> { self.ns_screens.clone() }
+
+        fn is_builtin(&self, did: u32) -> bool { self.builtin_id == Some(did) }
 
         fn notch_height(&self, _did: u32) -> f64 { 0.0 }
     }
@@ -839,11 +847,15 @@ mod test {
                     name: None,
                 },
             ],
+            builtin_id: Some(1),
         };
         let mut sc = ScreenCache::new_with(stub);
         let (screens, _) = sc.refresh().unwrap();
 
         let secondary = screens.iter().find(|screen| screen.id == ScreenId(1)).unwrap();
+        let external = screens.iter().find(|screen| screen.id == ScreenId(3)).unwrap();
+        assert!(secondary.is_builtin);
+        assert!(!external.is_builtin);
         assert_eq!(
             secondary.frame,
             super::constrain_display_bounds(

--- a/src/ui/mission_control.rs
+++ b/src/ui/mission_control.rs
@@ -1359,6 +1359,7 @@ impl MissionControlOverlay {
                 id: ScreenId::new(0),
                 frame: self.frame,
                 display_uuid: String::new(),
+                is_builtin: false,
                 name: None,
                 space: None,
             },


### PR DESCRIPTION
## Summary

- add optional external-display gap overrides
- preserve global defaults for built-in displays
- keep UUID-specific overrides as the most specific rule
- carry the existing macOS built-in display classification through layout resolution

## Configuration

```toml
[settings.layout.gaps.external.outer]
top = 48
left = 0
bottom = 0
right = 0
```

Resolution order is global defaults, external overrides, then UUID-specific overrides.

## Checks

- focused gap resolution, validation, and display classification tests: passed
- `cargo check --all-targets`: passed
- `cargo +nightly fmt --all -- --check`: passed
- `cargo test --all-targets`: 564 passed; one unrelated test failed identically on untouched upstream `main` (`topology_change_clears_stale_pending_hide_target_before_next_workspace_layout`)
- diff whitespace check: passed