### PR TITLE
fix: keep tracking the dragged frame while a drag swap is pending

### DIFF
--- a/src/actor/reactor/events/window.rs
+++ b/src/actor/reactor/events/window.rs
@@ -334,7 +334,13 @@ pub fn handle_window_frame_changed(
                 },
             };
         }
-        if let DragState::Active { session } = &mut drag.drag_state {
+        // A pending swap is still a live drag: `last_frame` and `settled_space` are
+        // what mouse-up uses to place the window and choose its final space, so
+        // freezing them here strands the window at the position where the swap
+        // candidate was first scored instead of where the user released it.
+        if let DragState::Active { session } | DragState::PendingSwap { session, .. } =
+            &mut drag.drag_state
+        {
             session.last_frame = new_frame;
             session.layout_dirty = true;
             if session.settled_space != new_space {

--- a/src/actor/reactor/tests.rs
+++ b/src/actor/reactor/tests.rs
@@ -1449,6 +1449,72 @@ fn cross_display_drag_clears_source_floating_position() {
 }
 
 #[test]
+fn floating_drag_with_latched_swap_stores_the_release_frame() {
+    let (mut reactor, floating_wid, space1, _screen, floating_frame) =
+        reactor_with_floating_window();
+    let workspace = reactor
+        .layout_manager
+        .layout_engine
+        .active_workspace(space1)
+        .expect("workspace");
+
+    // A tiled neighbour under the floating window. Overlapping it fully makes the
+    // drag-swap scorer latch a swap candidate on the first drag frame.
+    let tiled_wid = WindowId::new(1, 2);
+    reactor.add_test_window(tiled_wid, WindowServerId::new(102), Some(space1), floating_frame);
+    assert!(reactor.assign_test_window_to_workspace(space1, tiled_wid, workspace));
+    reactor.send_layout_event(LayoutEvent::WindowAdded(space1, tiled_wid));
+    assert!(!reactor.layout_manager.layout_engine.is_window_floating(tiled_wid));
+
+    let latched_frame = CGRect::new(
+        CGPoint::new(floating_frame.origin.x + 10., floating_frame.origin.y + 10.),
+        floating_frame.size,
+    );
+    reactor.handle_event(Event::WindowFrameChanged(
+        floating_wid,
+        latched_frame,
+        None,
+        Requested(false),
+        Some(MouseState::Down),
+    ));
+    assert!(
+        matches!(reactor.drag_manager.drag_state, DragState::PendingSwap { .. }),
+        "expected the overlap to latch a pending swap; got {:?}",
+        reactor.drag_manager.drag_state
+    );
+
+    // Keep dragging with the swap still latched, then release.
+    let released_frame = CGRect::new(
+        CGPoint::new(floating_frame.origin.x + 40., floating_frame.origin.y + 60.),
+        floating_frame.size,
+    );
+    reactor.handle_event(Event::WindowFrameChanged(
+        floating_wid,
+        released_frame,
+        None,
+        Requested(false),
+        Some(MouseState::Down),
+    ));
+    assert!(matches!(
+        reactor.drag_manager.drag_state,
+        DragState::PendingSwap { .. }
+    ));
+    reactor.handle_event(Event::MouseUp);
+
+    assert!(matches!(reactor.drag_manager.drag_state, DragState::Inactive));
+    assert!(reactor.layout_manager.layout_engine.is_window_floating(floating_wid));
+    let stored = reactor
+        .layout_manager
+        .layout_engine
+        .get_floating_position(space1, workspace, floating_wid)
+        .expect("floating position");
+    assert!(
+        stored.same_as(released_frame),
+        "mouse-up must store where the window was released, not where the swap latched: {stored:?}"
+    );
+}
+
+#[test]
 fn stale_user_space_disappearance_does_not_restore_old_display_assignment() {
     let (mut reactor, wid, wsid, space1, space2, _) = reactor_with_window_moved_to_space2();
 


### PR DESCRIPTION
## Summary
A floating window dragged over a tiled window snaps back to an earlier point in the drag on release, instead of staying where it was dropped.

## Root cause
`maybe_swap_on_drag` moves the session from `DragState::Active` to `DragState::PendingSwap` once a swap candidate latches. `handle_window_frame_changed` only refreshed `session.last_frame` / `settled_space` for `Active`, so the rest of the drag was not tracked. `handle_mouse_up` then stored the frozen `last_frame` as the floating position and the next arrange moved the window there.

`RUST_LOG=rift_wm=trace`, one drag of a floating Notes window:
```
18:27:29.415  Detected swap candidate; deferring until MouseUp, wid=Notes
18:27:29.645  MouseUp -> SetWindowFrame(Notes, origin: (671, 512))   <- frame from 29.415, not release
```

## Changes
- `events/window.rs`: refresh the drag session for `Active | PendingSwap`.
- `tests.rs`: `floating_drag_with_latched_swap_stores_the_release_frame`, red on `main` with the stored position at the latch point, green here.

## Test plan
- `cargo test --locked -- --test-threads=1` (only failure is `topology_change_clears_stale_pending_hide_target_before_next_workspace_layout`, which also fails on unmodified `main`)
- `cargo +nightly fmt --all --check`, `cargo check --locked`
- Running the patched build daily; drift is gone.
