### PR TITLE
fix: keep self-initiated focus raises quiet

### DIFF
--- a/src/actor/reactor/events/command.rs
+++ b/src/actor/reactor/events/command.rs
@@ -325,7 +325,7 @@ fn focus_window_raise_request(apps: &AppManager, window: WindowId) -> raise_mana
         raise_windows: Vec::new(),
         focus_window: Some((window, None)),
         app_handles,
-        focus_quiet: Quiet::No,
+        focus_quiet: Quiet::Yes,
     })
 }
 

--- a/src/actor/reactor/events/window.rs
+++ b/src/actor/reactor/events/window.rs
@@ -472,7 +472,7 @@ pub fn handle_mouse_moved_over_window(
                 raise_windows: vec![vec![window]],
                 focus_window: Some((window, None)),
                 app_handles,
-                focus_quiet: Quiet::No,
+                focus_quiet: Quiet::Yes,
             },
         ));
     }

--- a/src/actor/reactor/tests.rs
+++ b/src/actor/reactor/tests.rs
@@ -2815,6 +2815,38 @@ fn focus_follows_mouse_emits_focus_without_explicit_arrange() {
 }
 
 #[test]
+fn focus_follows_mouse_raise_is_quiet_so_stale_main_window_cannot_switch_workspace() {
+    let reactor = test_reactor();
+    let space = SpaceId::new(1);
+    let window = WindowId::new(7, 1);
+
+    let outcome = window_workflow::handle_mouse_moved_over_window(
+        &reactor.app_manager,
+        window_workflow::MouseMovedPayload {
+            window: Some(window),
+            should_sync: true,
+            is_main: false,
+            needs_layout_sync: true,
+            active_space: Some(space),
+        },
+    )
+    .expect("mouse focus workflow");
+
+    match outcome.raise_requests.as_slice() {
+        [raise_manager::Event::RaiseRequest(RaiseRequest { focus_window, focus_quiet, .. })] => {
+            assert_eq!(focus_window.map(|(wid, _)| wid), Some(window));
+            assert_eq!(*focus_quiet, Quiet::Yes);
+        }
+        other => panic!("Unexpected raise requests: {other:?}"),
+    }
+    assert!(matches!(
+        outcome.layout_events.as_slice(),
+        [LayoutEvent::WindowFocused(event_space, event_window)]
+            if *event_space == space && *event_window == window
+    ));
+}
+
+#[test]
 fn resolved_activation_without_main_window_does_not_choose_arbitrary_app_window() {
     let (mut apps, mut reactor) = test_context();
     let screen = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));


### PR DESCRIPTION
## Summary

Focus-follows-mouse could focus the wrong window when an app has windows on more than
one display. Hovering a window on one display would switch the *other* display to a
different workspace and focus that app's window there. Easy to hit with any app kept
open per-display on different workspaces, a browser like Zen, for example.

The hit test and raise target were always correct; the hop came from the activation
echo afterwards.

## How it works

The raise was sent as `Quiet::No`, so the resulting `ApplicationActivated` ran
`handle_app_activation_workspace_switch`. That helper derives its target from
`main_window()` rather than from the window rift just asked to focus, and
`main_window()` still resolved to the app's other window, whose space and workspace
live on the other display. The helper already warns it is "especially unsafe for apps
whose windows span multiple virtual workspaces" (`src/actor/reactor.rs:3910`).

`Quiet::Yes` already means "initiated by rift", and the workspace-switch raise path
uses it; these focus raises were the outlier. Each of the call sites already emits its
own `WindowFocused` layout event, so the loud activation could only contradict a
decision rift had already made.

Applies to the hover raise and to `focus_window_raise_request`, shared by the
`focus window`, `focus display` and `move mouse to display` commands.

User-initiated activations are unaffected: cmd-tab, Dock clicks and app
self-activation carry no activation context, so they still arrive as `Quiet::No` and
still auto-switch workspace.

## Test plan

New test `focus_follows_mouse_raise_is_quiet_so_stale_main_window_cannot_switch_workspace`
asserts the hover raise targets the hovered window, is quiet, and still emits its own
focus event. It fails before the change and passes after.

`cargo test --lib actor::reactor` — 169 passed, 1 failed. The failure
(`topology_change_clears_stale_pending_hide_target_before_next_workspace_layout`) also
fails on clean `main` and is unrelated.
