### PR TITLE
feat(scrolling): add optional continuous trackpad scrolling

### DIFF
--- a/rift.default.toml
+++ b/rift.default.toml
@@ -127,6 +127,9 @@ focus_navigation_style = "niri"
 # animate = false
 
 [settings.layout.scrolling.gestures]
+# Experimental continuous tracking; false preserves distance-based stepping.
+# Uses immediate position updates even when layout animations are enabled.
+smooth = false
 # Enable horizontal scroll gestures to switch columns
 enabled = false
 # Invert horizontal direction (swap left/right)

--- a/src/actor/app.rs
+++ b/src/actor/app.rs
@@ -339,7 +339,7 @@ pub enum Request {
 
     SetWindowFrame(WindowId, CGRect, TransactionId, bool),
     SetBatchWindowFrame(Vec<(WindowId, CGRect)>, TransactionId, bool),
-    /// Position-only batch reserved for virtual workspace switches.
+    /// Position-only batch for workspace switches and interactive strip movement.
     SetWorkspaceSwitchPositions(Vec<(WindowId, CGPoint)>, TransactionId, bool),
     SetWindowPos(WindowId, CGPoint, TransactionId, bool),
     AnimationFrame {

--- a/src/actor/gesture_tap.rs
+++ b/src/actor/gesture_tap.rs
@@ -8,6 +8,7 @@
 use std::cell::{Cell, RefCell};
 use std::panic::AssertUnwindSafe;
 use std::rc::Rc;
+use std::time::Duration;
 
 use objc2_core_foundation::{CGPoint, CGRect};
 use objc2_core_graphics::{
@@ -43,6 +44,8 @@ pub type Sender = actor::Sender<GestureRequest>;
 pub type Receiver = actor::Receiver<GestureRequest>;
 
 pub struct GestureTap {
+    pending_scroll: Cell<f64>,
+    scroll_flush_requested: tokio::sync::Notify,
     config: RefCell<Config>,
     wm_sender: wm_controller::Sender,
     swipe: RefCell<Option<SwipeHandler>>,
@@ -98,6 +101,7 @@ impl SwipeState {
 
 #[derive(Debug, Clone)]
 struct ScrollConfig {
+    smooth: bool,
     consume: bool,
     invert_horizontal: bool,
     vertical_tolerance: f64,
@@ -109,6 +113,7 @@ impl ScrollConfig {
     fn from_config(config: &Config) -> Option<Self> {
         let g = &config.settings.layout.scrolling.gestures;
         g.enabled.then(|| Self {
+            smooth: g.smooth,
             consume: config.settings.gestures.consume_dock_swipe,
             invert_horizontal: g.invert_horizontal,
             vertical_tolerance: normalize_tolerance(g.vertical_tolerance),
@@ -236,6 +241,8 @@ impl GestureTap {
         let default_layout_mode = config.settings.layout.mode;
         let (swipe, scroll) = Self::build_gesture_handlers(&config);
         Self {
+            pending_scroll: Cell::new(0.0),
+            scroll_flush_requested: tokio::sync::Notify::new(),
             config: RefCell::new(config),
             wm_sender,
             swipe: RefCell::new(swipe),
@@ -253,6 +260,8 @@ impl GestureTap {
         let mut requests_rx = self.requests_rx.take().unwrap();
         let (recovery_tx, mut recovery_rx) = tokio::sync::mpsc::unbounded_channel();
         let this = Rc::new(self);
+        let mut scroll_timer = crate::sys::timer::Timer::manual();
+        let mut scroll_scheduled = false;
 
         if this.gesture_handlers_enabled() {
             this.create_and_install_tap(&recovery_tx);
@@ -260,6 +269,19 @@ impl GestureTap {
 
         loop {
             tokio::select! {
+                _ = this.scroll_flush_requested.notified() => {
+                    if !scroll_scheduled {
+                        scroll_timer.set_next_fire(Duration::from_secs_f64(1.0 / 60.0));
+                        scroll_scheduled = true;
+                    }
+                }
+                _ = scroll_timer.next(), if scroll_scheduled => {
+                    scroll_scheduled = false;
+                    let delta = this.pending_scroll.replace(0.0);
+                    if delta != 0.0 {
+                        this.send_layout_command(LC::ScrollStrip { delta });
+                    }
+                }
                 recovery = recovery_rx.recv() => {
                     let Some(Recovery::TapInvalidated(generation)) = recovery else { break };
                     this.rebuild_invalidated_tap(generation, &recovery_tx);
@@ -290,6 +312,7 @@ impl GestureTap {
                 map.extend(modes);
             }
             GestureRequest::SpaceStateUpdated(space_state) => {
+                self.pending_scroll.set(0.0);
                 *self.screen_spaces.borrow_mut() = space_state
                     .screens
                     .into_iter()
@@ -619,7 +642,13 @@ impl GestureTap {
             dx = -dx;
         }
         state.accum_dx += dx;
-        if state.accum_dx.abs() >= cfg.distance_pct {
+        if cfg.smooth {
+            // Keep the final partial movement when contacts lift. A single timer
+            // flushes all samples in a frame, including immediate reversals.
+            self.pending_scroll.set(self.pending_scroll.get() + state.accum_dx);
+            state.accum_dx = 0.0;
+            self.scroll_flush_requested.notify_one();
+        } else if state.accum_dx.abs() >= cfg.distance_pct {
             let delta = state.accum_dx;
             state.accum_dx = 0.0;
             self.send_layout_command(LC::ScrollStrip { delta });
@@ -636,6 +665,7 @@ impl GestureTap {
     }
 
     fn reset_gesture_state(&self) {
+        self.pending_scroll.set(0.0);
         if let Some(handler) = self.swipe.borrow().as_ref() {
             handler.state.borrow_mut().reset();
         }
@@ -779,6 +809,60 @@ unsafe extern "C-unwind" fn gesture_tap_invalidated(user_info: *mut std::ffi::c_
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    fn frame(x: f64, y: f64, count: usize) -> ScrollTouchFrame {
+        let mut frame = ScrollTouchFrame::default();
+        frame.len = count;
+        for i in 0..count {
+            frame.paths[i] = TouchPath { index: i as isize, x, y };
+        }
+        frame
+    }
+
+    #[test]
+    fn smooth_scroll_preserves_small_motion_reversal_and_release_tail() {
+        let mut config = Config::default();
+        config.settings.layout.scrolling.gestures.enabled = true;
+        config.settings.layout.scrolling.gestures.smooth = true;
+        let (tx, mut rx) = actor::channel();
+        let (_, requests) = actor::channel();
+        let tap = GestureTap::new(config, tx, requests);
+        let scroll = tap.scroll.borrow();
+        let handler = scroll.as_ref().unwrap();
+        tap.handle_scroll(handler, frame(0.3, 0.3, 3));
+        tap.handle_scroll(handler, frame(0.31, 0.3, 3));
+        tap.handle_scroll(handler, frame(0.315, 0.3, 3));
+        tap.handle_scroll(handler, frame(0.312, 0.3, 3));
+        tap.handle_scroll(handler, frame(0.0, 0.0, 0));
+        assert!((tap.pending_scroll.get() - 0.012).abs() < 1e-9);
+        // Samples are accumulated for the timer, never sent individually.
+        assert!(rx.try_recv().is_err());
+        drop(scroll);
+        tap.reset_gesture_state();
+        assert_eq!(tap.pending_scroll.get(), 0.0);
+    }
+
+    #[test]
+    fn legacy_scroll_still_waits_for_distance_threshold() {
+        let mut config = Config::default();
+        config.settings.layout.scrolling.gestures.enabled = true;
+        let (tx, mut rx) = actor::channel();
+        let (_, requests) = actor::channel();
+        let tap = GestureTap::new(config, tx, requests);
+        let scroll = tap.scroll.borrow();
+        let handler = scroll.as_ref().unwrap();
+        tap.handle_scroll(handler, frame(0.3, 0.3, 3));
+        tap.handle_scroll(handler, frame(0.31, 0.3, 3));
+        assert!(rx.try_recv().is_err());
+        tap.handle_scroll(handler, frame(0.40, 0.3, 3));
+        assert!(matches!(rx.try_recv().unwrap().1,
+            WmEvent::Command(WmCommand::ReactorCommand(reactor::Command::Layout(
+                LC::ScrollStrip { delta }
+            ))) if (delta - 0.1).abs() < 1e-9));
+        assert_eq!(tap.pending_scroll.get(), 0.0);
+    }
+
     use super::{
         ContactDisposition, GestureState, PathDelta, classify_contacts, select_moving_cohort,
     };

--- a/src/actor/reactor.rs
+++ b/src/actor/reactor.rs
@@ -1900,11 +1900,13 @@ impl Reactor {
                 );
             }
             Event::Command(Command::Layout(command)) => {
+                let direct_positions = matches!(command, layout::LayoutCommand::ScrollStrip { .. })
+                    && self.config.settings.layout.scrolling.gestures.smooth;
                 let post_arrange_mouse_warp =
                     self.config.settings.mouse_follows_focus.then(|| self.main_window()).flatten();
                 let command_space = self.command_context_space();
                 let (visible_spaces, visible_space_centers) = self.visible_spaces_for_layout(false);
-                return command_workflow::handle_command_layout(
+                let mut outcome = command_workflow::handle_command_layout(
                     &mut self.state,
                     &mut self.layout_manager,
                     &mut self.workspace_switch_manager,
@@ -1915,7 +1917,12 @@ impl Reactor {
                         visible_space_centers,
                         post_arrange_mouse_warp,
                     },
-                );
+                )?;
+                outcome.arrange.direct_positions = direct_positions;
+                if direct_positions {
+                    outcome.arrange.space_scope = command_space;
+                }
+                return Ok(outcome);
             }
             Event::Command(Command::Reactor(ReactorCommand::MoveWindowToDisplay {
                 selector,
@@ -2161,6 +2168,15 @@ impl Reactor {
         if outcome.arrange.requested && (!self.is_in_drag() || outcome.arrange.window_was_destroyed)
         {
             for _ in 0..outcome.arrange.passes.max(1) {
+                if outcome.arrange.direct_positions {
+                    layout_changed |=
+                        LayoutManager::update_scroll_layout(self, outcome.arrange.space_scope)
+                            .unwrap_or_else(|error| {
+                                warn!(?error, "Scroll layout update failed");
+                                false
+                            });
+                    continue;
+                }
                 layout_changed |= self.update_layout_or_warn(
                     outcome.arrange.is_resize,
                     matches!(

--- a/src/actor/reactor/animation.rs
+++ b/src/actor/reactor/animation.rs
@@ -22,6 +22,7 @@ pub type Receiver = mpsc::UnboundedReceiver<Message>;
 pub enum Message {
     Replace(Animation),
     SkipToEnd(Animation),
+    DirectPositions(Animation),
 }
 
 #[derive(Debug, Default)]
@@ -118,6 +119,11 @@ impl AnimationManager {
                 animation.skip_to_end();
                 None
             }
+            Message::DirectPositions(animation) => {
+                self.finish_active();
+                animation.skip_to_end_positions();
+                None
+            }
         }
     }
 
@@ -145,6 +151,26 @@ impl AnimationManager {
         layout: &[(WindowId, CGRect)],
         is_resize: bool,
         skip_wid: Option<WindowId>,
+    ) -> bool {
+        Self::animate_layout_inner(reactor, space, layout, is_resize, skip_wid, false)
+    }
+
+    pub fn scroll_layout(
+        reactor: &mut Reactor,
+        space: SpaceId,
+        layout: &[(WindowId, CGRect)],
+        skip_wid: Option<WindowId>,
+    ) -> bool {
+        Self::animate_layout_inner(reactor, space, layout, false, skip_wid, true)
+    }
+
+    fn animate_layout_inner(
+        reactor: &mut Reactor,
+        space: SpaceId,
+        layout: &[(WindowId, CGRect)],
+        is_resize: bool,
+        skip_wid: Option<WindowId>,
+        direct_positions: bool,
     ) -> bool {
         let Some(active_ws) = reactor.layout_manager.layout_engine.active_workspace(space) else {
             return false;
@@ -249,7 +275,9 @@ impl AnimationManager {
             let skip_anim = is_resize || !layout_animate || low_power;
 
             if let Some(tx) = &reactor.animation_tx {
-                let message = if skip_anim {
+                let message = if direct_positions {
+                    Message::DirectPositions(anim)
+                } else if skip_anim {
                     Message::SkipToEnd(anim)
                 } else {
                     Message::Replace(anim)
@@ -258,10 +286,15 @@ impl AnimationManager {
                     match err.0 {
                         Message::Replace(animation) => animation.skip_to_end(),
                         Message::SkipToEnd(animation) => animation.skip_to_end(),
+                        Message::DirectPositions(animation) => animation.skip_to_end_positions(),
                     }
                 }
             } else {
-                anim.skip_to_end();
+                if direct_positions {
+                    anim.skip_to_end_positions();
+                } else {
+                    anim.skip_to_end();
+                }
             }
         }
 
@@ -509,6 +542,21 @@ impl Animation {
         }
     }
 
+    fn skip_to_end_positions(&self) {
+        for window in &self.windows {
+            let request = if window.start.size.same_as(window.finish.size) {
+                Request::SetWorkspaceSwitchPositions(
+                    vec![(window.wid, window.finish.origin)],
+                    window.txid,
+                    true,
+                )
+            } else {
+                Request::SetWindowFrame(window.wid, window.finish, window.txid, true)
+            };
+            _ = window.handle.send(request);
+        }
+    }
+
     pub fn is_empty(&self) -> bool { self.windows.is_empty() }
 
     fn begin(&self) { self.begin_windows_not_in(&[]); }
@@ -630,6 +678,42 @@ mod tests {
     use objc2_core_foundation::{CGPoint, CGSize};
 
     use super::*;
+
+    #[test]
+    fn direct_scroll_positions_preserve_size_changes_and_finish_active_animation() {
+        let (tx, mut rx) = crate::actor::channel();
+        let handle = AppThreadHandle::new_for_test(tx);
+        let wid = WindowId::new(1, 1);
+        let mut manager = AnimationManager::new();
+        manager.handle_message(Message::Replace(animation(
+            &handle,
+            wid,
+            rect(0., 0., 100., 100.),
+            rect(100., 0., 100., 100.),
+        )));
+        let _ = collect_requests(&mut rx);
+        manager.handle_message(Message::DirectPositions(animation(
+            &handle,
+            wid,
+            rect(100., 0., 100., 100.),
+            rect(120., 0., 100., 100.),
+        )));
+        let requests = collect_requests(&mut rx);
+        assert!(manager.active.is_none());
+        assert!(
+            matches!(requests.last(), Some(Request::SetWorkspaceSwitchPositions(p, _, true))
+            if p.as_slice() == [(wid, CGPoint::new(120., 0.))])
+        );
+        manager.handle_message(Message::DirectPositions(animation(
+            &handle,
+            wid,
+            rect(120., 0., 100., 100.),
+            rect(130., 0., 200., 100.),
+        )));
+        let requests = collect_requests(&mut rx);
+        assert_eq!(requests.len(), 1);
+        assert_set_window_frame(&requests[0], wid, rect(130., 0., 200., 100.));
+    }
 
     fn rect(origin_x: f64, origin_y: f64, width: f64, height: f64) -> CGRect {
         CGRect::new(CGPoint::new(origin_x, origin_y), CGSize::new(width, height))

--- a/src/actor/reactor/events/outcome.rs
+++ b/src/actor/reactor/events/outcome.rs
@@ -86,6 +86,7 @@ pub(crate) struct EventOutcome {
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub(crate) struct ArrangeRequest {
+    pub(crate) direct_positions: bool,
     pub(crate) requested: bool,
     pub(crate) passes: u8,
     pub(crate) is_resize: bool,
@@ -148,6 +149,7 @@ impl EventOutcome {
             self.arrange.requested = true;
             self.arrange.passes = self.arrange.passes.saturating_add(other.arrange.passes).max(1);
             self.arrange.is_resize |= other.arrange.is_resize;
+            self.arrange.direct_positions |= other.arrange.direct_positions;
             self.arrange.window_was_destroyed |= other.arrange.window_was_destroyed;
         }
         self.focused_window = other.focused_window.or(self.focused_window);
@@ -192,6 +194,7 @@ impl EventOutcome {
             layout_events: Vec::new(),
             layout_responses: Vec::new(),
             arrange: ArrangeRequest {
+                direct_positions: false,
                 requested: true,
                 passes: 1,
                 is_resize,

--- a/src/actor/reactor/managers.rs
+++ b/src/actor/reactor/managers.rs
@@ -216,7 +216,15 @@ impl LayoutManager {
         space_scope: Option<SpaceId>,
     ) -> Result<bool, crate::model::reactor::ReactorError> {
         let layout_result = Self::calculate_layout(reactor, space_scope);
-        Self::apply_layout(reactor, layout_result, is_resize, is_workspace_switch)
+        Self::apply_layout(reactor, layout_result, is_resize, is_workspace_switch, false)
+    }
+
+    pub fn update_scroll_layout(
+        reactor: &mut Reactor,
+        space_scope: Option<SpaceId>,
+    ) -> Result<bool, crate::model::reactor::ReactorError> {
+        let layout = Self::calculate_layout(reactor, space_scope);
+        Self::apply_layout(reactor, layout, false, false, true)
     }
 
     fn calculate_layout(reactor: &mut Reactor, space_scope: Option<SpaceId>) -> LayoutResult {
@@ -293,6 +301,7 @@ impl LayoutManager {
         layout_result: LayoutResult,
         is_resize: bool,
         is_workspace_switch: bool,
+        direct_positions: bool,
     ) -> Result<bool, crate::model::reactor::ReactorError> {
         let main_window = reactor.main_window();
         trace!(?main_window);
@@ -407,7 +416,10 @@ impl LayoutManager {
                 }
             }
 
-            if is_workspace_switch {
+            if direct_positions {
+                any_frame_changed |=
+                    AnimationManager::scroll_layout(reactor, space, &layout, skip_wid);
+            } else if is_workspace_switch {
                 any_frame_changed |=
                     AnimationManager::workspace_switch_layout(reactor, space, &layout, skip_wid);
             } else if reactor.workspace_switch_manager.active_workspace_switch.is_some() {

--- a/src/actor/reactor/tests.rs
+++ b/src/actor/reactor/tests.rs
@@ -2352,6 +2352,37 @@ fn non_workspace_instant_layout_keeps_full_frame_batch() {
 }
 
 #[test]
+fn smooth_scroll_command_uses_positions_and_leaves_focus_unchanged() {
+    let (mut apps, mut reactor) = test_context();
+    let screen = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
+    let space = SpaceId::new(1);
+    let focused = WindowId::new(1, 2);
+    reactor.config.settings.layout.scrolling.gestures.smooth = true;
+    reactor.handle_event(space_state_event(vec![screen], vec![Some(space)]));
+    make_active_app(&mut apps, &mut reactor, 1, make_windows(2), Some(focused));
+    reactor.handle_test_layout_command(LayoutCommand::SetWorkspaceLayout {
+        workspace: None,
+        mode: LayoutMode::Scrolling,
+    });
+    apps.simulate_until_quiet(&mut reactor);
+    let _ = apps.requests();
+    let before = reactor.main_window();
+    reactor.handle_test_layout_command(LayoutCommand::ScrollStrip { delta: -0.02 });
+    let requests = apps.requests();
+    assert!(
+        requests.iter().any(|r| matches!(r, Request::SetWorkspaceSwitchPositions(..))),
+        "scroll must use position-only writes: {requests:?}"
+    );
+    assert!(
+        !requests
+            .iter()
+            .any(|r| matches!(r, Request::SetWindowFrame(..) | Request::SetBatchWindowFrame(..))),
+        "pure scrolling must not resize windows: {requests:?}"
+    );
+    assert_eq!(reactor.main_window(), before);
+}
+
+#[test]
 fn workspace_switch_layout_falls_back_to_full_frames_for_size_changes() {
     let (mut apps, mut reactor) = test_context();
     let screen = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -851,6 +851,9 @@ pub enum MasterStackNewWindowPlacement {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub struct ScrollingGestureSettings {
+    /// Coalesce continuous motion at 60 Hz instead of dispatching distance steps.
+    #[serde(default)]
+    pub smooth: bool,
     /// Enable horizontal scroll gestures to switch columns
     #[serde(default = "no")]
     pub enabled: bool,
@@ -877,6 +880,7 @@ pub struct ScrollingGestureSettings {
 impl Default for ScrollingGestureSettings {
     fn default() -> Self {
         Self {
+            smooth: false,
             enabled: false,
             invert_horizontal: false,
             vertical_tolerance: default_swipe_vertical_tolerance(),


### PR DESCRIPTION
## Summary

Add an opt-in `smooth` setting for scrolling-layout trackpad gestures.

When enabled, horizontal three-finger movement is accumulated and flushed at most once per ~16.7 ms instead of waiting for the existing `distance_pct` threshold. This makes slow movement, direction reversals, and the final partial movement before lift track continuously.

For scrolling-only layout updates, unchanged window sizes use the existing workspace-switch position-update request rather than a full frame update.

```toml
[settings.layout.scrolling.gestures]
smooth = true
```

`false` remains the default and preserves the existing threshold-based behavior.

## Motivation

The current gesture path waits until accumulated movement reaches `distance_pct` before issuing `ScrollStrip`. This can feel stepped during slow trackpad movement, even when lowering the threshold.

This change keeps the existing gesture recognition, contact filtering, layout computation, animation manager, and application request channels. It only changes how accepted horizontal deltas are scheduled and how position-only results are applied.

The goal is more direct manipulation without adding inertia, snapping, a new animation system, or a new dependency.

## Behavior

With `smooth = true`:

- Gesture samples are coalesced into one `ScrollStrip` update per ~16.7 ms.
- Small deltas, reversals, and the final partial delta before release are retained.
- Pending motion is discarded when gesture state is reset or Space state changes.
- Existing gesture direction, finger-count, vertical-tolerance, inversion, contact-cohort, and palm filtering behavior is unchanged.
- Any active layout animation is finished before the direct position update is applied, so it cannot overwrite the drag position.
- A window with unchanged size receives a position-only update; a size change still receives a complete frame update.

With `smooth = false`, the previous `distance_pct` threshold behavior is unchanged.

## Why this shape

Rift already has an animation and window-update pipeline, so this patch reuses it rather than introducing a second scrolling or rendering system.

The direct-position path is deliberately limited to continuous scrolling updates. Normal layout changes continue to use the existing animation behavior.

There is intentionally no inertial continuation, release snap, or bounce. Those would be separate user-visible interaction policies and should be discussed independently.

## Validation

- `cargo +nightly fmt --all`
- `cargo test --lib`
  - 570 passed, 0 failed
- `cargo build --release --bins`
- `git diff --check`

New tests cover:

- smooth-mode preservation of small movement, immediate reversal, and release tail;
- legacy threshold behavior when smooth mode is disabled;
- direct position updates for unchanged-size windows;
- full frame updates when a scrolling result changes window size;
- completion of an active animation before a direct scrolling update.

## Manual testing

Tested with a three-finger horizontal trackpad gesture in a scrolling workspace:

- slow short drags;
- fast long drags;
- immediate direction reversal;
- release after a partial movement.

The opt-in mode felt substantially more direct and continuous than the threshold-based path.

## Follow-up ideas

If this direction is desirable, a follow-up could measure AX request volume and frame timing across different displays and window counts.

Inertia should be considered separately. It changes post-release behavior and needs clear rules for cancellation, workspace changes, keyboard navigation, focus changes, and edge behavior.
