### PR TITLE
fix(bsp): raise only the focus target on move_focus

### DIFF
--- a/src/layout_engine/systems/bsp.rs
+++ b/src/layout_engine/systems/bsp.rs
@@ -773,6 +773,24 @@ mod tests {
     }
 
     #[test]
+    fn move_focus_raises_only_the_focus_target() {
+        let mut system = BspLayoutSystem::default();
+        let layout = system.create_layout();
+        system.add_window_after_selection(layout, w(1));
+        system.add_window_after_selection(layout, w(2));
+        system.add_window_after_selection(layout, w(3));
+
+        let (focus, raise_windows) = system.move_focus(layout, Direction::Left);
+
+        assert_eq!(focus, Some(w(1)));
+        assert_eq!(
+            raise_windows,
+            vec![w(1)],
+            "BSP windows never overlap; raising the other visible windows fronts every app in turn"
+        );
+    }
+
+    #[test]
     fn window_in_direction_prefers_top_for_down_direction_after_orientation_toggle() {
         let mut system = BspLayoutSystem::default();
         let layout = system.create_layout();
@@ -1197,8 +1215,7 @@ impl LayoutSystem for BspLayoutSystem {
         layout: LayoutId,
         direction: Direction,
     ) -> (Option<WindowId>, Vec<WindowId>) {
-        let raise_windows = self.visible_windows_in_layout(layout);
-        if raise_windows.is_empty() {
+        if self.visible_windows_in_layout(layout).is_empty() {
             return (None, vec![]);
         }
         let sel_snapshot = self.selection_of_layout(layout);
@@ -1214,7 +1231,12 @@ impl LayoutSystem for BspLayoutSystem {
             Some(NodeKind::Leaf { window, .. }) => *window,
             _ => None,
         };
-        (focus, raise_windows)
+        // Tiled BSP windows never overlap, so only the focus target needs to be
+        // raised. Raising every visible window makes the raise manager front
+        // each app in turn (via make_key_window) before the target, which
+        // flickers the menu bar and any focus border on every focus move. The
+        // traditional engine already raises only the revealed group.
+        (focus, focus.into_iter().collect())
     }
 
     fn window_in_direction(&self, layout: LayoutId, direction: Direction) -> Option<WindowId> {


### PR DESCRIPTION
# Description

Fixes #477.

### The Problem
`BspLayoutSystem::move_focus` returns every visible window in the layout as `raise_windows`. `RaiseManager::start_new_sequence` sends a `Request::Raise` to each app batch before the focus batch, and each raise fronts that process via `window_server::make_key_window` (`_SLPSSetFrontProcessWithOptions`). With N apps on a workspace, one focus keypress therefore fronts N-1 wrong apps (~50 ms apart) before the target, which cycles the menu bar and flashes any focus border on every move. Focus itself lands correctly.

The traditional engine only raises `visible_windows_under_internal(highest_revealed)`, so it does not show this.

### The Solution
Tiled BSP windows never overlap, so raising the focus target alone is sufficient. `move_focus` now returns `focus.into_iter().collect()` as `raise_windows`; the empty-layout early return is kept.

Adds a regression test (`move_focus_raises_only_the_focus_target`) asserting that `move_focus` returns exactly the target in `raise_windows`.

### Testing
- `cargo test` passes (run through a Nix build of the patched tree; the pre-existing `topology_change_clears_stale_pending_hide_target_before_next_workspace_layout` test is skipped there as in nixpkgs).
- Running the patched binary on macOS 26.6.2 with a BSP workspace of three apps: the frontmost app now switches once, directly to the target; menu bar and JankyBorders no longer flicker.
