### PR TITLE
feat: add i3-style scratchpad

### DIFF
--- a/crates/rift-protocol/src/commands.rs
+++ b/crates/rift-protocol/src/commands.rs
@@ -50,6 +50,8 @@ pub enum LayoutCommand {
     ToggleWindowFloatingWithOptions(ToggleWindowFloatingOptions),
     ToggleFullscreen,
     ToggleFullscreenWithinGaps,
+    ToggleScratchpad,
+    MoveToScratchpad,
     ResizeWindowGrow(ResizeOrientation),
     ResizeWindowShrink(ResizeOrientation),
     ResizeWindowBy {

--- a/rift.default.toml
+++ b/rift.default.toml
@@ -312,6 +312,10 @@ workspace_names = [
 #   - size ({ w, h }): initial size in logical pixels. Either dimension may be omitted. Floating
 #     windows are initially resized; tiled windows receive a one-time resize after insertion.
 #   - focus (boolean): focus the window after applying the rule, switching to its virtual workspace.
+#   - scratchpad (boolean): park matching windows in the scratchpad as soon as they appear (implies
+#     floating). Summon them with the `toggle_scratchpad` command; the first show sizes the window to
+#     50% x 75% of the screen and centers it, later shows keep the geometry you left it in.
+#     Cannot be combined with workspace, position, size, focus, or manage = false.
 #   - manage (boolean): optional explicit management override. Set to false to ignore the
 #     matching window completely, or true to override Rift/macOS manageability heuristics
 #     for a visible window. When omitted, normal heuristics apply. Minimized windows remain unmanaged.
@@ -407,6 +411,10 @@ comb1 = "Alt + Shift"
 # - consume_or_expel_window = "left"|"right"|"up"|"down"
 # - toggle_stack / toggle_orientation / unjoin_windows
 # - toggle_focus_floating / toggle_window_floating / toggle_fullscreen / toggle_fullscreen_within_gaps
+# - move_to_scratchpad (i3 "move scratchpad": hide the focused window off every workspace; it becomes floating)
+# - toggle_scratchpad (i3 "scratchpad show": focused scratchpad window -> hide it; otherwise show the next
+#   hidden one centered on the current workspace, cycling oldest first; with no scratchpad windows at all,
+#   parks the focused window. Tiling a scratchpad window with toggle_window_floating removes it from the scratchpad)
 # - resize_window_grow / resize_window_shrink (without param, horizontal is default)
 # - resize_window_grow = "horizontal"|"vertical"|"smart"
 # - resize_window_shrink = "horizontal"|"vertical"|"smart"
@@ -472,6 +480,11 @@ comb1 = "Alt + Shift"
 "Alt + F" = "toggle_fullscreen"
 "Alt + Shift + F" = "toggle_fullscreen_within_gaps"
 "comb1 + Ctrl + Space" = "toggle_focus_floating" # briefly bring focus to floating window
+
+# i3-style scratchpad: park a window off every workspace and summon it with one key.
+# Pair with an app rule such as { app_id = "net.kovidgoyal.kitty", title_substring = "Scratchpad", scratchpad = true }
+# "Alt + Escape" = "toggle_scratchpad"
+# "Alt + Shift + Escape" = "move_to_scratchpad"
 
 # smartly resize windows
 "Alt + Shift + Equal" = "resize_window_grow"

--- a/src/actor/reactor.rs
+++ b/src/actor/reactor.rs
@@ -3040,7 +3040,7 @@ impl Reactor {
         let wid = self.state.windows.tracked_window_id(wsid)?;
         let assigned_space = self.assigned_space_for_window_id(wid)?;
         if !self.is_space_active(assigned_space)
-            || !self.window_in_non_active_workspace(assigned_space, wid)
+            || !self.window_hidden_from_active_workspace(assigned_space, wid)
         {
             return None;
         }
@@ -3691,6 +3691,25 @@ impl Reactor {
             return false;
         }
 
+        // A visible scratchpad window holds focus against hover; only a click or toggle moves it.
+        let engine = &self.layout_manager.layout_engine;
+        let active_workspace = engine.active_workspace(space);
+        let scratchpad_holds_focus = engine.scratchpad_shown().any(|member| {
+            member != wid
+                && engine.virtual_workspace_manager().workspace_for_window(
+                    &self.state.windows,
+                    space,
+                    member,
+                ) == active_workspace
+        });
+        if scratchpad_holds_focus {
+            trace!(
+                ?wid,
+                "Ignoring mouse over window while a scratchpad window is shown"
+            );
+            return false;
+        }
+
         let Some(candidate_wsid) = window.info.sys_id else {
             return true;
         };
@@ -3830,6 +3849,7 @@ impl Reactor {
                             windows_needing_layout_refresh.push((*wid, assignment));
                         }
                     }
+                    Ok(AppRuleResult::Unchanged) => {}
                     Ok(AppRuleResult::Rejected(_)) => {
                         if utils::rejection_needs_removal(
                             &self.state,
@@ -3940,6 +3960,20 @@ impl Reactor {
         let Some(window_space) = self.best_space_for_window_id(app_window_id) else {
             return EventOutcome::no_change();
         };
+
+        // Cmd-Tab / Dock activation of a parked scratchpad window: show it rather than leave
+        // keyboard focus on an off-screen window.
+        if self.layout_manager.layout_engine.is_scratchpad_parked(app_window_id)
+            && let Some(screen) = self.space_state.screen_by_space(window_space).map(|s| s.frame)
+        {
+            let response = self.layout_manager.layout_engine.show_scratchpad_window(
+                &mut self.state.windows,
+                window_space,
+                screen,
+                app_window_id,
+            );
+            return EventOutcome::layout_changed(false).with_layout_response(response, None);
+        }
 
         self.maybe_auto_switch_to_window_workspace(pid, app_window_id, window_space)
     }
@@ -4499,12 +4533,15 @@ impl Reactor {
     }
 
     fn request_refocus_if_hidden(&mut self, space: SpaceId, window_id: WindowId) {
-        if self.window_in_non_active_workspace(space, window_id) {
+        if self.window_hidden_from_active_workspace(space, window_id) {
             self.refocus_manager.refocus_state = RefocusState::Pending(space);
         }
     }
 
-    fn window_in_non_active_workspace(&self, space: SpaceId, window_id: WindowId) -> bool {
+    fn window_hidden_from_active_workspace(&self, space: SpaceId, window_id: WindowId) -> bool {
+        if self.layout_manager.layout_engine.is_scratchpad_parked(window_id) {
+            return true;
+        }
         let Some(active_workspace) = self.layout_manager.layout_engine.active_workspace(space)
         else {
             return false;
@@ -4522,7 +4559,7 @@ impl Reactor {
                 self.request_refocus_if_hidden(*space, *wid);
             }
             LayoutEvent::WindowObserved(space, window) => {
-                if self.window_in_non_active_workspace(*space, window.info.window_id) {
+                if self.window_hidden_from_active_workspace(*space, window.info.window_id) {
                     self.refocus_manager.refocus_state = RefocusState::Pending(*space);
                 }
             }

--- a/src/actor/reactor/events/window_discovery.rs
+++ b/src/actor/reactor/events/window_discovery.rs
@@ -377,6 +377,7 @@ fn apply_assignment_result(
     let mut outcome = crate::actor::reactor::events::EventOutcome::default();
     let effects = match assign_result {
         Ok(AppRuleResult::Managed(effects)) => Some(effects),
+        Ok(AppRuleResult::Unchanged) => None,
         Ok(AppRuleResult::Rejected(_)) => {
             if utils::rejection_needs_removal(state, layout, wid, space) {
                 outcome = outcome.with_layout_event(LayoutEvent::WindowRemoved(wid));

--- a/src/actor/reactor/managers.rs
+++ b/src/actor/reactor/managers.rs
@@ -16,6 +16,7 @@ use crate::actor::{
 use crate::common::collections::{HashMap, HashSet};
 use crate::common::config::{LayoutMode, WindowSnappingSettings};
 use crate::layout_engine::LayoutEngine;
+use crate::model::HideCorner;
 use crate::model::broadcast::{BroadcastEvent, BroadcastSender, protocol_workspace_id};
 use crate::sys::screen::SpaceId;
 
@@ -170,6 +171,40 @@ pub struct LayoutManager {
 
 pub type LayoutResult = Vec<(SpaceId, Vec<(WindowId, CGRect)>)>;
 
+/// Parked scratchpad windows belong to no workspace, so the per-space layout never sees them.
+/// Park each one in the hidden corner of the in-scope screen it currently sits on.
+fn place_parked_scratchpad_windows(
+    reactor: &Reactor,
+    screens_in_scope: &[(SpaceId, CGRect)],
+    all_screen_frames: &[CGRect],
+    layout_result: &mut LayoutResult,
+) {
+    let engine = &reactor.layout_manager.layout_engine;
+    for wid in engine.scratchpad_parked() {
+        let Some(frame) = reactor.state.windows.window(wid).map(|w| w.frame_monotonic) else {
+            continue;
+        };
+        let current_space = reactor.best_space_for_window_id(wid);
+        let target = screens_in_scope
+            .iter()
+            .find(|(space, _)| Some(*space) == current_space)
+            .or_else(|| current_space.is_none().then(|| screens_in_scope.first()).flatten());
+        let Some((space, screen)) = target else {
+            continue;
+        };
+        let hidden = engine.virtual_workspace_manager().calculate_hidden_position_multi(
+            *screen,
+            frame,
+            HideCorner::BottomRight,
+            None,
+            all_screen_frames,
+        );
+        if let Some((_, positions)) = layout_result.iter_mut().find(|(s, _)| s == space) {
+            positions.push((wid, hidden));
+        }
+    }
+}
+
 fn bound_frame_to_screen(frame: CGRect, screen: CGRect) -> CGRect {
     const WINDOW_HIDDEN_THRESHOLD: f64 = 10.0;
 
@@ -231,6 +266,7 @@ impl LayoutManager {
             .filter(|space| reactor.is_space_active(*space))
             .count();
         let mut layout_result = LayoutResult::new();
+        let mut screens_in_scope = Vec::new();
 
         for screen in screens {
             let Some(space) = screen.space else {
@@ -282,9 +318,16 @@ impl LayoutManager {
                     &active_workspace_windows,
                 );
             }
+            screens_in_scope.push((space, screen.frame));
             layout_result.push((space, layout));
         }
 
+        place_parked_scratchpad_windows(
+            reactor,
+            &screens_in_scope,
+            &all_screen_frames,
+            &mut layout_result,
+        );
         layout_result
     }
 

--- a/src/actor/reactor/tests.rs
+++ b/src/actor/reactor/tests.rs
@@ -7,6 +7,7 @@ use crate::actor::app::{AppThreadHandle, Request, pid_t};
 use crate::actor::wm_controller::WmEvent;
 use crate::common::config::{LayoutMode, OuterGaps, WorkspaceSelector};
 use crate::layout_engine::{Direction, LayoutCommand, LayoutEvent};
+use crate::model::HideCorner;
 use crate::model::window_store::NativeFullscreenTransition;
 use crate::sys::app::{AppInfo, WindowInfo};
 use crate::sys::geometry::SameAs;
@@ -3964,6 +3965,7 @@ fn fullscreen_startup_fixture(
             position: None,
             size: None,
             focus: false,
+            scratchpad: false,
             manage: Some(true),
             app_name: None,
             title_regex: None,
@@ -5617,4 +5619,322 @@ fn floating_window_toggles_to_fullscreen_within_gaps() {
         laid_out.same_as(expected),
         "expected {expected:?}, got {laid_out:?}"
     );
+}
+
+/// Two workspaces, one 1000x1000 screen, `window_count` tiled windows of pid 1, window (1, 1) focused.
+fn scratchpad_context(window_count: usize) -> (Apps, Reactor, SpaceId, CGRect) {
+    let (mut apps, mut reactor) = test_context_with_workspace_count(2);
+    let screen = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
+    let space = SpaceId::new(1);
+    apps.make_app_and_settle_on_screen(&mut reactor, screen, space, 1, make_windows(window_count));
+    reactor.send_layout_event(LayoutEvent::WindowFocused(space, WindowId::new(1, 1)));
+    let _ = apps.requests();
+    (apps, reactor, space, screen)
+}
+
+fn last_frame_write_for(requests: &[Request], wid: WindowId) -> Option<CGRect> {
+    requests.iter().rev().find_map(|req| match req {
+        Request::SetWindowFrame(w, frame, _, _) if *w == wid => Some(*frame),
+        Request::SetBatchWindowFrame(frames, _, _) => {
+            frames.iter().find(|(w, _)| *w == wid).map(|(_, frame)| *frame)
+        }
+        _ => None,
+    })
+}
+
+fn is_parked(reactor: &Reactor, space: SpaceId, wid: WindowId) -> bool {
+    reactor.test_workspace_for_window(space, wid).is_none()
+}
+
+#[test]
+fn move_to_scratchpad_parks_focused_window_offscreen_and_unassigns_it() {
+    let (mut apps, mut reactor, space, screen) = scratchpad_context(2);
+    let wid = WindowId::new(1, 1);
+    let frame = reactor.state.windows.window(wid).expect("window").frame_monotonic;
+    let hidden = reactor
+        .layout_manager
+        .layout_engine
+        .virtual_workspace_manager()
+        .calculate_hidden_position_multi(screen, frame, HideCorner::BottomRight, None, &[screen]);
+
+    reactor.handle_test_layout_command(LayoutCommand::MoveToScratchpad);
+
+    assert!(is_parked(&reactor, space, wid));
+    assert_eq!(reactor.test_active_workspace_windows(space), vec![
+        WindowId::new(1, 2)
+    ]);
+    assert!(reactor.layout_manager.layout_engine.is_window_floating(wid));
+    let requests = apps.requests();
+    let written = last_frame_write_for(&requests, wid)
+        .unwrap_or_else(|| panic!("parked window must be moved off-screen: {requests:?}"));
+    assert!(written.same_as(hidden), "expected {hidden:?}, got {written:?}");
+}
+
+#[test]
+fn toggle_scratchpad_shows_parked_window_at_half_width_three_quarter_height_centered() {
+    let (mut apps, mut reactor, space, _screen) = scratchpad_context(2);
+    let (raise_tx, mut raise_rx) = actor::channel();
+    reactor.communication_manager.raise_manager_tx = raise_tx;
+    let wid = WindowId::new(1, 1);
+    reactor.handle_test_layout_command(LayoutCommand::MoveToScratchpad);
+    apps.simulate_until_quiet(&mut reactor);
+    while raise_rx.try_recv().is_ok() {}
+
+    reactor.handle_test_layout_command(LayoutCommand::ToggleScratchpad);
+
+    let active = reactor.layout_manager.layout_engine.active_workspace(space);
+    assert_eq!(reactor.test_workspace_for_window(space, wid), active);
+    let requests = apps.requests();
+    let written = last_frame_write_for(&requests, wid)
+        .unwrap_or_else(|| panic!("shown window must be laid out: {requests:?}"));
+    let expected = CGRect::new(CGPoint::new(250., 125.), CGSize::new(500., 750.));
+    assert!(
+        written.same_as(expected),
+        "expected {expected:?}, got {written:?}"
+    );
+    let msg = raise_rx.try_recv().expect("showing must raise the window").1;
+    match msg {
+        raise_manager::Event::RaiseRequest(RaiseRequest { focus_window, .. }) => {
+            assert_eq!(focus_window.map(|(w, _)| w), Some(wid));
+        }
+        _ => panic!("Unexpected event: {msg:?}"),
+    }
+}
+
+#[test]
+fn toggle_scratchpad_on_shown_window_parks_it_and_focuses_remaining_window() {
+    let (mut apps, mut reactor, space, _screen) = scratchpad_context(2);
+    let (raise_tx, mut raise_rx) = actor::channel();
+    reactor.communication_manager.raise_manager_tx = raise_tx;
+    let wid = WindowId::new(1, 1);
+    reactor.handle_test_layout_command(LayoutCommand::MoveToScratchpad);
+    apps.simulate_until_quiet(&mut reactor);
+    reactor.handle_test_layout_command(LayoutCommand::ToggleScratchpad);
+    apps.simulate_until_quiet(&mut reactor);
+    while raise_rx.try_recv().is_ok() {}
+
+    reactor.handle_test_layout_command(LayoutCommand::ToggleScratchpad);
+
+    assert!(is_parked(&reactor, space, wid));
+    assert_eq!(reactor.test_active_workspace_windows(space), vec![
+        WindowId::new(1, 2)
+    ]);
+    let msg = raise_rx.try_recv().expect("hiding must hand focus to the remaining window").1;
+    match msg {
+        raise_manager::Event::RaiseRequest(RaiseRequest { focus_window, .. }) => {
+            assert_eq!(focus_window.map(|(w, _)| w), Some(WindowId::new(1, 2)));
+        }
+        _ => panic!("Unexpected event: {msg:?}"),
+    }
+}
+
+#[test]
+fn toggle_scratchpad_cycles_parked_windows_oldest_first() {
+    let (mut apps, mut reactor, space, _screen) = scratchpad_context(3);
+    let (a, b) = (WindowId::new(1, 1), WindowId::new(1, 2));
+    reactor.handle_test_layout_command(LayoutCommand::MoveToScratchpad);
+    reactor.send_layout_event(LayoutEvent::WindowFocused(space, b));
+    reactor.handle_test_layout_command(LayoutCommand::MoveToScratchpad);
+    apps.simulate_until_quiet(&mut reactor);
+    assert!(is_parked(&reactor, space, a) && is_parked(&reactor, space, b));
+
+    reactor.handle_test_layout_command(LayoutCommand::ToggleScratchpad);
+    assert!(
+        !is_parked(&reactor, space, a),
+        "oldest parked window shows first"
+    );
+    assert!(is_parked(&reactor, space, b));
+
+    reactor.handle_test_layout_command(LayoutCommand::ToggleScratchpad);
+    assert!(
+        is_parked(&reactor, space, a),
+        "toggle on the shown member hides it"
+    );
+    assert!(is_parked(&reactor, space, b));
+
+    reactor.handle_test_layout_command(LayoutCommand::ToggleScratchpad);
+    assert!(is_parked(&reactor, space, a));
+    assert!(
+        !is_parked(&reactor, space, b),
+        "next toggle shows the other window"
+    );
+}
+
+#[test]
+fn toggle_scratchpad_without_members_parks_focused_window() {
+    let (_apps, mut reactor, space, _screen) = scratchpad_context(2);
+    let wid = WindowId::new(1, 1);
+
+    reactor.handle_test_layout_command(LayoutCommand::ToggleScratchpad);
+
+    assert!(is_parked(&reactor, space, wid));
+    assert!(reactor.layout_manager.layout_engine.is_window_floating(wid));
+    assert_eq!(reactor.test_active_workspace_windows(space), vec![
+        WindowId::new(1, 2)
+    ]);
+}
+
+#[test]
+fn toggle_scratchpad_pulls_member_shown_on_inactive_workspace() {
+    let (mut apps, mut reactor, space, _screen) = scratchpad_context(2);
+    let wid = WindowId::new(1, 1);
+    reactor.handle_test_layout_command(LayoutCommand::MoveToScratchpad);
+    reactor.handle_test_layout_command(LayoutCommand::ToggleScratchpad);
+    apps.simulate_until_quiet(&mut reactor);
+    reactor.handle_test_layout_command(LayoutCommand::SwitchToWorkspace(1));
+    apps.simulate_until_quiet(&mut reactor);
+    let ws1 = reactor.test_workspace(space, 1);
+    assert_eq!(
+        reactor.layout_manager.layout_engine.active_workspace(space),
+        Some(ws1)
+    );
+
+    reactor.handle_test_layout_command(LayoutCommand::ToggleScratchpad);
+
+    assert_eq!(reactor.test_workspace_for_window(space, wid), Some(ws1));
+}
+
+#[test]
+fn unfloating_scratchpad_window_leaves_scratchpad() {
+    let (mut apps, mut reactor, space, _screen) = scratchpad_context(2);
+    let wid = WindowId::new(1, 1);
+    reactor.handle_test_layout_command(LayoutCommand::MoveToScratchpad);
+    reactor.handle_test_layout_command(LayoutCommand::ToggleScratchpad);
+    apps.simulate_until_quiet(&mut reactor);
+    assert!(reactor.layout_manager.layout_engine.is_scratchpad_member(wid));
+
+    reactor.handle_test_layout_command(LayoutCommand::ToggleWindowFloating);
+
+    assert!(!reactor.layout_manager.layout_engine.is_window_floating(wid));
+    assert!(!reactor.layout_manager.layout_engine.is_scratchpad_member(wid));
+    assert!(!is_parked(&reactor, space, wid));
+}
+
+#[test]
+fn windows_discovered_keeps_parked_scratchpad_window_hidden() {
+    let (mut apps, mut reactor, space, _screen) = scratchpad_context(2);
+    let wid = WindowId::new(1, 1);
+    reactor.handle_test_layout_command(LayoutCommand::MoveToScratchpad);
+    apps.simulate_until_quiet(&mut reactor);
+
+    reactor.discover_test_windows(1, vec![], vec![wid, WindowId::new(1, 2)]);
+
+    assert!(
+        is_parked(&reactor, space, wid),
+        "discovery must not re-assign a parked window"
+    );
+    assert_eq!(reactor.test_active_workspace_windows(space), vec![
+        WindowId::new(1, 2)
+    ]);
+}
+
+#[test]
+fn shown_scratchpad_holds_focus_against_hover_on_every_other_window() {
+    let (mut apps, mut reactor, space, _screen) = scratchpad_context(3);
+    apps.make_app_and_settle(&mut reactor, 2, make_windows(1));
+    let scratch = WindowId::new(1, 1);
+    let sibling = WindowId::new(1, 2);
+    let foreign = WindowId::new(2, 1);
+    reactor.send_layout_event(LayoutEvent::WindowFocused(space, scratch));
+    reactor.handle_test_layout_command(LayoutCommand::MoveToScratchpad);
+    reactor.handle_test_layout_command(LayoutCommand::ToggleScratchpad);
+    apps.simulate_until_quiet(&mut reactor);
+
+    assert!(
+        !reactor.should_raise_on_mouse_over(sibling),
+        "same-app window must not autoraise"
+    );
+    assert!(
+        !reactor.should_raise_on_mouse_over(foreign),
+        "other-app window must not autoraise"
+    );
+    assert!(
+        reactor.should_raise_on_mouse_over(scratch),
+        "the scratchpad itself may autoraise"
+    );
+
+    reactor.handle_test_layout_command(LayoutCommand::ToggleScratchpad);
+    apps.simulate_until_quiet(&mut reactor);
+
+    assert!(is_parked(&reactor, space, scratch));
+    assert!(
+        reactor.should_raise_on_mouse_over(sibling),
+        "focus-follows-mouse resumes once the scratchpad is hidden"
+    );
+}
+
+#[test]
+fn app_rule_scratchpad_parks_new_window_and_refocuses_previous() {
+    let settings = crate::common::config::VirtualWorkspaceSettings {
+        app_rules: vec![crate::common::config::AppWorkspaceRule {
+            app_id: Some("com.testapp2".into()),
+            scratchpad: true,
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let (mut apps, mut reactor) = (Apps::new(), test_reactor_with_workspace_settings(&settings));
+    reactor.config.virtual_workspaces = settings;
+    let (raise_tx, mut raise_rx) = actor::channel();
+    reactor.communication_manager.raise_manager_tx = raise_tx;
+    let screen = CGRect::new(CGPoint::new(0., 0.), CGSize::new(1000., 1000.));
+    let space = SpaceId::new(1);
+    let previous = WindowId::new(1, 1);
+    let scratch = WindowId::new(2, 1);
+    apps.make_app_and_settle_on_screen(&mut reactor, screen, space, 1, make_windows(1));
+    reactor.send_layout_event(LayoutEvent::WindowFocused(space, previous));
+    while raise_rx.try_recv().is_ok() {}
+
+    apps.make_app_and_settle(&mut reactor, 2, make_windows(1));
+
+    assert!(
+        is_parked(&reactor, space, scratch),
+        "rule must park the new window"
+    );
+    assert!(reactor.layout_manager.layout_engine.is_window_floating(scratch));
+    assert_eq!(reactor.test_active_workspace_windows(space), vec![previous]);
+    let refocus = std::iter::from_fn(|| raise_rx.try_recv().ok())
+        .filter_map(|(_, msg)| match msg {
+            raise_manager::Event::RaiseRequest(RaiseRequest { focus_window, .. }) => {
+                focus_window.map(|(w, _)| w)
+            }
+            _ => None,
+        })
+        .last();
+    assert_eq!(
+        refocus,
+        Some(previous),
+        "focus must return to the previously focused window"
+    );
+}
+
+#[test]
+fn activating_parked_scratchpad_window_shows_it() {
+    let (mut apps, mut reactor, space, _screen) = scratchpad_context(2);
+    let (raise_tx, mut raise_rx) = actor::channel();
+    reactor.communication_manager.raise_manager_tx = raise_tx;
+    let wid = WindowId::new(1, 1);
+    reactor.handle_test_layout_command(LayoutCommand::MoveToScratchpad);
+    apps.simulate_until_quiet(&mut reactor);
+    while raise_rx.try_recv().is_ok() {}
+    let _ = apps.requests();
+
+    // Cmd-Tab / Dock click: the app thread resolves the app's main window, which is the parked one.
+    reactor.handle_event(Event::ApplicationGloballyActivated(1));
+    assert_eq!(reactor.main_window(), Some(wid));
+    reactor.handle_event(Event::ApplicationActivated(1, Quiet::No));
+
+    assert!(
+        !is_parked(&reactor, space, wid),
+        "activation must unpark instead of focusing a hidden window"
+    );
+    let active = reactor.layout_manager.layout_engine.active_workspace(space);
+    assert_eq!(reactor.test_workspace_for_window(space, wid), active);
+    let msg = raise_rx.try_recv().expect("unparking must raise the window").1;
+    match msg {
+        raise_manager::Event::RaiseRequest(RaiseRequest { focus_window, .. }) => {
+            assert_eq!(focus_window.map(|(w, _)| w), Some(wid));
+        }
+        _ => panic!("Unexpected event: {msg:?}"),
+    }
 }

--- a/src/bin/rift-cli.rs
+++ b/src/bin/rift-cli.rs
@@ -193,6 +193,10 @@ enum WindowCommands {
     ToggleFullscreen,
     /// Toggle fullscreen within configured outer gaps (respects outer gaps / fills tiling area)
     ToggleFullscreenWithinGaps,
+    /// Hide the focused scratchpad window, or show the next hidden one on the current workspace
+    ToggleScratchpad,
+    /// Park the focused window in the scratchpad (hidden, floating, on no workspace)
+    MoveToScratchpad,
     /// Grow the current window size (increments by ~5%).
     ResizeGrow {
         /// Axis to resize; smart chooses the nearest applicable split.
@@ -765,6 +769,12 @@ fn map_window_command(cmd: WindowCommands) -> Result<CliCommand, String> {
         WindowCommands::ToggleFullscreenWithinGaps => Ok(CliCommand::Reactor(
             reactor::Command::Layout(LC::ToggleFullscreenWithinGaps),
         )),
+        WindowCommands::ToggleScratchpad => Ok(CliCommand::Reactor(reactor::Command::Layout(
+            LC::ToggleScratchpad,
+        ))),
+        WindowCommands::MoveToScratchpad => Ok(CliCommand::Reactor(reactor::Command::Layout(
+            LC::MoveToScratchpad,
+        ))),
         WindowCommands::ResizeGrow { orientation } => Ok(CliCommand::Reactor(
             reactor::Command::Layout(LC::ResizeWindowGrow(orientation.into())),
         )),
@@ -1172,6 +1182,24 @@ mod tests {
                 "execute_command": { "command": { "layout": "next_window" } }
             })
         );
+    }
+
+    #[test]
+    fn scratchpad_window_commands_map_to_layout_commands() {
+        for (subcommand, layout_command) in [
+            ("toggle-scratchpad", "toggle_scratchpad"),
+            ("move-to-scratchpad", "move_to_scratchpad"),
+        ] {
+            let cli = Cli::try_parse_from(["rift-cli", "execute", "window", subcommand])
+                .unwrap_or_else(|error| panic!("{subcommand} should parse: {error}"));
+            let request = build_request(cli.command).unwrap();
+            assert_eq!(
+                serde_json::to_value(request).unwrap(),
+                serde_json::json!({
+                    "execute_command": { "command": { "layout": layout_command } }
+                })
+            );
+        }
     }
 
     #[test]

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -81,6 +81,10 @@ pub struct AppWorkspaceRule {
     /// Focus the window after applying this rule, switching virtual workspaces if needed.
     #[serde(default)]
     pub focus: bool,
+    /// Park matching windows in the scratchpad when they appear (implies floating). Summon them
+    /// with the `toggle_scratchpad` command.
+    #[serde(default)]
+    pub scratchpad: bool,
     /// An explicit management override. `false` makes the window invisible to Rift;
     /// `true` overrides normal manageability heuristics for a visible window. When
     /// omitted, the matching rule leaves Rift's normal manageability decision intact.
@@ -286,6 +290,19 @@ impl VirtualWorkspaceSettings {
             {
                 issues.push(format!(
                     "App rule {} sets manage = false, so its workspace, floating, position, size, and focus effects are ignored",
+                    index
+                ));
+            }
+
+            if rule.scratchpad
+                && (rule.manage == Some(false)
+                    || rule.workspace.is_some()
+                    || rule.position.is_some()
+                    || rule.size.is_some()
+                    || rule.focus)
+            {
+                issues.push(format!(
+                    "App rule {} sets scratchpad = true (the window is parked on launch and shown via toggle_scratchpad), which cannot be combined with workspace, position, size, focus, or manage = false",
                     index
                 ));
             }
@@ -1708,6 +1725,7 @@ mod tests {
                 h: Some(f64::NAN),
             }),
             focus: false,
+            scratchpad: false,
             manage: Some(true),
             app_name: None,
             title_regex: None,
@@ -1738,6 +1756,56 @@ mod tests {
         let issues = settings.validate();
         assert!(issues.iter().any(|issue| issue.contains("invalid title_regex")));
         assert!(issues.iter().any(|issue| issue.contains("effects are ignored")));
+    }
+
+    #[test]
+    fn app_rule_scratchpad_parses_and_rejects_conflicting_effects() {
+        let settings: VirtualWorkspaceSettings = toml::from_str(
+            r#"
+                app_rules = [{ app_id = "net.kovidgoyal.kitty", title_substring = "Scratchpad", scratchpad = true }]
+            "#,
+        )
+        .unwrap();
+        assert!(settings.app_rules[0].scratchpad);
+        assert!(settings.validate().is_empty());
+
+        let mut conflicting = VirtualWorkspaceSettings::default();
+        conflicting.app_rules.push(AppWorkspaceRule {
+            app_id: Some("com.example.Tool".into()),
+            scratchpad: true,
+            floating: true,
+            position: Some(AppRulePosition { x: 0.5, y: 0.5 }),
+            ..Default::default()
+        });
+        let issues = conflicting.validate();
+        assert!(
+            issues.iter().any(|issue| issue.contains("scratchpad")),
+            "position must be rejected together with scratchpad: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn scratchpad_commands_parse_from_key_bindings() {
+        #[derive(Deserialize)]
+        struct TestConfig {
+            keys: HashMap<String, WmCommand>,
+        }
+        let parsed: TestConfig = toml::from_str(
+            r#"
+            [keys]
+            toggle = "toggle_scratchpad"
+            park = "move_to_scratchpad"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(
+            parsed.keys["toggle"],
+            WmCommand::ReactorCommand(reactor::Command::Layout(LayoutCommand::ToggleScratchpad))
+        );
+        assert_eq!(
+            parsed.keys["park"],
+            WmCommand::ReactorCommand(reactor::Command::Layout(LayoutCommand::MoveToScratchpad))
+        );
     }
 
     #[test]

--- a/src/layout_engine.rs
+++ b/src/layout_engine.rs
@@ -1,6 +1,7 @@
 pub mod engine;
 mod floating;
 pub(crate) mod graph;
+mod scratchpad;
 pub mod systems;
 pub mod utils;
 mod workspaces;
@@ -12,6 +13,7 @@ pub use engine::{
 };
 pub(crate) use floating::FloatingManager;
 pub use graph::{Direction, LayoutKind, Orientation, ResizeOrientation};
+pub(crate) use scratchpad::Scratchpad;
 pub(crate) use systems::LayoutId;
 pub use systems::{
     BspLayoutSystem, LayoutSystem, LayoutSystemKind, MasterStackLayoutSystem,

--- a/src/layout_engine/engine.rs
+++ b/src/layout_engine/engine.rs
@@ -6,7 +6,8 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
 
 use super::{
-    Direction, FloatingManager, LayoutId, LayoutSystemKind, ResizeOrientation, WorkspaceLayouts,
+    Direction, FloatingManager, LayoutId, LayoutSystemKind, ResizeOrientation, Scratchpad,
+    WorkspaceLayouts,
 };
 #[cfg(test)]
 use crate::actor::app::AppInfo;
@@ -33,6 +34,9 @@ pub use rift_protocol::LayoutCommand;
 
 const SMART_FLOATING_WIDTH_RATIO: f64 = 0.8;
 const SMART_FLOATING_HEIGHT_RATIO: f64 = 0.93;
+// i3's defaults for a scratchpad window first shown after being parked from tiling.
+const SCRATCHPAD_WIDTH_RATIO: f64 = 0.5;
+const SCRATCHPAD_HEIGHT_RATIO: f64 = 0.75;
 
 fn requested_floating_frame(
     mut frame: CGRect,
@@ -154,6 +158,7 @@ impl std::ops::Deref for LayoutEventOutcome {
 pub struct LayoutEngine {
     workspace_layouts: WorkspaceLayouts,
     floating: FloatingManager,
+    scratchpad: Scratchpad,
     floating_positions: FloatingPositionStore,
     app_rules: AppRuleEngine,
     focused_window: Option<WindowId>,
@@ -1074,6 +1079,7 @@ impl LayoutEngine {
         if !preserve_floating {
             self.virtual_workspace_manager.remove_window(window_store, wid);
             self.floating_positions.remove_window(wid);
+            self.scratchpad.remove(wid);
             self.forget_persisted_window(wid);
         }
 
@@ -1119,6 +1125,9 @@ impl LayoutEngine {
         space: SpaceId,
         wid: WindowId,
     ) -> bool {
+        if self.scratchpad.is_parked(wid) {
+            return false;
+        }
         let active_space_before = self.space_with_window(wid);
 
         let assigned_workspace =
@@ -1293,6 +1302,7 @@ impl LayoutEngine {
         LayoutEngine {
             workspace_layouts: WorkspaceLayouts::default(),
             floating: FloatingManager::new(),
+            scratchpad: Scratchpad::default(),
             floating_positions: FloatingPositionStore::default(),
             app_rules: AppRuleEngine::new(&virtual_workspace_config.app_rules),
             focused_window: None,
@@ -1524,6 +1534,11 @@ impl LayoutEngine {
                     self.broadcast_windows_changed(window_store, space);
                 }
 
+                // Last, so the floating/tiling bookkeeping above cannot re-activate the window.
+                if effects.scratchpad && !self.scratchpad.is_member(wid) {
+                    return self.park_window(window_store, space, wid);
+                }
+
                 if let Some((window, workspace)) = focus_request {
                     let workspace_index = self
                         .virtual_workspace_manager_mut()
@@ -1582,6 +1597,7 @@ impl LayoutEngine {
                     ws.layout_system.remove_windows_for_app(pid);
                 }
                 self.floating.remove_all_for_pid(pid);
+                self.scratchpad.remove_for_pid(pid);
                 self.window_layout_constraints.retain(|wid, _| wid.pid != pid);
                 self.forget_persisted_app(pid);
 
@@ -1605,6 +1621,9 @@ impl LayoutEngine {
                 self.remove_window_internal(window_store, wid, true);
             }
             LayoutEvent::WindowFocused(space, wid) => {
+                if self.scratchpad.is_parked(wid) {
+                    return EventResponse::default();
+                }
                 if self.floating.is_floating(wid) {
                     self.focused_window = Some(wid);
                     self.floating.set_last_focus(Some(wid));
@@ -1722,6 +1741,7 @@ impl LayoutEngine {
                 }
                 self.floating.remove_floating(wid);
                 self.floating.set_last_focus(None);
+                self.scratchpad.remove(wid);
             } else {
                 if let Some(space) = space {
                     self.floating.add_active(space, wid.pid, wid);
@@ -1861,6 +1881,15 @@ impl LayoutEngine {
             LayoutCommand::ToggleWindowFloating
             | LayoutCommand::ToggleWindowFloatingWithOptions(_) => unreachable!(),
             LayoutCommand::ToggleFocusFloating => unreachable!(),
+            LayoutCommand::MoveToScratchpad => match self.focused_window {
+                Some(wid) if !self.scratchpad.is_parked(wid) => {
+                    self.park_window(window_store, space, wid)
+                }
+                _ => EventResponse::default(),
+            },
+            LayoutCommand::ToggleScratchpad => {
+                self.toggle_scratchpad(window_store, space, workspace_id, visible_space_centers)
+            }
 
             LayoutCommand::SwapWindows(a, b) => {
                 let a = crate::actor::app::WindowId::new(a.pid, a.idx);
@@ -2830,6 +2859,10 @@ impl LayoutEngine {
         } else {
             false
         };
+        // After identity restore so a persisted parked window maps onto its live id first.
+        if self.scratchpad.is_parked(window_id) {
+            return Ok(AppRuleResult::Unchanged);
+        }
         let context = WindowRuleContext {
             app_bundle_id,
             app_name,
@@ -3051,6 +3084,22 @@ impl LayoutEngine {
         self.virtual_workspace_manager.get_stats(window_store)
     }
 
+    pub fn is_scratchpad_member(&self, window_id: WindowId) -> bool {
+        self.scratchpad.is_member(window_id)
+    }
+
+    pub fn is_scratchpad_parked(&self, window_id: WindowId) -> bool {
+        self.scratchpad.is_parked(window_id)
+    }
+
+    pub fn scratchpad_shown(&self) -> impl Iterator<Item = WindowId> + '_ {
+        self.scratchpad.shown()
+    }
+
+    pub fn scratchpad_parked(&self) -> impl Iterator<Item = WindowId> + '_ {
+        self.scratchpad.parked()
+    }
+
     pub fn is_window_floating(&self, window_id: WindowId) -> bool {
         self.floating.is_floating(window_id)
     }
@@ -3111,6 +3160,7 @@ impl LayoutEngine {
         self.virtual_workspace_manager.transfer_window_identity(from, to);
         self.floating_positions.transfer_window_identity(from, to);
         self.floating.transfer_window_identity(from, to);
+        self.scratchpad.transfer_identity(from, to);
         self.transfer_persisted_window_identity(from, to);
         if let Some(constraints) = self.window_layout_constraints.remove(&from) {
             self.window_layout_constraints.insert(to, constraints);
@@ -3226,8 +3276,168 @@ impl LayoutEngine {
         space: SpaceId,
         window_id: WindowId,
     ) -> bool {
+        // Unassigned windows count as active; parked scratchpad windows are the exception.
+        !self.scratchpad.is_parked(window_id)
+            && self.virtual_workspace_manager.is_window_in_active_workspace(
+                window_store,
+                space,
+                window_id,
+            )
+    }
+
+    fn command_screen(
+        &self,
+        space: SpaceId,
+        workspace_id: VirtualWorkspaceId,
+        visible_space_centers: &HashMap<SpaceId, CGPoint>,
+    ) -> Option<CGRect> {
+        let center = visible_space_centers.get(&space)?;
+        let size = self.workspace_layouts.active_size(space, workspace_id)?;
+        Some(CGRect::new(
+            CGPoint::new(center.x - size.width / 2.0, center.y - size.height / 2.0),
+            size,
+        ))
+    }
+
+    fn toggle_scratchpad(
+        &mut self,
+        window_store: &mut WindowStore,
+        space: SpaceId,
+        workspace_id: VirtualWorkspaceId,
+        visible_space_centers: &HashMap<SpaceId, CGPoint>,
+    ) -> EventResponse {
+        if let Some(wid) = self.focused_window.filter(|wid| self.scratchpad.is_shown(*wid)) {
+            return self.park_window(window_store, space, wid);
+        }
+        let Some(screen) = self.command_screen(space, workspace_id, visible_space_centers) else {
+            return EventResponse::default();
+        };
+        // Persisted members whose app is gone are skipped rather than pruned.
+        let is_live = |wid: &WindowId| window_store.window(*wid).is_some();
+        let shown = self.scratchpad.shown().find(is_live);
+        if let Some(wid) = shown {
+            if self.virtual_workspace_manager.workspace_for_window(window_store, space, wid)
+                == Some(workspace_id)
+            {
+                self.focused_window = Some(wid);
+                self.floating.set_last_focus(Some(wid));
+                return EventResponse {
+                    changed: true,
+                    raise_windows: vec![wid],
+                    focus_window: Some(wid),
+                    boundary_hit: None,
+                };
+            }
+            return self.show_scratchpad_window(window_store, space, screen, wid);
+        }
+        let parked = self.scratchpad.parked().find(is_live);
+        if let Some(wid) = parked {
+            return self.show_scratchpad_window(window_store, space, screen, wid);
+        }
+        match self.focused_window {
+            Some(wid) => self.park_window(window_store, space, wid),
+            None => EventResponse::default(),
+        }
+    }
+
+    /// Hides `wid` in the scratchpad: floating, on no workspace, parked off-screen by the reactor.
+    fn park_window(
+        &mut self,
+        window_store: &mut WindowStore,
+        space: SpaceId,
+        wid: WindowId,
+    ) -> EventResponse {
+        let Some(active_workspace) = self.virtual_workspace_manager.active_workspace(space) else {
+            return EventResponse::default();
+        };
+        let workspace_id = self
+            .virtual_workspace_manager
+            .workspace_for_window(window_store, space, wid)
+            .unwrap_or(active_workspace);
+        let was_tiled = !self.floating.is_floating(wid);
+        if was_tiled {
+            self.remove_window_from_all_tiling_trees(wid);
+        } else {
+            self.floating.remove_active_for_window(wid);
+        }
+        // Saved for every park: restores the pre-hide frame on re-show and keeps the floating
+        // flag alive across a restart (load drops floating windows without a saved location).
+        if self.floating.fullscreen_kind(wid).is_none()
+            && let Some(frame) = window_store.window(wid).map(|w| w.frame_monotonic)
+        {
+            self.floating_positions.store(space, workspace_id, wid, frame);
+        }
+        self.floating.set_fullscreen(wid, None);
+        self.floating.add_floating(wid);
+        if self.virtual_workspace_manager.last_focused_window(space, workspace_id) == Some(wid) {
+            self.virtual_workspace_manager
+                .set_last_focused_window(space, workspace_id, None);
+        }
+        self.virtual_workspace_manager.remove_window(window_store, wid);
+        if self.focused_window == Some(wid) {
+            self.focused_window = None;
+        }
+        if self.floating.last_focus() == Some(wid) {
+            self.floating.set_last_focus(None);
+        }
+        self.scratchpad.park(wid, was_tiled);
+        self.broadcast_windows_changed(window_store, space);
+        EventResponse {
+            changed: true,
+            raise_windows: Vec::new(),
+            focus_window: self.preferred_focus_for_workspace(
+                window_store,
+                space,
+                active_workspace,
+                None,
+            ),
+            boundary_hit: None,
+        }
+    }
+
+    /// Shows scratchpad member `wid` as a floating window on the active workspace of `space`.
+    /// Also pulls a member that is currently shown on another workspace or space.
+    pub fn show_scratchpad_window(
+        &mut self,
+        window_store: &mut WindowStore,
+        space: SpaceId,
+        screen: CGRect,
+        wid: WindowId,
+    ) -> EventResponse {
+        let Some(workspace_id) = self.virtual_workspace_manager.active_workspace(space) else {
+            return EventResponse::default();
+        };
+        self.floating.remove_active_for_window(wid);
+        if !self.virtual_workspace_manager.assign_window_to_workspace(
+            window_store,
+            space,
+            wid,
+            workspace_id,
+        ) {
+            return EventResponse::default();
+        }
+        self.floating.add_floating(wid);
+        self.floating.add_active(space, wid.pid, wid);
+        if self.scratchpad.show(wid) {
+            let current = window_store.window(wid).map_or(screen, |w| w.frame_monotonic);
+            let size = FloatingWindowSize::Dimensions {
+                w: screen.size.width * SCRATCHPAD_WIDTH_RATIO,
+                h: screen.size.height * SCRATCHPAD_HEIGHT_RATIO,
+            };
+            let frame = requested_floating_frame(current, screen, true, Some(size));
+            self.floating_positions.store(space, workspace_id, wid, frame);
+        }
+        self.focused_window = Some(wid);
+        self.floating.set_last_focus(Some(wid));
         self.virtual_workspace_manager
-            .is_window_in_active_workspace(window_store, space, window_id)
+            .set_last_focused_window(space, workspace_id, Some(wid));
+        self.broadcast_windows_changed(window_store, space);
+        EventResponse {
+            changed: true,
+            raise_windows: vec![wid],
+            focus_window: Some(wid),
+            boundary_hit: None,
+        }
     }
 }
 
@@ -3357,6 +3567,7 @@ mod tests {
             position: Some(AppRulePosition { x: 0.4, y: 0.7 }),
             size: Some(AppRuleSize { w: Some(640.0), h: Some(480.0) }),
             focus: true,
+            scratchpad: false,
             manage: Some(true),
             app_name: None,
             title_regex: None,
@@ -3432,6 +3643,7 @@ mod tests {
             position: None,
             size: Some(AppRuleSize { w: Some(234.0), h: None }),
             focus: false,
+            scratchpad: false,
             manage: Some(true),
             app_name: None,
             title_regex: None,

--- a/src/layout_engine/engine/persistence/mod.rs
+++ b/src/layout_engine/engine/persistence/mod.rs
@@ -8,7 +8,7 @@ use objc2_core_foundation::CGSize;
 pub use rift_protocol::{RestoreScope, RestoreSource};
 use serde::{Deserialize, Serialize};
 
-use super::{FloatingManager, LayoutEngine, WorkspaceLayouts};
+use super::{FloatingManager, LayoutEngine, Scratchpad, WorkspaceLayouts};
 use crate::actor::app::{WindowId, pid_t};
 use crate::common::collections::{HashMap, HashSet};
 use crate::common::config::{LayoutSettings, VirtualWorkspaceSettings};

--- a/src/layout_engine/engine/persistence/reconcile.rs
+++ b/src/layout_engine/engine/persistence/reconcile.rs
@@ -16,6 +16,7 @@ impl LayoutEngine {
             self.remove_window_from_all_tiling_trees(*window);
             self.floating_positions.remove_window(*window);
             self.floating.remove_floating(*window);
+            self.scratchpad.remove(*window);
             self.virtual_workspace_manager.forget_window_identity(*window);
             self.window_layout_constraints.remove(window);
             if self.focused_window == Some(*window) {

--- a/src/layout_engine/engine/persistence/snapshot.rs
+++ b/src/layout_engine/engine/persistence/snapshot.rs
@@ -14,6 +14,8 @@ pub(super) struct PersistedLayout {
     pub(super) schema_version: u32,
     pub(super) workspace_layouts: WorkspaceLayouts,
     pub(super) floating: FloatingManager,
+    #[serde(default)]
+    pub(super) scratchpad: Scratchpad,
     pub(super) floating_positions: FloatingPositionStore,
     pub(super) virtual_workspace_manager: WorkspaceStore,
     #[serde(default)]
@@ -30,6 +32,7 @@ struct PersistedLayoutRef<'a> {
     schema_version: u32,
     workspace_layouts: &'a WorkspaceLayouts,
     floating: &'a FloatingManager,
+    scratchpad: &'a Scratchpad,
     floating_positions: &'a FloatingPositionStore,
     virtual_workspace_manager: &'a WorkspaceStore,
     space_display_map: &'a HashMap<SpaceId, Option<String>>,
@@ -48,6 +51,7 @@ impl PersistedLayout {
             schema_version: CURRENT_SCHEMA_VERSION,
             workspace_layouts: &engine.workspace_layouts,
             floating: &engine.floating,
+            scratchpad: &engine.scratchpad,
             floating_positions: &engine.floating_positions,
             virtual_workspace_manager: &engine.virtual_workspace_manager,
             space_display_map: &engine.space_display_map,
@@ -61,6 +65,7 @@ impl PersistedLayout {
         LayoutEngine {
             workspace_layouts: self.workspace_layouts,
             floating: self.floating,
+            scratchpad: self.scratchpad,
             floating_positions: self.floating_positions,
             app_rules: AppRuleEngine::default(),
             focused_window: None,

--- a/src/layout_engine/engine/persistence/storage.rs
+++ b/src/layout_engine/engine/persistence/storage.rs
@@ -253,6 +253,8 @@ impl LayoutEngine {
             }
         }
         self.floating.normalize_persisted_focus();
+        let floating = &self.floating;
+        self.scratchpad.retain(|window| floating.is_floating(window));
     }
 
     fn normalize_loaded_workspace_focus(&mut self) {

--- a/src/layout_engine/engine/persistence/tests.rs
+++ b/src/layout_engine/engine/persistence/tests.rs
@@ -16,6 +16,33 @@ fn test_engine() -> LayoutEngine {
     )
 }
 
+fn plain_window_state(title: &str) -> WindowState {
+    let frame = objc2_core_foundation::CGRect::new(
+        objc2_core_foundation::CGPoint::new(100.0, 100.0),
+        CGSize::new(800.0, 600.0),
+    );
+    WindowState {
+        info: WindowInfo {
+            is_standard: true,
+            is_root: true,
+            is_minimized: false,
+            is_resizable: true,
+            min_size: None,
+            max_size: None,
+            title: title.into(),
+            frame,
+            sys_id: None,
+            bundle_id: None,
+            path: None,
+            ax_role: None,
+            ax_subrole: None,
+        },
+        frame_monotonic: frame,
+        is_manageable: true,
+        manage_override: None,
+    }
+}
+
 #[test]
 fn identity_transfer_preserves_window_tree_position_and_fingerprint() {
     let mut window_store = WindowStore::default();
@@ -392,6 +419,56 @@ fn load_removes_serialized_window_state_without_a_fingerprint() {
         loaded.virtual_workspace_manager.last_focused_window(space, workspace),
         None
     );
+}
+
+#[test]
+fn save_and_load_preserve_parked_scratchpad_window() {
+    let mut engine = test_engine();
+    let mut window_store = WindowStore::default();
+    let space = SpaceId::new(123);
+    let parked = WindowId::new(42, 1);
+    let sibling = WindowId::new(42, 2);
+    let _ = engine.handle_event(
+        &mut window_store,
+        LayoutEvent::SpaceExposed(space, CGSize::new(1200.0, 800.0)),
+    );
+    let _ = engine.handle_event(&mut window_store, LayoutEvent::WindowAdded(space, parked));
+    let _ = engine.handle_event(&mut window_store, LayoutEvent::WindowAdded(space, sibling));
+    window_store.insert_window(parked, plain_window_state("Scratch"));
+    engine.persistence.windows.insert(parked, WindowFingerprint {
+        window_server_id: Some(7),
+        title: Some("Scratch".into()),
+        width: 800.0,
+        height: 600.0,
+        app_id: Some("com.example.term".into()),
+    });
+    let _ = engine.park_window(&mut window_store, space, parked);
+    assert!(engine.is_scratchpad_parked(parked));
+
+    let loaded = LayoutEngine::deserialize_from_str(&engine.serialize_to_string()).unwrap();
+
+    assert!(loaded.is_scratchpad_parked(parked));
+    assert!(loaded.is_window_floating(parked));
+}
+
+#[test]
+fn load_drops_scratchpad_member_without_a_fingerprint() {
+    let mut engine = test_engine();
+    let mut window_store = WindowStore::default();
+    let space = SpaceId::new(123);
+    let ghost = WindowId::new(42, 9);
+    let _ = engine.handle_event(
+        &mut window_store,
+        LayoutEvent::SpaceExposed(space, CGSize::new(1200.0, 800.0)),
+    );
+    let _ = engine.handle_event(&mut window_store, LayoutEvent::WindowAdded(space, ghost));
+    window_store.insert_window(ghost, plain_window_state("Ghost"));
+    let _ = engine.park_window(&mut window_store, space, ghost);
+    assert!(!engine.persistence.windows.contains_key(&ghost));
+
+    let loaded = LayoutEngine::deserialize_from_str(&engine.serialize_to_string()).unwrap();
+
+    assert!(!loaded.is_scratchpad_member(ghost));
 }
 
 #[test]

--- a/src/layout_engine/scratchpad.rs
+++ b/src/layout_engine/scratchpad.rs
@@ -1,0 +1,177 @@
+use std::collections::{BTreeSet, VecDeque};
+
+use serde::{Deserialize, Serialize};
+
+use crate::actor::app::{WindowId, pid_t};
+
+/// i3-style scratchpad membership. Parked windows live on no virtual workspace; shown
+/// members are ordinary floating windows on whichever workspace they were summoned to.
+#[derive(Default, Serialize, Deserialize)]
+pub(crate) struct Scratchpad {
+    /// Hidden members, least recently parked first; `toggle` shows the front.
+    parked: VecDeque<WindowId>,
+    shown: BTreeSet<WindowId>,
+    /// Parked while tiled and not shown since; first show applies the default geometry.
+    fresh: BTreeSet<WindowId>,
+}
+
+impl Scratchpad {
+    pub(crate) fn is_member(&self, wid: WindowId) -> bool {
+        self.is_parked(wid) || self.is_shown(wid)
+    }
+
+    pub(crate) fn is_parked(&self, wid: WindowId) -> bool { self.parked.contains(&wid) }
+
+    pub(crate) fn is_shown(&self, wid: WindowId) -> bool { self.shown.contains(&wid) }
+
+    pub(crate) fn park(&mut self, wid: WindowId, was_tiled: bool) {
+        self.shown.remove(&wid);
+        if !self.parked.contains(&wid) {
+            self.parked.push_back(wid);
+        }
+        if was_tiled {
+            self.fresh.insert(wid);
+        }
+    }
+
+    /// Marks `wid` shown. Returns true when this is its first show after a tiled park.
+    pub(crate) fn show(&mut self, wid: WindowId) -> bool {
+        self.parked.retain(|w| *w != wid);
+        self.shown.insert(wid);
+        self.fresh.remove(&wid)
+    }
+
+    pub(crate) fn parked(&self) -> impl Iterator<Item = WindowId> + '_ {
+        self.parked.iter().copied()
+    }
+
+    pub(crate) fn shown(&self) -> impl Iterator<Item = WindowId> + '_ { self.shown.iter().copied() }
+
+    pub(crate) fn remove(&mut self, wid: WindowId) {
+        self.parked.retain(|w| *w != wid);
+        self.shown.remove(&wid);
+        self.fresh.remove(&wid);
+    }
+
+    pub(crate) fn remove_for_pid(&mut self, pid: pid_t) { self.retain(|w| w.pid != pid); }
+
+    pub(crate) fn retain(&mut self, mut keep: impl FnMut(WindowId) -> bool) {
+        self.parked.retain(|w| keep(*w));
+        self.shown.retain(|w| keep(*w));
+        self.fresh.retain(|w| keep(*w));
+    }
+
+    pub(crate) fn transfer_identity(&mut self, from: WindowId, to: WindowId) {
+        for w in self.parked.iter_mut().filter(|w| **w == from) {
+            *w = to;
+        }
+        if self.shown.remove(&from) {
+            self.shown.insert(to);
+        }
+        if self.fresh.remove(&from) {
+            self.fresh.insert(to);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn wid(pid: pid_t, idx: u32) -> WindowId { WindowId::new(pid, idx) }
+
+    #[test]
+    fn park_makes_window_a_parked_member() {
+        let mut pad = Scratchpad::default();
+        pad.park(wid(1, 1), false);
+        assert!(pad.is_member(wid(1, 1)));
+        assert!(pad.is_parked(wid(1, 1)));
+        assert!(!pad.is_shown(wid(1, 1)));
+        assert_eq!(pad.parked().collect::<Vec<_>>(), vec![wid(1, 1)]);
+    }
+
+    #[test]
+    fn show_moves_window_from_parked_to_shown() {
+        let mut pad = Scratchpad::default();
+        pad.park(wid(1, 1), false);
+        pad.show(wid(1, 1));
+        assert!(pad.is_shown(wid(1, 1)));
+        assert!(!pad.is_parked(wid(1, 1)));
+        assert_eq!(pad.parked().next(), None);
+        assert_eq!(pad.shown().collect::<Vec<_>>(), vec![wid(1, 1)]);
+    }
+
+    #[test]
+    fn show_is_fresh_exactly_once_after_a_tiled_park() {
+        let mut pad = Scratchpad::default();
+        pad.park(wid(1, 1), true);
+        assert!(pad.show(wid(1, 1)));
+        pad.park(wid(1, 1), false);
+        assert!(!pad.show(wid(1, 1)));
+    }
+
+    #[test]
+    fn show_is_not_fresh_after_a_floating_park() {
+        let mut pad = Scratchpad::default();
+        pad.park(wid(1, 1), false);
+        assert!(!pad.show(wid(1, 1)));
+    }
+
+    #[test]
+    fn parked_iterates_least_recently_parked_first() {
+        let mut pad = Scratchpad::default();
+        pad.park(wid(1, 1), false);
+        pad.park(wid(1, 2), false);
+        assert_eq!(pad.parked().next(), Some(wid(1, 1)));
+        pad.show(wid(1, 1));
+        pad.park(wid(1, 1), false);
+        assert_eq!(pad.parked().next(), Some(wid(1, 2)));
+    }
+
+    #[test]
+    fn parking_an_already_parked_window_keeps_its_queue_position() {
+        let mut pad = Scratchpad::default();
+        pad.park(wid(1, 1), false);
+        pad.park(wid(1, 2), false);
+        pad.park(wid(1, 1), false);
+        assert_eq!(pad.parked().collect::<Vec<_>>(), vec![wid(1, 1), wid(1, 2)]);
+    }
+
+    #[test]
+    fn remove_clears_all_membership() {
+        let mut pad = Scratchpad::default();
+        pad.park(wid(1, 1), true);
+        pad.remove(wid(1, 1));
+        assert!(!pad.is_member(wid(1, 1)));
+        pad.park(wid(1, 1), false);
+        assert!(!pad.show(wid(1, 1)), "fresh flag must not survive removal");
+    }
+
+    #[test]
+    fn remove_for_pid_drops_only_that_apps_windows() {
+        let mut pad = Scratchpad::default();
+        pad.park(wid(1, 1), true);
+        pad.park(wid(2, 1), false);
+        pad.show(wid(2, 1));
+        pad.park(wid(2, 2), false);
+        pad.remove_for_pid(2);
+        assert_eq!(pad.parked().collect::<Vec<_>>(), vec![wid(1, 1)]);
+        assert_eq!(pad.shown().count(), 0);
+    }
+
+    #[test]
+    fn transfer_identity_preserves_state_and_queue_order() {
+        let mut pad = Scratchpad::default();
+        pad.park(wid(1, 1), true);
+        pad.park(wid(1, 2), false);
+        pad.park(wid(1, 3), false);
+        pad.show(wid(1, 3));
+        pad.transfer_identity(wid(1, 1), wid(9, 1));
+        pad.transfer_identity(wid(1, 3), wid(9, 3));
+        assert_eq!(pad.parked().collect::<Vec<_>>(), vec![wid(9, 1), wid(1, 2)]);
+        assert!(pad.is_shown(wid(9, 3)));
+        assert!(!pad.is_member(wid(1, 1)));
+        assert!(!pad.is_member(wid(1, 3)));
+        assert!(pad.show(wid(9, 1)), "fresh flag follows the new identity");
+    }
+}

--- a/src/model/app_rules.rs
+++ b/src/model/app_rules.rs
@@ -25,6 +25,7 @@ pub struct AppRuleDecision {
     pub position: Option<AppRulePosition>,
     pub size: Option<AppRuleSize>,
     pub focus: bool,
+    pub scratchpad: bool,
 }
 
 impl AppRuleDecision {
@@ -42,12 +43,13 @@ pub struct AppRuleEffects {
     pub position: Option<AppRulePosition>,
     pub size: Option<AppRuleSize>,
     pub focus: bool,
+    pub scratchpad: bool,
     pub was_rule_floating: bool,
 }
 
 impl AppRuleEffects {
     pub(crate) fn should_float(self, was_floating: bool) -> bool {
-        self.floating || (!self.was_rule_floating && was_floating)
+        self.floating || self.scratchpad || (!self.was_rule_floating && was_floating)
     }
 
     pub(crate) fn floating_placement(
@@ -85,6 +87,8 @@ impl AppRuleEffects {
 pub enum AppRuleResult {
     Managed(AppRuleEffects),
     Rejected(AppRuleRejection),
+    /// Rule evaluation was skipped; the window keeps its current state (parked scratchpad).
+    Unchanged,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -267,6 +271,7 @@ impl CompiledRule {
             position,
             size,
             focus,
+            scratchpad,
             manage,
             app_name,
             title_regex,
@@ -312,6 +317,7 @@ impl CompiledRule {
                 position,
                 size,
                 focus,
+                scratchpad,
             },
             app_id,
             app_name,
@@ -388,6 +394,7 @@ mod tests {
                 position: Some(AppRulePosition { x: 0.4, y: 0.7 }),
                 size: Some(AppRuleSize { w: Some(640.0), h: Some(480.0) }),
                 focus: true,
+                scratchpad: false,
             })
         );
     }

--- a/src/model/virtual_workspace.rs
+++ b/src/model/virtual_workspace.rs
@@ -1067,14 +1067,15 @@ impl WorkspaceStore {
             }));
         }
 
-        let (workspace, floating, position, size, focus) =
-            rule_decision.map_or((None, false, None, None, false), |decision| {
+        let (workspace, floating, position, size, focus, scratchpad) =
+            rule_decision.map_or((None, false, None, None, false, false), |decision| {
                 (
                     decision.workspace,
                     decision.floating,
                     decision.position,
                     decision.size,
                     decision.focus,
+                    decision.scratchpad,
                 )
             });
         let workspace_id = self.resolve_rule_workspace_with_policy(
@@ -1097,6 +1098,7 @@ impl WorkspaceStore {
             position,
             size,
             focus,
+            scratchpad,
             was_rule_floating,
         }))
     }
@@ -1191,6 +1193,7 @@ mod tests {
             Ok(AppRuleResult::Rejected(reason)) => {
                 panic!("Window was unexpectedly rejected: {reason:?}")
             }
+            Ok(AppRuleResult::Unchanged) => panic!("Window was unexpectedly left unchanged"),
             Err(e) => panic!("assign_window_with_app_info failed: {:?}", e),
         }
     }
@@ -1512,6 +1515,7 @@ mod tests {
             position: None,
             size: None,
             focus: false,
+            scratchpad: false,
             manage: Some(false),
             app_name: None,
             title_regex: None,


### PR DESCRIPTION
Adds an i3-style scratchpad (roadmap item "scratchpad windows/workspace").

## Behaviour

- `move_to_scratchpad`: park the focused window off every virtual workspace (i3 `move scratchpad`). The window becomes floating.
- `toggle_scratchpad` (i3 `scratchpad show`), in order:
  1. focused window is a scratchpad window: hide it;
  2. a scratchpad window is visible on another workspace/display: pull it onto the current workspace and focus it;
  3. otherwise show the least recently parked window on the current workspace, centered, and focus it (repeated toggles cycle);
  4. no scratchpad windows at all: park the focused window.
- First show after a tiled park sizes the window to 50% x 75% of the screen and centers it (i3 defaults). Later shows keep whatever geometry the user left.
- While a scratchpad window is visible on a space, focus-follows-mouse does not raise other windows on that space, so the scratchpad stays on top until the user clicks another window or toggles it away.
- Cmd-Tab / Dock activation of a parked window shows it instead of leaving focus on an off-screen window.
- Tiling a scratchpad window (`toggle_window_floating`) removes it from the scratchpad; closing it does too.
- Membership survives restarts through the layout file (additive, `#[serde(default)]`, no schema bump) and is pruned with the same rules as floating state.
- App rule `scratchpad = true` parks matching windows as soon as they appear (implies floating). Validation rejects it together with `workspace`, `position`, `size`, `focus`, or `manage = false`, since none of them apply to a parked window.
- `rift-cli execute window toggle-scratchpad | move-to-scratchpad`.

```toml
[keys]
"Alt + Escape"         = "toggle_scratchpad"
"Alt + Shift + Escape" = "move_to_scratchpad"

app_rules = [
  { app_id = "net.kovidgoyal.kitty", title_substring = "Scratchpad", scratchpad = true },
]
```

## Design

A parked window is a floating window with **no workspace assignment** (the analogue of i3's `__i3_scratch`), tracked in a small `Scratchpad` struct owned by `LayoutEngine` (parked queue, shown set, "fresh" set). Because parked windows are unassigned, workspace queries and counts exclude them for free, and showing one is just assigning it to the active workspace as a normal floating window. No new visibility machinery: the reactor parks them in the hidden screen corner using the existing `HiddenWindowPlacement` geometry in `LayoutManager::calculate_layout`.

Guards for the "unassigned but managed" state sit at existing choke points rather than per caller:

- `LayoutEngine::is_window_in_active_workspace` returns false for parked windows (unassigned windows otherwise count as active).
- `assign_window_with_app_info_policy` returns a new `AppRuleResult::Unchanged` for parked windows, so discovery re-inventory, title-change reapply, and space activation cannot re-assign them. The check runs after persistence identity restore so a persisted parked window maps onto its live id first.
- `add_window_to_layout` ignores parked windows.
- `window_hidden_from_active_workspace` (renamed from `window_in_non_active_workspace`) treats parked windows as hidden, so the existing post-discovery refocus handles a rule-parked window stealing focus on launch.

This supersedes the approach in #233/#378 (separate manager, `hide_windows` side channel in `EventResponse`, duplicated hide geometry in the reactor).

## Tests

- Unit tests for `Scratchpad`.
- Reactor tests: park/unassign/off-screen placement, show geometry and raise, hide-and-refocus, cycling order, empty-toggle parks, pull from inactive workspace, unfloat leaves scratchpad, discovery keeps parked windows hidden, Cmd-Tab unparks, app rule parks and refocuses, focus-follows-mouse suppression while shown.
- Persistence round-trip and ghost pruning; config parsing and validation; rift-cli mapping.

`cargo test --lib` on this branch: 599 passed, 1 failed. The failure, `topology_change_clears_stale_pending_hide_target_before_next_workspace_layout`, fails identically on `main` without this change (macOS 15.6, this machine); happy to look into it separately if it is not known.

## Out of scope

Named scratchpads, per-rule scratchpad size/position, and a `scratchpad` flag in `rift-cli query windows` output. Easy follow-ups if wanted.
