### PR TITLE
feat: add mouse_modifier for drag-to-move and drag-to-resize

### DIFF
--- a/rift.default.toml
+++ b/rift.default.toml
@@ -30,6 +30,11 @@ mouse_hides_on_focus = true
 # e.g. "Fn"; omit or set to null to keep focus-follows-mouse always active
 #focus_follows_mouse_disable_hotkey = "Fn"
 
+# mouse_modifier: hold this modifier and drag a window with the left mouse button to
+# move it, or with the right mouse button to resize it (like yabai's mouse_modifier).
+# Modifier-only spec, e.g. "Cmd" or "Ctrl + Alt". Omit to disable.
+#mouse_modifier = "Cmd"
+
 # Prevent certain apps from stealing focus/causing workspace switches
 # Provide bundle identifiers (e.g., "com.apple.Spotlight")
 # Examples:

--- a/src/actor/event_tap.rs
+++ b/src/actor/event_tap.rs
@@ -933,11 +933,16 @@ impl State {
     }
 
     fn compute_disable_hotkey_active(&self, target: &Hotkey) -> bool {
+        self.modifiers_active(target.modifiers) && self.base_key_active(target.key_code)
+    }
+
+    /// Whether every modifier in `target` is held. Extra modifiers are allowed.
+    fn modifiers_active(&self, target: Modifiers) -> bool {
         let active_mods = modifiers_from_flags_with_keys(self.current_flags, &self.pressed_keys);
 
         let check_modifier = |left: Modifiers, right: Modifiers| -> bool {
-            let target_has_left = target.modifiers.contains(left);
-            let target_has_right = target.modifiers.contains(right);
+            let target_has_left = target.contains(left);
+            let target_has_right = target.contains(right);
             let active_has_left = active_mods.contains(left);
             let active_has_right = active_mods.contains(right);
 
@@ -957,11 +962,7 @@ impl State {
         let alt_ok = check_modifier(Modifiers::ALT_LEFT, Modifiers::ALT_RIGHT);
         let meta_ok = check_modifier(Modifiers::META_LEFT, Modifiers::META_RIGHT);
 
-        if !(shift_ok && ctrl_ok && alt_ok && meta_ok) {
-            return false;
-        }
-
-        self.base_key_active(target.key_code)
+        shift_ok && ctrl_ok && alt_ok && meta_ok
     }
 
     fn base_key_active(&self, key_code: KeyCode) -> bool {

--- a/src/actor/event_tap.rs
+++ b/src/actor/event_tap.rs
@@ -28,7 +28,7 @@ use objc2_core_graphics::{
 };
 use tracing::{debug, error, trace, warn};
 
-use super::reactor::{self, Event};
+use super::reactor::{self, Event, MouseDragAction};
 use super::stack_line;
 use crate::actor;
 use crate::actor::spaces::ForwardedSpaceState;
@@ -47,6 +47,9 @@ use crate::ui::stack_line::point_hits_indicator_frame;
 
 const MOUSE_MOVE_MIN_INTERVAL_NS_NORMAL: u64 = 8_000_000; // 8ms ~= 125 Hz
 const MOUSE_MOVE_MIN_INTERVAL_NS_LOW_POWER: u64 = 16_000_000; // 16ms ~= 62 Hz
+/// Modifier-drag samples arrive faster than the window can be moved, and every
+/// one costs a reactor pass. Coalesce them to roughly one per display frame.
+const MODIFIER_DRAG_MIN_INTERVAL_NS: u64 = 16_000_000; // 16ms ~= 62 Hz
 
 #[derive(Debug)]
 pub enum Request {
@@ -99,12 +102,46 @@ struct State {
     stack_line_enabled: bool,
     stack_line_hover_mode: StackLineHoverMode,
     disable_hotkey_active: bool,
+    mouse_modifier: Option<Modifiers>,
+    modifier_drag: Option<ModifierDrag>,
     low_power_mode: bool,
     pressed_keys: HashSet<KeyCode>,
     current_flags: CGEventFlags,
     screen_spaces: Vec<(CGRect, SpaceId)>,
     layout_mode_by_space: HashMap<SpaceId, crate::common::config::LayoutMode>,
     last_stack_line_hit: Option<bool>,
+}
+
+/// An in-progress `settings.mouse_modifier` drag.
+struct ModifierDrag {
+    window: WindowServerId,
+    action: MouseDragAction,
+    last: CGPoint,
+    /// Motion observed but not yet handed to the reactor.
+    pending: CGPoint,
+    last_emit: u64,
+}
+
+impl ModifierDrag {
+    /// Records raw motion, releasing it only once per
+    /// [`MODIFIER_DRAG_MIN_INTERVAL_NS`]. Motion held back is added to the next
+    /// release, so throttling changes the update rate and never the distance.
+    fn accumulate(&mut self, loc: CGPoint, timestamp: u64) -> Option<CGPoint> {
+        self.pending.x += loc.x - self.last.x;
+        self.pending.y += loc.y - self.last.y;
+        self.last = loc;
+        if timestamp.saturating_sub(self.last_emit) < MODIFIER_DRAG_MIN_INTERVAL_NS {
+            return None;
+        }
+        self.last_emit = timestamp;
+        self.flush()
+    }
+
+    /// Releases accumulated motion regardless of the interval, for drag end.
+    fn flush(&mut self) -> Option<CGPoint> {
+        let delta = std::mem::replace(&mut self.pending, CGPoint::new(0.0, 0.0));
+        (delta.x != 0.0 || delta.y != 0.0).then_some(delta)
+    }
 }
 
 #[derive(Clone, Copy, Default)]
@@ -128,6 +165,8 @@ impl Default for State {
             stack_line_enabled: false,
             stack_line_hover_mode: StackLineHoverMode::default(),
             disable_hotkey_active: false,
+            mouse_modifier: None,
+            modifier_drag: None,
             low_power_mode: power::is_low_power_mode_enabled(),
             pressed_keys: HashSet::default(),
             current_flags: CGEventFlags::empty(),
@@ -276,6 +315,7 @@ impl EventTap {
             .and_then(|spec| spec.to_hotkey());
         let mut state = State::default();
         state.mouse_hides_on_focus = config.settings.mouse_hides_on_focus;
+        state.mouse_modifier = config.settings.mouse_modifier;
         state.focus_follows_mouse_config_enabled = config.settings.focus_follows_mouse;
         state.stack_line_enabled = config.settings.ui.stack_line.enabled;
         state.stack_line_hover_mode = config.settings.ui.stack_line.hover;
@@ -444,6 +484,7 @@ impl EventTap {
                     state.stack_line_enabled = stack_line_enabled;
                     state.stack_line_hover_mode = stack_line_hover_mode;
                     state.default_layout_mode = default_layout_mode;
+                    state.mouse_modifier = new_config.settings.mouse_modifier;
                     let prev_active = state.disable_hotkey_active;
                     state.disable_hotkey_active = self
                         .disable_hotkey
@@ -606,7 +647,39 @@ impl EventTap {
             state.show_mouse();
         }
         match event_type {
+            CGEventType::LeftMouseDown | CGEventType::RightMouseDown => {
+                if let Some(drag) = state.begin_modifier_drag(event_type, event) {
+                    state.modifier_drag = Some(drag);
+                    return false;
+                }
+            }
+            CGEventType::LeftMouseDragged | CGEventType::RightMouseDragged => {
+                if let Some(drag) = state.modifier_drag.as_mut() {
+                    let loc = CGEvent::location(Some(event));
+                    if let Some(delta) = drag.accumulate(loc, CGEvent::timestamp(Some(event))) {
+                        _ = self.events_tx.send(Event::ModifierDrag {
+                            window: drag.window,
+                            action: drag.action,
+                            delta,
+                        });
+                    }
+                    return false;
+                }
+            }
             CGEventType::RightMouseUp | CGEventType::LeftMouseUp => {
+                // Held-back motion has to land before the drag session closes.
+                if let Some(mut drag) = state.modifier_drag.take() {
+                    if let Some(delta) = drag.flush() {
+                        _ = self.events_tx.send(Event::ModifierDrag {
+                            window: drag.window,
+                            action: drag.action,
+                            delta,
+                        });
+                    }
+                    _ = self.events_tx.send(Event::MouseUp);
+                    // The app never saw the press that started the drag; hide the release too.
+                    return false;
+                }
                 _ = self.events_tx.send(Event::MouseUp);
             }
             _ => (),
@@ -965,6 +1038,35 @@ impl State {
         shift_ok && ctrl_ok && alt_ok && meta_ok
     }
 
+    fn begin_modifier_drag(
+        &self,
+        event_type: CGEventType,
+        event: &CGEvent,
+    ) -> Option<ModifierDrag> {
+        let modifier = self.mouse_modifier?;
+        if !self.modifiers_active(modifier) {
+            return None;
+        }
+        let last = CGEvent::location(Some(event));
+        let window = window_server::get_window_at_point(last)?;
+        let action = if event_type == CGEventType::LeftMouseDown {
+            MouseDragAction::Move
+        } else {
+            let frame = window_server::get_window(window)?.frame;
+            MouseDragAction::Resize {
+                left: last.x < frame.origin.x + frame.size.width / 2.0,
+                top: last.y < frame.origin.y + frame.size.height / 2.0,
+            }
+        };
+        Some(ModifierDrag {
+            window,
+            action,
+            last,
+            pending: CGPoint::new(0.0, 0.0),
+            last_emit: 0,
+        })
+    }
+
     fn base_key_active(&self, key_code: KeyCode) -> bool {
         if is_modifier_key(key_code) {
             modifier_key_is_active(self.current_flags, key_code)
@@ -1031,6 +1133,43 @@ fn build_event_mask(keyboard_enabled: bool, mouse_move_enabled: bool) -> CGEvent
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn modifier_drag_throttles_updates_without_losing_distance() {
+        let mut drag = ModifierDrag {
+            window: WindowServerId::new(1),
+            action: MouseDragAction::Move,
+            last: CGPoint::new(0.0, 0.0),
+            pending: CGPoint::new(0.0, 0.0),
+            last_emit: 0,
+        };
+
+        // The first sample is not withheld.
+        assert_eq!(
+            drag.accumulate(CGPoint::new(4.0, 0.0), MODIFIER_DRAG_MIN_INTERVAL_NS),
+            Some(CGPoint::new(4.0, 0.0))
+        );
+
+        // Samples inside the interval accumulate instead of dispatching.
+        let mut timestamp = MODIFIER_DRAG_MIN_INTERVAL_NS;
+        for step in 1..=3 {
+            timestamp += MODIFIER_DRAG_MIN_INTERVAL_NS / 4;
+            assert_eq!(
+                drag.accumulate(CGPoint::new(4.0 + f64::from(step), 0.0), timestamp),
+                None
+            );
+        }
+
+        // Crossing the interval releases every withheld pixel at once.
+        timestamp += MODIFIER_DRAG_MIN_INTERVAL_NS;
+        assert_eq!(
+            drag.accumulate(CGPoint::new(10.0, 0.0), timestamp),
+            Some(CGPoint::new(6.0, 0.0))
+        );
+
+        // Nothing left over, and a still cursor dispatches nothing.
+        assert_eq!(drag.flush(), None);
+    }
 
     #[test]
     fn layout_mode_at_point_uses_space_mapping() {

--- a/src/actor/reactor.rs
+++ b/src/actor/reactor.rs
@@ -1133,6 +1133,109 @@ impl Reactor {
         }
     }
 
+    fn handle_window_frame_changed_event(
+        &mut self,
+        wid: WindowId,
+        new_frame: CGRect,
+        last_seen: Option<TransactionId>,
+        requested: bool,
+        mouse_state: Option<MouseState>,
+        raised_window: Option<WindowId>,
+    ) -> anyhow::Result<EventOutcome> {
+        let mission_control_active = self.is_mission_control_active();
+        let mut effective_mouse_state = mouse_state;
+        if matches!(
+            window_workflow::classify_window_frame_change(
+                &mut self.state,
+                &self.transaction_manager,
+                &mut self.drag_manager,
+                wid,
+                new_frame,
+                last_seen,
+                requested,
+                &mut effective_mouse_state,
+                mission_control_active,
+            ),
+            window_workflow::FrameChangeDisposition::Handled
+        ) {
+            let mut outcome = EventOutcome::no_change();
+            outcome.dispatch_mouse_up = effective_mouse_state
+                == Some(crate::sys::event::MouseState::Up)
+                && matches!(
+                    self.drag_manager.drag_state,
+                    DragState::Active { .. } | DragState::PendingSwap { .. }
+                );
+            outcome.focused_window = raised_window;
+            return Ok(outcome);
+        }
+        let (server_id, old_frame) = self
+            .state
+            .windows
+            .window(wid)
+            .map(|window| (window.info.sys_id, window.frame_monotonic))
+            .unwrap_or((None, new_frame));
+        let old_space = self.geometry_space_for_window(&old_frame, server_id);
+        let new_space = self.geometry_space_for_window(&new_frame, server_id);
+        let old_space_active = old_space.is_some_and(|space| self.is_space_active(space));
+        let new_space_active = new_space.is_some_and(|space| self.is_space_active(space));
+        let best_resize_space = self.best_space_for_window(&new_frame, server_id);
+        let active_resize_space = best_resize_space
+            .filter(|space| self.is_space_active(*space))
+            .or_else(|| server_id.is_none().then(|| self.workspace_command_space()).flatten());
+        let pending_target_space =
+            server_id.and_then(|server| self.pending_target_space_for_window_server_id(server));
+        let assigned_space = self.assigned_space_for_window_id(wid);
+        let keep_assigned_for_scrolling = old_space.is_some_and(|space| {
+            self.layout_manager.layout_engine.active_layout_mode_at(space)
+                == crate::common::config::LayoutMode::Scrolling
+                && !self.layout_manager.layout_engine.is_window_floating(wid)
+                && self
+                    .layout_manager
+                    .layout_engine
+                    .virtual_workspace_manager()
+                    .workspace_for_window(&self.state.windows, space, wid)
+                    .is_some()
+        });
+        let screens = self
+            .space_state
+            .screens
+            .iter()
+            .filter_map(|screen| Some((screen.space?, screen.frame, screen.display_uuid_owned())))
+            .collect();
+        let mut outcome = window_workflow::handle_window_frame_changed(
+            &mut self.state,
+            &mut self.layout_manager,
+            &mut self.drag_manager,
+            window_workflow::WindowFrameChangedPayload {
+                window: wid,
+                new_frame,
+                mouse_state: effective_mouse_state,
+                old_space,
+                new_space,
+                old_space_active,
+                new_space_active,
+                active_resize_space,
+                pending_target_space,
+                assigned_space,
+                keep_assigned_for_scrolling,
+                screens,
+            },
+        )?;
+        // Frame acknowledgements and no-op geometry changes can return
+        // early from the reducer. Mouse release still has to terminate
+        // an existing drag session in those cases.
+        if effective_mouse_state == Some(crate::sys::event::MouseState::Up)
+            && matches!(
+                self.drag_manager.drag_state,
+                DragState::Active { .. } | DragState::PendingSwap { .. }
+            )
+        {
+            outcome.dispatch_mouse_up = true;
+        }
+        outcome.focused_window = raised_window;
+        return Ok(outcome);
+    }
+
     fn dispatch_workflow(&mut self, event: Event) -> anyhow::Result<EventOutcome> {
         self.log_event(&event);
         self.recording_manager.record.on_event(&event);
@@ -1476,101 +1579,14 @@ impl Reactor {
                 );
             }
             Event::WindowFrameChanged(wid, new_frame, last_seen, requested, mouse_state) => {
-                let mission_control_active = self.is_mission_control_active();
-                let mut effective_mouse_state = mouse_state;
-                if matches!(
-                    window_workflow::classify_window_frame_change(
-                        &mut self.state,
-                        &self.transaction_manager,
-                        &mut self.drag_manager,
-                        wid,
-                        new_frame,
-                        last_seen,
-                        requested.0,
-                        &mut effective_mouse_state,
-                        mission_control_active,
-                    ),
-                    window_workflow::FrameChangeDisposition::Handled
-                ) {
-                    let mut outcome = EventOutcome::no_change();
-                    outcome.dispatch_mouse_up = effective_mouse_state
-                        == Some(crate::sys::event::MouseState::Up)
-                        && matches!(
-                            self.drag_manager.drag_state,
-                            DragState::Active { .. } | DragState::PendingSwap { .. }
-                        );
-                    outcome.focused_window = raised_window;
-                    return Ok(outcome);
-                }
-                let (server_id, old_frame) = self
-                    .state
-                    .windows
-                    .window(wid)
-                    .map(|window| (window.info.sys_id, window.frame_monotonic))
-                    .unwrap_or((None, new_frame));
-                let old_space = self.geometry_space_for_window(&old_frame, server_id);
-                let new_space = self.geometry_space_for_window(&new_frame, server_id);
-                let old_space_active = old_space.is_some_and(|space| self.is_space_active(space));
-                let new_space_active = new_space.is_some_and(|space| self.is_space_active(space));
-                let best_resize_space = self.best_space_for_window(&new_frame, server_id);
-                let active_resize_space =
-                    best_resize_space.filter(|space| self.is_space_active(*space)).or_else(|| {
-                        server_id.is_none().then(|| self.workspace_command_space()).flatten()
-                    });
-                let pending_target_space = server_id
-                    .and_then(|server| self.pending_target_space_for_window_server_id(server));
-                let assigned_space = self.assigned_space_for_window_id(wid);
-                let keep_assigned_for_scrolling = old_space.is_some_and(|space| {
-                    self.layout_manager.layout_engine.active_layout_mode_at(space)
-                        == crate::common::config::LayoutMode::Scrolling
-                        && !self.layout_manager.layout_engine.is_window_floating(wid)
-                        && self
-                            .layout_manager
-                            .layout_engine
-                            .virtual_workspace_manager()
-                            .workspace_for_window(&self.state.windows, space, wid)
-                            .is_some()
-                });
-                let screens = self
-                    .space_state
-                    .screens
-                    .iter()
-                    .filter_map(|screen| {
-                        Some((screen.space?, screen.frame, screen.display_uuid_owned()))
-                    })
-                    .collect();
-                let mut outcome = window_workflow::handle_window_frame_changed(
-                    &mut self.state,
-                    &mut self.layout_manager,
-                    &mut self.drag_manager,
-                    window_workflow::WindowFrameChangedPayload {
-                        window: wid,
-                        new_frame,
-                        mouse_state: effective_mouse_state,
-                        old_space,
-                        new_space,
-                        old_space_active,
-                        new_space_active,
-                        active_resize_space,
-                        pending_target_space,
-                        assigned_space,
-                        keep_assigned_for_scrolling,
-                        screens,
-                    },
-                )?;
-                // Frame acknowledgements and no-op geometry changes can return
-                // early from the reducer. Mouse release still has to terminate
-                // an existing drag session in those cases.
-                if effective_mouse_state == Some(crate::sys::event::MouseState::Up)
-                    && matches!(
-                        self.drag_manager.drag_state,
-                        DragState::Active { .. } | DragState::PendingSwap { .. }
-                    )
-                {
-                    outcome.dispatch_mouse_up = true;
-                }
-                outcome.focused_window = raised_window;
-                return Ok(outcome);
+                return self.handle_window_frame_changed_event(
+                    wid,
+                    new_frame,
+                    last_seen,
+                    requested.0,
+                    mouse_state,
+                    raised_window,
+                );
             }
             Event::WindowTitleChanged(wid, new_title) => {
                 let mut outcome = window_workflow::handle_window_title_changed(

--- a/src/actor/reactor.rs
+++ b/src/actor/reactor.rs
@@ -102,7 +102,7 @@ use crate::model::tx_store::WindowTxStore;
 use crate::model::{AppRuleResult, RiftState};
 use crate::sys::event::MouseState;
 use crate::sys::executor::Executor;
-use crate::sys::geometry::{CGRectDef, CGRectExt};
+use crate::sys::geometry::{CGPointDef, CGRectDef, CGRectExt};
 pub use crate::sys::screen::ScreenInfo;
 use crate::sys::screen::{SpaceId, order_visible_spaces_by_position};
 use crate::sys::window_server::{
@@ -117,8 +117,8 @@ pub use query::ReactorQueryHandle;
 pub(crate) use crate::model::reactor::{AppState, WindowState};
 pub use crate::model::reactor::{
     Command, DisplaySelector, DragSession, DragState, MenuState, MissionControlState,
-    ReactorCommand, RefocusState, Requested, StaleCleanupState, WorkspaceSwitchOrigin,
-    WorkspaceSwitchState,
+    MouseDragAction, ReactorCommand, RefocusState, Requested, StaleCleanupState,
+    WorkspaceSwitchOrigin, WorkspaceSwitchState,
 };
 
 #[derive(Clone)]
@@ -263,6 +263,13 @@ pub enum Event {
     /// Window resolution and transition deduplication stay on the input
     /// thread; the reactor only applies the model-dependent focus/raise work.
     MouseMoved(WindowServerId),
+    /// The mouse was dragged over a window while `settings.mouse_modifier` was held.
+    ModifierDrag {
+        window: WindowServerId,
+        action: MouseDragAction,
+        #[serde(with = "CGPointDef")]
+        delta: CGPoint,
+    },
     /// Forwarded by the spaces actor after wake has been observed.
     ///
     /// The spaces actor is the authority for sleep/lock/display lifecycle.
@@ -346,6 +353,9 @@ pub struct Reactor {
     refresh_quarantine_manager: managers::RefreshQuarantineManager,
     pending_space_change_manager: managers::PendingSpaceChangeManager,
     active_spaces: HashSet<SpaceId>,
+    /// Window whose app currently holds a drag write lease. See
+    /// [`Reactor::begin_modifier_drag_writes`].
+    modifier_drag_window: Option<WindowId>,
     pub animation_tx: Option<AnimationSender>,
     #[cfg(test)]
     event_outcome_phase_trace: Vec<&'static str>,
@@ -474,6 +484,7 @@ impl Reactor {
                 pending_space_change: None,
             },
             active_spaces: HashSet::default(),
+            modifier_drag_window: None,
             animation_tx: None,
             #[cfg(test)]
             event_outcome_phase_trace: Vec::new(),
@@ -1133,6 +1144,51 @@ impl Reactor {
         }
     }
 
+    /// Takes a frame-write lease on the app owning a modifier-dragged window.
+    ///
+    /// The lease suppresses Enhanced UI and the window's Accessibility
+    /// notifications once for the whole drag rather than once per write, which
+    /// is what [`Request::SetWindowFrame`] would otherwise cost per sample.
+    fn begin_modifier_drag_writes(&mut self, wid: WindowId) {
+        if self.modifier_drag_window == Some(wid) {
+            return;
+        }
+        self.end_modifier_drag_writes();
+        self.modifier_drag_window = Some(wid);
+        if let Some(app) = self.app_manager.apps.get(&wid.pid) {
+            _ = app.handle.send(Request::BeginWindowAnimation(wid));
+        }
+    }
+
+    /// Releases the lease, flushing the last frame and resyncing observers.
+    fn end_modifier_drag_writes(&mut self) {
+        let Some(wid) = self.modifier_drag_window.take() else {
+            return;
+        };
+        if let Some(app) = self.app_manager.apps.get(&wid.pid) {
+            _ = app.handle.send(Request::EndWindowAnimation(wid));
+        }
+    }
+
+    /// Writes a dragged window's frame through the coalescing animation path.
+    ///
+    /// The app actor keeps only the newest frame per window and applies it once
+    /// per drained batch, with no frame read-back and no echo event, so a fast
+    /// drag cannot outrun the Accessibility writes.
+    fn write_modifier_drag_frame(&mut self, wid: WindowId, frame: CGRect, set_size: bool) {
+        let window_server_id = self.state.windows.window(wid).and_then(|window| window.info.sys_id);
+        let txid = if let Some(window_server_id) = window_server_id {
+            let txid = self.transaction_manager.generate_next_txid(window_server_id);
+            self.transaction_manager.store_txid(window_server_id, txid, frame);
+            txid
+        } else {
+            TransactionId::default()
+        };
+        if let Some(app) = self.app_manager.apps.get(&wid.pid) {
+            _ = app.handle.send(Request::AnimationFrame { wid, frame, set_size, txid });
+        }
+    }
+
     fn handle_window_frame_changed_event(
         &mut self,
         wid: WindowId,
@@ -1588,6 +1644,29 @@ impl Reactor {
                     raised_window,
                 );
             }
+            Event::ModifierDrag { window, action, delta } => {
+                let Some((wid, frame)) =
+                    self.state.windows.tracked_window_id(window).and_then(|wid| {
+                        Some((wid, self.state.windows.window(wid)?.frame_monotonic))
+                    })
+                else {
+                    return Ok(EventOutcome::no_change());
+                };
+                let new_frame = action.apply(frame, delta);
+                self.begin_modifier_drag_writes(wid);
+                // Same path as a native drag so swap detection and split resizing apply;
+                // the frame write follows because macOS is not moving the window for us.
+                let outcome = self.handle_window_frame_changed_event(
+                    wid,
+                    new_frame,
+                    None,
+                    false,
+                    Some(MouseState::Down),
+                    raised_window,
+                )?;
+                self.write_modifier_drag_frame(wid, new_frame, action.changes_size());
+                return Ok(outcome);
+            }
             Event::WindowTitleChanged(wid, new_title) => {
                 let mut outcome = window_workflow::handle_window_title_changed(
                     &mut self.state,
@@ -1633,6 +1712,7 @@ impl Reactor {
                 return Ok(EventOutcome::default());
             }
             Event::MouseUp => {
+                self.end_modifier_drag_writes();
                 let pending_swap = self.get_pending_drag_swap();
                 let (visible_spaces, visible_space_centers) = self.visible_spaces_for_layout(true);
                 let swap_space = pending_swap

--- a/src/actor/reactor/tests.rs
+++ b/src/actor/reactor/tests.rs
@@ -5618,3 +5618,45 @@ fn floating_window_toggles_to_fullscreen_within_gaps() {
         "expected {expected:?}, got {laid_out:?}"
     );
 }
+
+#[test]
+fn modifier_drag_move_updates_frame_writes_it_and_starts_a_drag_session() {
+    let (mut reactor, wid, wsid, _space1, _space2, frame) = reactor_with_window_on_space1();
+
+    reactor.handle_event(Event::ModifierDrag {
+        window: wsid,
+        action: MouseDragAction::Move,
+        delta: CGPoint::new(30., 20.),
+    });
+
+    let expected = CGRect::new(
+        CGPoint::new(frame.origin.x + 30., frame.origin.y + 20.),
+        frame.size,
+    );
+    assert!(reactor.state.windows.window(wid).unwrap().frame_monotonic.same_as(expected));
+    assert!(matches!(
+        reactor.drag_manager.drag_state,
+        DragState::Active { .. }
+    ));
+    // The write lease is held for the whole drag and released on mouse up.
+    assert_eq!(reactor.modifier_drag_window, Some(wid));
+    reactor.handle_event(Event::MouseUp);
+    assert_eq!(reactor.modifier_drag_window, None);
+}
+
+#[test]
+fn modifier_drag_resize_from_top_left_moves_origin_and_shrinks() {
+    let (mut reactor, wid, wsid, _space1, _space2, frame) = reactor_with_window_on_space1();
+
+    reactor.handle_event(Event::ModifierDrag {
+        window: wsid,
+        action: MouseDragAction::Resize { left: true, top: true },
+        delta: CGPoint::new(10., 40.),
+    });
+
+    let expected = CGRect::new(
+        CGPoint::new(frame.origin.x + 10., frame.origin.y + 40.),
+        CGSize::new(frame.size.width - 10., frame.size.height - 40.),
+    );
+    assert!(reactor.state.windows.window(wid).unwrap().frame_monotonic.same_as(expected));
+}

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use super::collections::HashMap;
 use crate::actor::wm_controller::WmCommand;
-use crate::sys::hotkey::{Hotkey, HotkeySpec};
+use crate::sys::hotkey::{Hotkey, HotkeySpec, Modifiers};
 
 pub const MAX_WORKSPACES: usize = 128;
 
@@ -435,6 +435,10 @@ pub struct Settings {
     /// Accepts either a full hotkey (e.g. "Ctrl + A") or a modifier-only spec (e.g. "Ctrl")
     #[serde(default)]
     pub focus_follows_mouse_disable_hotkey: Option<HotkeySpec>,
+    /// Modifier held while dragging a window with the mouse: the left button
+    /// moves it, the right button resizes it. Modifier-only spec, e.g. "Cmd".
+    #[serde(default, with = "mouse_modifier_serde")]
+    pub mouse_modifier: Option<Modifiers>,
     /// Apps that should not trigger automatic workspace switching when activated.
     /// List of bundle identifiers (e.g., "com.apple.Spotlight") that often
     /// inappropriately steal focus and shouldn't cause workspace switches.
@@ -1257,6 +1261,25 @@ impl InnerGaps {
 
 fn yes() -> bool { true }
 
+mod mouse_modifier_serde {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    use crate::sys::hotkey::{Modifiers, modifiers_from_str};
+
+    pub fn serialize<S: Serializer>(value: &Option<Modifiers>, s: S) -> Result<S::Ok, S::Error> {
+        match value {
+            Some(mods) => s.serialize_some(&mods.to_string()),
+            None => s.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<Modifiers>, D::Error> {
+        Option::<String>::deserialize(d)?
+            .map(|s| modifiers_from_str(&s).map_err(serde::de::Error::custom))
+            .transpose()
+    }
+}
+
 fn default_stack_offset() -> f64 { 40.0 }
 
 pub fn default_stack_orientation() -> StackDefaultOrientation {
@@ -1837,6 +1860,13 @@ mod tests {
         let cfg = Config::parse(toml).unwrap();
         // We expect keys to be parsed into hotkeys
         assert!(!cfg.keys.is_empty());
+    }
+
+    #[test]
+    fn mouse_modifier_is_a_modifier_only_spec() {
+        let cfg = Config::parse("[settings]\nmouse_modifier = \"Cmd\"\n[keys]\n").unwrap();
+        assert_eq!(cfg.settings.mouse_modifier, Some(Modifiers::META));
+        assert!(Config::parse("[settings]\nmouse_modifier = \"Cmd + T\"\n[keys]\n").is_err());
     }
 
     #[test]

--- a/src/model/reactor.rs
+++ b/src/model/reactor.rs
@@ -1,4 +1,4 @@
-use objc2_core_foundation::CGRect;
+use objc2_core_foundation::{CGPoint, CGRect};
 pub use rift_protocol::{DisplaySelector, ReactorCommand};
 use serde::{Deserialize, Serialize};
 
@@ -22,6 +22,47 @@ pub struct RiftState {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Requested(pub bool);
+
+/// What a `settings.mouse_modifier` drag does to the window under the cursor.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+pub enum MouseDragAction {
+    Move,
+    /// Resize by moving the edges nearest to where the drag started.
+    Resize {
+        left: bool,
+        top: bool,
+    },
+}
+
+impl MouseDragAction {
+    pub fn changes_size(self) -> bool { matches!(self, MouseDragAction::Resize { .. }) }
+
+    pub fn apply(self, mut frame: CGRect, delta: CGPoint) -> CGRect {
+        match self {
+            MouseDragAction::Move => {
+                frame.origin.x += delta.x;
+                frame.origin.y += delta.y;
+            }
+            MouseDragAction::Resize { left, top } => {
+                if left {
+                    frame.origin.x += delta.x;
+                    frame.size.width -= delta.x;
+                } else {
+                    frame.size.width += delta.x;
+                }
+                if top {
+                    frame.origin.y += delta.y;
+                    frame.size.height -= delta.y;
+                } else {
+                    frame.size.height += delta.y;
+                }
+                frame.size.width = frame.size.width.max(1.0);
+                frame.size.height = frame.size.height.max(1.0);
+            }
+        }
+        frame
+    }
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(untagged)]


### PR DESCRIPTION
Implements the yabai-style modifier drag from #371.

Hold the configured modifier and drag a window with the left button to move it,
or with the right button to resize it. Resizing grabs the edges nearest to where
the drag started, so pressing near the top-left corner drags that corner.

```toml
[settings]
mouse_modifier = "Cmd"
```

The value is a modifier-only spec parsed by the same code as keybindings, so
`"Ctrl + Alt"` works, and a spec that names an ordinary key is rejected when the
config loads instead of silently binding just the modifier. The setting is
optional and off when absent, so nothing changes for anyone who does not set it.

### How it works

The event tap owns the gesture: it picks move or resize on mouse down, feeds
deltas to the reactor, and swallows the press and release so the application
underneath never sees a stray click. The reactor applies each delta to the
window's last known frame and pushes the result through the same handler a
native drag already uses, so drag-to-swap and split resizing keep working
without a second code path.

Two things decide whether it feels immediate, and both were painfully obvious
in the first draft:

- Raw drag samples arrive faster than a window can be moved and each one costs
  a reactor pass, so they are coalesced to about one per display frame. Motion
  that gets withheld is rolled into the next update, so the update rate changes
  and the distance travelled does not.
- Frames go out as `AnimationFrame` requests, since that path keeps only the
  newest frame per window and applies it once per drained batch with no
  read-back and no echo event. A `SetWindowFrame` per sample instead spends
  three Accessibility writes plus a frame read and emits an echo that costs
  another reactor pass, which a fast drag outruns within a second or two. A
  drag also holds one Enhanced UI lease for its whole duration rather than
  taking one per write.

Moves are written position-only, as they have no reason to pay for the size
writes a resize needs.

### Commits

The two refactors are separated out so the feature commit stays readable. Both
are behaviour-preserving; the second one's diff is mostly rustfmt reacting to a
smaller indent.

### Testing

Used as a daily driver on macOS 15.6 (Apple silicon) across a 3440x1440 display
and a retina laptop display, in the `bsp` layout, moving and resizing both tiled
and floating windows.

Added unit tests for the throttle behaviour, the config parsing rule, and the
move and resize geometry. `cargo test` gives 579 passing. One test,
`topology_change_clears_stale_pending_hide_target_before_next_workspace_layout`,
fails for me on an untouched `main` as well, so it looks unrelated to this
branch. `cargo +nightly fmt --all --check` is clean.

### Open questions

- Left is always move and right is always resize. I left out a configurable
  button mapping (yabai's `mouse_action1` / `mouse_action2`) until someone
  actually wants the inverse; happy to add it if you would rather have it now.
- If a window is destroyed mid-drag the write lease leaks for that window,
  leaving its notifications off. It seemed too narrow to guard, but say the word
  and I will handle it.
